### PR TITLE
Add dedicated MCP integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This is not a Git forge. It is an AI-native substrate for memory, retrieval, mes
 
 - [System Overview](docs/system-overview.md)
 - [API Surface](docs/api-surface.md)
+- [MCP Guide](docs/mcp.md)
 - [Design Doc](DESIGN_DOC.md)
 - [Go-live Runbook](deploy/GO_LIVE_RUNBOOK.md)
 - [Production Signoff Checklist](deploy/PRODUCTION_SIGNOFF_CHECKLIST.md)
@@ -47,6 +48,8 @@ For non-local exposure, prefer file-based peer tokens in `data_repo/config/peer_
 - Search layer: stdlib `sqlite3` FTS5 with JSON-index fallback
 - Auth model: bearer tokens with scopes and split read/write namespace restrictions
 - Machine discoverability: `/v1/manifest`, `/v1/discovery/*`, and `POST /v1/mcp`
+
+For agent integration details, including the MCP bootstrap flow and tool mapping, see [docs/mcp.md](docs/mcp.md).
 
 ## Development
 

--- a/docs/api-surface.md
+++ b/docs/api-surface.md
@@ -22,6 +22,8 @@ The sections below mirror that runtime shape and group endpoints by behavior rat
 - `GET /.well-known/mcp.json`: MCP compatibility descriptor
 - `POST /v1/mcp`: JSON-RPC bridge for `initialize`, `notifications/initialized`, `ping`, `tools/list`, and `tools/call`
 
+For the MCP bootstrap flow, tool metadata model, and HTTP-to-MCP relationship, see `docs/mcp.md`.
+
 ## Memory, file, and index operations
 
 - `POST /v1/write`: write text content to a repo-relative path

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,121 @@
+# MCP Guide
+
+This document describes CogniRelay's MCP-facing surface and how it relates to the broader HTTP API.
+
+## Scope
+
+CogniRelay exposes two machine-oriented integration styles:
+
+- HTTP-native discovery via `GET /v1/discovery`, `GET /v1/discovery/tools`, and `GET /v1/discovery/workflows`
+- MCP-compatible JSON-RPC via `GET /.well-known/mcp.json` and `POST /v1/mcp`
+
+The implementation describes the protocol as `mcp-compatible` and `mcp-like`, not as a claim of full MCP-spec coverage. In practice, the MCP bridge is designed around tool discovery and tool execution for autonomous clients.
+
+## Bootstrap Flow
+
+For an MCP-oriented client, the expected startup sequence is:
+
+1. `GET /.well-known/mcp.json`
+2. `POST /v1/mcp` with `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+3. `POST /v1/mcp` with `{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`
+4. `POST /v1/mcp` with `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`
+5. `POST /v1/mcp` with `tools/call` requests as needed
+
+The well-known descriptor advertises:
+
+- endpoint: `/v1/mcp`
+- protocol: JSON-RPC 2.0 over HTTP+JSON
+- methods: `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`
+- auth: bearer token in `Authorization`
+
+## What MCP Exposes
+
+The MCP tool catalog is broad. It covers the project's substantive feature set, including:
+
+- service discovery and contracts
+- memory read/write and JSONL append
+- indexing, search, recent items, and context retrieval
+- peer registry and peer trust transitions
+- direct messaging, relay forwarding, verification, and replay
+- shared tasks and patch/code workflows
+- token lifecycle, key rotation, metrics, replication, backup, and host ops
+
+In other words, the usable application capabilities are available through MCP tools.
+
+## What MCP Does Not Mirror One-To-One
+
+Not every HTTP endpoint appears as an MCP tool name. The main exclusions are transport and descriptor endpoints:
+
+- `GET /.well-known/mcp.json`
+- `GET /.well-known/cognirelay.json`
+- `POST /v1/mcp`
+
+Those endpoints exist to describe or host the MCP bridge rather than to represent domain actions.
+
+## Tool Model
+
+`tools/list` returns each tool with:
+
+- `name`
+- `description`
+- `inputSchema`
+- `metadata.method`
+- `metadata.path`
+- `metadata.scopes`
+- `metadata.idempotent`
+- `metadata.local_only`
+
+That metadata lets an agent understand both the MCP entrypoint and the underlying HTTP behavior without scraping the REST docs separately.
+
+## Tool-to-HTTP Mapping
+
+MCP tools are adapters over the HTTP API. Examples:
+
+- `system.discovery` -> `GET /v1/discovery`
+- `memory.write` -> `POST /v1/write`
+- `search.query` -> `POST /v1/search`
+- `tasks.create` -> `POST /v1/tasks`
+- `messages.send` -> `POST /v1/messages/send`
+- `code.checks_run` -> `POST /v1/code/checks/run`
+- `security.tokens_issue` -> `POST /v1/security/tokens/issue`
+- `ops.run` -> `POST /v1/ops/run`
+
+For the complete runtime mapping, prefer `tools/list` and `GET /v1/discovery/tools`.
+
+## Auth and Authorization
+
+`tools/call` uses the same bearer-token model as the HTTP API:
+
+- no-auth tools remain callable without a token
+- protected tools require scopes and namespace restrictions matching the underlying operation
+- host ops tools remain local-only even when called through MCP
+
+This means MCP is not a separate permission system. It is a protocol wrapper over the same authorization rules.
+
+## Response Shape
+
+`tools/call` returns:
+
+- `toolName`
+- a simple text `content` entry
+- `structuredContent` containing the underlying tool result
+
+Clients should treat `structuredContent` as the authoritative machine-readable payload.
+
+## Error Behavior
+
+The bridge returns JSON-RPC errors for:
+
+- invalid JSON-RPC requests
+- unknown methods
+- invalid parameters
+- unauthorized and forbidden tool calls
+- execution failures
+
+This is documented at the protocol level by the implementation and should be preferred over inferring behavior from HTTP status codes alone.
+
+## Recommendations
+
+- Use MCP when your runtime already speaks JSON-RPC tool protocols.
+- Use HTTP discovery endpoints when you want broader service introspection or simpler direct integration.
+- Use `GET /v1/discovery` alongside MCP if you want startup guidance and workflow hints beyond the basic MCP descriptor.

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -102,6 +102,8 @@ For an agent cold start, the recommended sequence is:
 
 If the runtime prefers MCP-style JSON-RPC, use `GET /.well-known/mcp.json` and then `POST /v1/mcp` for `initialize`, `notifications/initialized`, and `tools/list`.
 
+For the complete MCP integration notes, including what is and is not mirrored through the tool catalog, see `docs/mcp.md`.
+
 ### Write behavior
 
 - Prefer small writes and append-only JSONL records for event and message flows


### PR DESCRIPTION
## Summary
- add a dedicated MCP guide covering bootstrap, tool mapping, auth, and limitations
- link the guide from the README, API surface, and system overview docs
- clarify the difference between MCP tool coverage and descriptor/transport endpoints

## Testing
- not run (docs-only change)