### PR TITLE
Refactor discovery and MCP services out of main

### DIFF
--- a/app/discovery/__init__.py
+++ b/app/discovery/__init__.py
@@ -1,0 +1,31 @@
+from .service import (
+    capabilities_payload,
+    contracts_payload,
+    discovery_payload,
+    discovery_tools_payload,
+    discovery_workflows_payload,
+    handle_mcp_rpc_request,
+    health_payload,
+    manifest_payload,
+    tool_catalog,
+    tool_schema_lookup,
+    well_known_cognirelay_payload,
+    well_known_mcp_payload,
+    workflow_catalog,
+)
+
+__all__ = [
+    "capabilities_payload",
+    "contracts_payload",
+    "discovery_payload",
+    "discovery_tools_payload",
+    "discovery_workflows_payload",
+    "handle_mcp_rpc_request",
+    "health_payload",
+    "manifest_payload",
+    "tool_catalog",
+    "tool_schema_lookup",
+    "well_known_cognirelay_payload",
+    "well_known_mcp_payload",
+    "workflow_catalog",
+]

--- a/app/discovery/service.py
+++ b/app/discovery/service.py
@@ -1,0 +1,1065 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.auth import AuthContext
+from app.models import (
+    AppendRequest,
+    BackupCreateRequest,
+    BackupRestoreTestRequest,
+    CodeCheckRunRequest,
+    CodeMergeRequest,
+    CompactRequest,
+    ContinuityUpsertRequest,
+    ContextRetrieveRequest,
+    ContextSnapshotRequest,
+    MessageAckRequest,
+    MessageReplayRequest,
+    MessageSendRequest,
+    MessageVerifyRequest,
+    OpsRunRequest,
+    PatchApplyRequest,
+    PatchProposeRequest,
+    PeerRegisterRequest,
+    PeerTrustTransitionRequest,
+    RecentRequest,
+    RelayForwardRequest,
+    ReplicationPullRequest,
+    ReplicationPushRequest,
+    SearchRequest,
+    SecurityKeysRotateRequest,
+    SecurityTokenIssueRequest,
+    SecurityTokenRevokeRequest,
+    SecurityTokenRotateRequest,
+    TaskCreateRequest,
+    TaskUpdateRequest,
+    WriteRequest,
+)
+
+
+def _canonical_json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def tool_catalog(schema_for_model: Callable[[Any], dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "system.health",
+            "description": "Check service liveness and git state.",
+            "method": "GET",
+            "path": "/health",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "system.capabilities",
+            "description": "Return high-level feature flags.",
+            "method": "GET",
+            "path": "/capabilities",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "system.manifest",
+            "description": "Return endpoint map and auth expectations.",
+            "method": "GET",
+            "path": "/v1/manifest",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "system.contracts",
+            "description": "Return frozen API/tool contract version and compatibility policy.",
+            "method": "GET",
+            "path": "/v1/contracts",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "system.governance_policy",
+            "description": "Return machine-readable governance policy pack.",
+            "method": "GET",
+            "path": "/v1/governance/policy",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "system.discovery",
+            "description": "Return machine guidance and entrypoints (MCP-like metadata).",
+            "method": "GET",
+            "path": "/v1/discovery",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "system.discovery_tools",
+            "description": "Return machine-usable tool catalog with schemas.",
+            "method": "GET",
+            "path": "/v1/discovery/tools",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "system.discovery_workflows",
+            "description": "Return recommended autonomous workflows.",
+            "method": "GET",
+            "path": "/v1/discovery/workflows",
+            "scopes": [],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "memory.write",
+            "description": "Write text content to a repo-relative path and commit.",
+            "method": "POST",
+            "path": "/v1/write",
+            "scopes": ["write:journal|write:messages|write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(WriteRequest),
+        },
+        {
+            "name": "memory.append_jsonl",
+            "description": "Append one JSON object as a JSONL record and commit.",
+            "method": "POST",
+            "path": "/v1/append",
+            "scopes": ["write:journal|write:messages|write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(AppendRequest),
+        },
+        {
+            "name": "memory.read",
+            "description": "Read a file by path.",
+            "method": "GET",
+            "path": "/v1/read",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "index.rebuild_full",
+            "description": "Rebuild derived indexes and SQLite FTS from repo files.",
+            "method": "POST",
+            "path": "/v1/index/rebuild",
+            "scopes": ["read:index"],
+            "idempotent": False,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "index.rebuild_incremental",
+            "description": "Incrementally rebuild indexes from mtime state.",
+            "method": "POST",
+            "path": "/v1/index/rebuild-incremental",
+            "scopes": ["read:index"],
+            "idempotent": False,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "index.status",
+            "description": "Inspect current index status and derived artifacts.",
+            "method": "GET",
+            "path": "/v1/index/status",
+            "scopes": ["read:index"],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "peers.list",
+            "description": "List known peer records from registry.",
+            "method": "GET",
+            "path": "/v1/peers",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "peers.register",
+            "description": "Create or update a peer registry record.",
+            "method": "POST",
+            "path": "/v1/peers/register",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(PeerRegisterRequest),
+        },
+        {
+            "name": "peers.trust_transition",
+            "description": "Apply explicit peer trust-level transition with reason and fingerprint guard.",
+            "method": "POST",
+            "path": "/v1/peers/{peer_id}/trust",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "peer_id": {"type": "string"},
+                    **schema_for_model(PeerTrustTransitionRequest).get("properties", {}),
+                },
+                "required": ["peer_id", "trust_level", "reason"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "peers.fetch_manifest",
+            "description": "Fetch and return a peer's advertised manifest.",
+            "method": "GET",
+            "path": "/v1/peers/{peer_id}/manifest",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {"peer_id": {"type": "string"}},
+                "required": ["peer_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "search.query",
+            "description": "Search indexed repo content.",
+            "method": "POST",
+            "path": "/v1/search",
+            "scopes": ["search", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": schema_for_model(SearchRequest),
+        },
+        {
+            "name": "recent.list",
+            "description": "List recently modified indexed content without a query string.",
+            "method": "POST",
+            "path": "/v1/recent",
+            "scopes": ["search", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": schema_for_model(RecentRequest),
+        },
+        {
+            "name": "context.retrieve",
+            "description": "Build a compact context bundle for task continuation.",
+            "method": "POST",
+            "path": "/v1/context/retrieve",
+            "scopes": ["search", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": schema_for_model(ContextRetrieveRequest),
+        },
+        {
+            "name": "continuity.upsert",
+            "description": "Create or replace one continuity capsule atomically.",
+            "method": "POST",
+            "path": "/v1/continuity/upsert",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(ContinuityUpsertRequest),
+        },
+        {
+            "name": "context.snapshot_create",
+            "description": "Create deterministic context snapshot and persist it.",
+            "method": "POST",
+            "path": "/v1/context/snapshot",
+            "scopes": ["search", "write:projects", "write_namespaces", "read_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(ContextSnapshotRequest),
+        },
+        {
+            "name": "context.snapshot_get",
+            "description": "Load persisted context snapshot by id.",
+            "method": "GET",
+            "path": "/v1/context/snapshot/{snapshot_id}",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {"snapshot_id": {"type": "string"}},
+                "required": ["snapshot_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "tasks.create",
+            "description": "Create a collaborative task record.",
+            "method": "POST",
+            "path": "/v1/tasks",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(TaskCreateRequest),
+        },
+        {
+            "name": "tasks.update",
+            "description": "Update a task and enforce status transitions.",
+            "method": "PATCH",
+            "path": "/v1/tasks/{task_id}",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": {
+                "type": "object",
+                "properties": {"task_id": {"type": "string"}, **schema_for_model(TaskUpdateRequest).get("properties", {})},
+                "required": ["task_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "tasks.query",
+            "description": "Query task records by status/owner/collaborator/thread.",
+            "method": "GET",
+            "path": "/v1/tasks/query",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "status": {"type": "string"},
+                    "owner_peer": {"type": "string"},
+                    "collaborator": {"type": "string"},
+                    "thread_id": {"type": "string"},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 500},
+                },
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "docs.patch_propose",
+            "description": "Propose unified diff patch for docs/content target.",
+            "method": "POST",
+            "path": "/v1/docs/patch/propose",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(PatchProposeRequest),
+        },
+        {
+            "name": "docs.patch_apply",
+            "description": "Apply proposed docs/content patch with base-ref checks.",
+            "method": "POST",
+            "path": "/v1/docs/patch/apply",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(PatchApplyRequest),
+        },
+        {
+            "name": "code.patch_propose",
+            "description": "Propose unified diff patch for code target.",
+            "method": "POST",
+            "path": "/v1/code/patch/propose",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(PatchProposeRequest),
+        },
+        {
+            "name": "code.checks_run",
+            "description": "Run configured check profile on a git ref and persist artifact.",
+            "method": "POST",
+            "path": "/v1/code/checks/run",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(CodeCheckRunRequest),
+        },
+        {
+            "name": "code.merge",
+            "description": "Fast-forward merge a source ref into HEAD after required checks pass.",
+            "method": "POST",
+            "path": "/v1/code/merge",
+            "scopes": ["write:projects", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(CodeMergeRequest),
+        },
+        {
+            "name": "security.tokens_list",
+            "description": "List token entries with status and expiry metadata.",
+            "method": "GET",
+            "path": "/v1/security/tokens",
+            "scopes": ["admin:peers", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "peer_id": {"type": "string"},
+                    "status": {"type": "string"},
+                    "include_inactive": {"type": "boolean"},
+                },
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "security.tokens_issue",
+            "description": "Issue a new peer token with scopes/namespaces and optional expiry.",
+            "method": "POST",
+            "path": "/v1/security/tokens/issue",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(SecurityTokenIssueRequest),
+        },
+        {
+            "name": "security.tokens_revoke",
+            "description": "Revoke a token by id/sha or revoke all tokens for a peer.",
+            "method": "POST",
+            "path": "/v1/security/tokens/revoke",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(SecurityTokenRevokeRequest),
+        },
+        {
+            "name": "security.tokens_rotate",
+            "description": "Rotate token credentials by revoking old token and issuing a replacement atomically.",
+            "method": "POST",
+            "path": "/v1/security/tokens/rotate",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(SecurityTokenRotateRequest),
+        },
+        {
+            "name": "security.keys_rotate",
+            "description": "Rotate message verification key material.",
+            "method": "POST",
+            "path": "/v1/security/keys/rotate",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(SecurityKeysRotateRequest),
+        },
+        {
+            "name": "messages.verify",
+            "description": "Verify signed message envelope and optionally consume nonce.",
+            "method": "POST",
+            "path": "/v1/messages/verify",
+            "scopes": ["write:messages", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(MessageVerifyRequest),
+        },
+        {
+            "name": "metrics.get",
+            "description": "Return operational metrics summary.",
+            "method": "GET",
+            "path": "/v1/metrics",
+            "scopes": ["read:index"],
+            "idempotent": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "messages.replay",
+            "description": "Replay a tracked dead-letter message back into delivery flow.",
+            "method": "POST",
+            "path": "/v1/replay/messages",
+            "scopes": ["write:messages", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(MessageReplayRequest),
+        },
+        {
+            "name": "replication.pull",
+            "description": "Ingest replicated file bundle from peer.",
+            "method": "POST",
+            "path": "/v1/replication/pull",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(ReplicationPullRequest),
+        },
+        {
+            "name": "replication.push",
+            "description": "Build and optionally push replication bundle to peer endpoint.",
+            "method": "POST",
+            "path": "/v1/replication/push",
+            "scopes": ["admin:peers", "read_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(ReplicationPushRequest),
+        },
+        {
+            "name": "messages.send",
+            "description": "Write message to recipient inbox/outbox/thread.",
+            "method": "POST",
+            "path": "/v1/messages/send",
+            "scopes": ["write:messages", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(MessageSendRequest),
+        },
+        {
+            "name": "messages.ack",
+            "description": "Acknowledge/defer/reject tracked message delivery.",
+            "method": "POST",
+            "path": "/v1/messages/ack",
+            "scopes": ["write:messages", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(MessageAckRequest),
+        },
+        {
+            "name": "messages.pending",
+            "description": "Inspect pending and terminal delivery states.",
+            "method": "GET",
+            "path": "/v1/messages/pending",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "recipient": {"type": "string"},
+                    "status": {"type": "string"},
+                    "include_terminal": {"type": "boolean"},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 500},
+                },
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "messages.inbox",
+            "description": "Read recipient inbox messages.",
+            "method": "GET",
+            "path": "/v1/messages/inbox",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "recipient": {"type": "string"},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 200},
+                },
+                "required": ["recipient"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "messages.thread",
+            "description": "Read thread messages by thread_id.",
+            "method": "GET",
+            "path": "/v1/messages/thread",
+            "scopes": ["read:files", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "thread_id": {"type": "string"},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 1000},
+                },
+                "required": ["thread_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "messages.relay_forward",
+            "description": "Forward a message via relay log + inbox + thread write.",
+            "method": "POST",
+            "path": "/v1/relay/forward",
+            "scopes": ["write:messages", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(RelayForwardRequest),
+        },
+        {
+            "name": "memory.compaction_plan",
+            "description": "Generate compaction planning report (planner only).",
+            "method": "POST",
+            "path": "/v1/compact/run",
+            "scopes": ["compact:trigger", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(CompactRequest),
+        },
+        {
+            "name": "backup.create",
+            "description": "Create deterministic tar.gz backup bundle and manifest.",
+            "method": "POST",
+            "path": "/v1/backup/create",
+            "scopes": ["admin:peers", "write_namespaces"],
+            "idempotent": False,
+            "input_schema": schema_for_model(BackupCreateRequest),
+        },
+        {
+            "name": "backup.restore_test",
+            "description": "Run backup restore validation in temporary directory.",
+            "method": "POST",
+            "path": "/v1/backup/restore-test",
+            "scopes": ["admin:peers", "read_namespaces"],
+            "idempotent": True,
+            "input_schema": schema_for_model(BackupRestoreTestRequest),
+        },
+        {
+            "name": "ops.catalog",
+            "description": "List host-ops automation jobs and local security constraints.",
+            "method": "GET",
+            "path": "/v1/ops/catalog",
+            "scopes": ["admin:peers"],
+            "idempotent": True,
+            "local_only": True,
+            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+        {
+            "name": "ops.status",
+            "description": "Inspect recent host-ops runs and active job locks.",
+            "method": "GET",
+            "path": "/v1/ops/status",
+            "scopes": ["admin:peers"],
+            "idempotent": True,
+            "local_only": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {"limit": {"type": "integer", "minimum": 1, "maximum": 500}},
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "ops.run",
+            "description": "Run one host-ops job locally with lock/audit controls.",
+            "method": "POST",
+            "path": "/v1/ops/run",
+            "scopes": ["admin:peers"],
+            "idempotent": False,
+            "local_only": True,
+            "input_schema": schema_for_model(OpsRunRequest),
+        },
+        {
+            "name": "ops.schedule_export",
+            "description": "Export suggested systemd/cron schedule for host-ops jobs.",
+            "method": "GET",
+            "path": "/v1/ops/schedule/export",
+            "scopes": ["admin:peers"],
+            "idempotent": True,
+            "local_only": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {"format": {"type": "string", "enum": ["systemd", "cron"]}},
+                "additionalProperties": False,
+            },
+        },
+    ]
+
+
+def workflow_catalog() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "bootstrap_cycle",
+            "description": "Recommended autonomous startup/loop sequence.",
+            "steps": [
+                {"order": 1, "tool": "system.discovery"},
+                {"order": 2, "tool": "system.manifest"},
+                {"order": 3, "tool": "system.health"},
+                {"order": 4, "tool": "index.rebuild_incremental"},
+                {"order": 5, "tool": "context.retrieve"},
+            ],
+        },
+        {
+            "name": "collaborative_writing",
+            "description": "Message exchange workflow with delivery acknowledgement.",
+            "steps": [
+                {"order": 1, "tool": "messages.send"},
+                {"order": 2, "tool": "messages.pending"},
+                {"order": 3, "tool": "messages.ack"},
+                {"order": 4, "tool": "messages.thread"},
+                {"order": 5, "tool": "memory.append_jsonl"},
+                {"order": 6, "tool": "context.retrieve"},
+            ],
+        },
+        {
+            "name": "collaborative_tasks_and_code",
+            "description": "Task graph + patch proposal + checks/merge sequence.",
+            "steps": [
+                {"order": 1, "tool": "tasks.query"},
+                {"order": 2, "tool": "tasks.create"},
+                {"order": 3, "tool": "tasks.update"},
+                {"order": 4, "tool": "docs.patch_propose"},
+                {"order": 5, "tool": "docs.patch_apply"},
+                {"order": 6, "tool": "code.patch_propose"},
+                {"order": 7, "tool": "code.checks_run"},
+                {"order": 8, "tool": "code.merge"},
+            ],
+        },
+        {
+            "name": "federation_hardening",
+            "description": "Signed envelope verification and replication operations.",
+            "steps": [
+                {"order": 1, "tool": "security.tokens_list"},
+                {"order": 2, "tool": "security.tokens_issue"},
+                {"order": 3, "tool": "security.tokens_rotate"},
+                {"order": 4, "tool": "security.tokens_revoke"},
+                {"order": 5, "tool": "peers.trust_transition"},
+                {"order": 6, "tool": "security.keys_rotate"},
+                {"order": 7, "tool": "messages.verify"},
+                {"order": 8, "tool": "metrics.get"},
+                {"order": 9, "tool": "messages.replay"},
+                {"order": 10, "tool": "replication.push"},
+                {"order": 11, "tool": "replication.pull"},
+            ],
+        },
+        {
+            "name": "maintenance_compaction",
+            "description": "Periodic maintenance for index freshness and compaction planning.",
+            "steps": [
+                {"order": 1, "tool": "index.rebuild_incremental"},
+                {"order": 2, "tool": "backup.create"},
+                {"order": 3, "tool": "backup.restore_test"},
+                {"order": 4, "tool": "memory.compaction_plan"},
+                {"order": 5, "tool": "memory.write"},
+            ],
+        },
+        {
+            "name": "host_ops_automation",
+            "description": "Local-only host automation runner for maintenance and safety jobs.",
+            "steps": [
+                {"order": 1, "tool": "ops.catalog"},
+                {"order": 2, "tool": "ops.status"},
+                {"order": 3, "tool": "ops.run"},
+                {"order": 4, "tool": "ops.schedule_export"},
+            ],
+        },
+    ]
+
+
+def discovery_payload(contract_version: str, *, tools: list[dict[str, Any]], workflows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "protocol": {
+            "name": "cognirelay-http",
+            "style": "mcp-like",
+            "version": contract_version,
+            "transport": "http+json",
+        },
+        "auth": {
+            "type": "bearer",
+            "header": "Authorization: Bearer <token>",
+            "notes": [
+                "Scopes and namespace restrictions are enforced per token.",
+                "Use /v1/manifest for endpoint-level scope requirements.",
+                "If strict signed ingress is enabled, message ingress requires signed_envelope.",
+                "Rate limits and payload caps are enforced per token/IP.",
+                "Host ops endpoints are local-only and intended for daemon/scheduler use on hosting machine.",
+            ],
+        },
+        "entrypoints": {
+            "manifest": "/v1/manifest",
+            "contracts": "/v1/contracts",
+            "governance_policy": "/v1/governance/policy",
+            "ops_catalog": "/v1/ops/catalog",
+            "ops_status": "/v1/ops/status",
+            "tools": "/v1/discovery/tools",
+            "workflows": "/v1/discovery/workflows",
+            "mcp_rpc": "/v1/mcp",
+            "mcp_well_known": "/.well-known/mcp.json",
+        },
+        "agent_guidance": {
+            "first_calls": ["GET /v1/discovery", "GET /v1/manifest", "GET /health"],
+            "mcp_first_calls": [
+                "POST /v1/mcp {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}",
+                "POST /v1/mcp {\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}",
+                "POST /v1/mcp {\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
+            ],
+            "loop_hint": "Prefer /v1/index/rebuild-incremental over full rebuild in frequent loops.",
+            "write_hint": "Prefer append-only JSONL for events/messages and frequent commits.",
+        },
+        "counts": {"tools": len(tools), "workflows": len(workflows)},
+    }
+
+
+def discovery_tools_payload(contract_version: str, *, tools: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "protocol": {"name": "cognirelay-http", "style": "mcp-like", "version": contract_version},
+        "count": len(tools),
+        "tools": tools,
+    }
+
+
+def discovery_workflows_payload(*, workflows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"ok": True, "count": len(workflows), "workflows": workflows}
+
+
+def well_known_cognirelay_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload
+
+
+def well_known_mcp_payload(contract_version: str) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "protocol": "jsonrpc-2.0",
+        "style": "mcp-compatible",
+        "transport": "http+json",
+        "endpoint": "/v1/mcp",
+        "contract_version": contract_version,
+        "methods": ["initialize", "notifications/initialized", "ping", "tools/list", "tools/call"],
+        "auth": {"type": "bearer", "header": "Authorization: Bearer <token>"},
+    }
+
+
+def _rpc_ok(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _rpc_error(request_id: Any, code: int, message: str, data: Any | None = None) -> dict[str, Any]:
+    err: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": request_id, "error": err}
+
+
+def _mcp_list_tools_result(tools: list[dict[str, Any]]) -> dict[str, Any]:
+    rows = []
+    for t in tools:
+        rows.append(
+            {
+                "name": t["name"],
+                "description": t["description"],
+                "inputSchema": t["input_schema"],
+                "metadata": {
+                    "method": t["method"],
+                    "path": t["path"],
+                    "scopes": t["scopes"],
+                    "idempotent": t["idempotent"],
+                    "local_only": bool(t.get("local_only", False)),
+                },
+            }
+        )
+    return {"tools": rows}
+
+
+def _mcp_initialize_result(contract_version: str, params: dict[str, Any]) -> dict[str, Any]:
+    requested_protocol = params.get("protocolVersion", contract_version)
+    return {
+        "protocolVersion": str(requested_protocol),
+        "capabilities": {
+            "tools": {"listChanged": False},
+            "sampling": {},
+        },
+        "serverInfo": {
+            "name": "cognirelay",
+            "version": contract_version,
+        },
+        "instructions": (
+            "Use tools/list to discover tool schemas, then tools/call for execution. "
+            "Prefer /v1/discovery for supplemental HTTP-native guidance."
+        ),
+    }
+
+
+def tool_schema_lookup(name: str, tools: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for t in tools:
+        if t["name"] == name:
+            return t
+    return None
+
+
+def handle_mcp_rpc_request(
+    request_payload: Any,
+    *,
+    authorization: str | None,
+    x_forwarded_for: str | None,
+    x_real_ip: str | None,
+    request: Any,
+    contract_version: str,
+    tools: list[dict[str, Any]],
+    resolve_auth_context: Callable[..., AuthContext | None],
+    invoke_tool_by_name: Callable[[str, dict[str, Any], AuthContext | None], dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not isinstance(request_payload, dict):
+        return _rpc_error(None, -32600, "Invalid Request")
+
+    request_id = request_payload.get("id")
+    is_notification = "id" not in request_payload
+    if request_payload.get("jsonrpc") != "2.0":
+        return _rpc_error(request_id, -32600, "Invalid Request: jsonrpc must be '2.0'")
+
+    method = request_payload.get("method")
+    params = request_payload.get("params", {})
+    if not isinstance(params, dict):
+        return _rpc_error(request_id, -32602, "Invalid params: params must be an object")
+
+    if method == "initialize":
+        return _rpc_ok(request_id, _mcp_initialize_result(contract_version, params))
+
+    if method == "notifications/initialized":
+        if is_notification:
+            return None
+        return _rpc_ok(request_id, {"acknowledged": True})
+
+    if method == "ping":
+        return _rpc_ok(request_id, {"ok": True, "ts": datetime.now(timezone.utc).isoformat()})
+
+    if method == "tools/list":
+        return _rpc_ok(request_id, _mcp_list_tools_result(tools))
+    if method != "tools/call":
+        return _rpc_error(request_id, -32601, f"Method not found: {method}")
+
+    name = params.get("name")
+    arguments = params.get("arguments", {})
+    if not isinstance(name, str) or not name:
+        return _rpc_error(request_id, -32602, "Invalid params: 'name' is required")
+
+    tool = tool_schema_lookup(name, tools)
+    if tool is None:
+        return _rpc_error(request_id, -32602, f"Unknown tool: {name}")
+
+    auth_required = bool(tool.get("scopes"))
+    try:
+        auth = resolve_auth_context(
+            authorization,
+            required=auth_required,
+            x_forwarded_for=x_forwarded_for,
+            x_real_ip=x_real_ip,
+            request=request,
+        )
+        result = invoke_tool_by_name(name, arguments, auth)
+    except ValidationError as e:
+        return _rpc_error(request_id, -32602, "Invalid params", data=e.errors())
+    except HTTPException as e:
+        if e.status_code == 401:
+            return _rpc_error(request_id, -32001, "Unauthorized", data=e.detail)
+        if e.status_code == 403:
+            return _rpc_error(request_id, -32002, "Forbidden", data=e.detail)
+        if e.status_code == 404:
+            return _rpc_error(request_id, -32004, "Not Found", data=e.detail)
+        return _rpc_error(request_id, -32003, "Tool execution failed", data=e.detail)
+    except (KeyError, TypeError, ValueError) as e:
+        return _rpc_error(request_id, -32602, "Invalid params", data=str(e))
+    except Exception as e:
+        return _rpc_error(request_id, -32003, "Tool execution failed", data=str(e))
+
+    return _rpc_ok(
+        request_id,
+        {
+            "toolName": name,
+            "content": [{"type": "text", "text": f"Executed {name}"}],
+            "structuredContent": result,
+        },
+    )
+
+
+def health_payload(*, app_version: str, contract_version: str, repo_root: str, git_initialized: bool, latest_commit: str | None, signed_ingress_required: bool) -> dict:
+    return {
+        "ok": True,
+        "service": "cognirelay",
+        "version": app_version,
+        "contract_version": contract_version,
+        "repo_root": repo_root,
+        "git_initialized": git_initialized,
+        "latest_commit": latest_commit,
+        "signed_ingress_required": signed_ingress_required,
+        "time": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def capabilities_payload() -> dict[str, Any]:
+    return {
+        "features": [
+            "write",
+            "read",
+            "append_jsonl",
+            "index_rebuild",
+            "search",
+            "context_retrieve",
+            "continuity_state",
+            "context_snapshot",
+            "messages_send_inbox",
+            "compact_summary",
+            "audit_log",
+            "peer_tokens_json",
+            "peers_registry",
+            "sqlite_fts_search",
+            "index_incremental",
+            "relay_forward",
+            "messages_reliable_delivery",
+            "discovery_manifest",
+            "discovery_tools",
+            "discovery_workflows",
+            "mcp_jsonrpc",
+            "tasks_workflows",
+            "patch_proposals",
+            "checks_and_merge_policy",
+            "security_keys_rotation",
+            "security_token_lifecycle",
+            "messages_signature_verify",
+            "strict_signed_ingress",
+            "metrics_endpoint",
+            "messages_replay",
+            "replication_push_pull",
+            "trust_policy_transitions",
+            "backup_restore_validation",
+            "api_contract_versioning",
+            "governance_policy_pack",
+            "abuse_controls",
+            "host_ops_orchestration",
+        ]
+    }
+
+
+def manifest_payload(*, app_version: str) -> dict[str, Any]:
+    return {
+        "service": "cognirelay",
+        "version": app_version,
+        "auth": {"type": "bearer", "header": "Authorization: Bearer <token>"},
+        "endpoints": {
+            "GET /health": {"scope": None},
+            "GET /capabilities": {"scope": None},
+            "GET /v1/manifest": {"scope": None},
+            "GET /v1/contracts": {"scope": None},
+            "GET /v1/governance/policy": {"scope": None},
+            "GET /v1/discovery": {"scope": None},
+            "GET /v1/discovery/tools": {"scope": None},
+            "GET /v1/discovery/workflows": {"scope": None},
+            "GET /.well-known/cognirelay.json": {"scope": None},
+            "GET /.well-known/mcp.json": {"scope": None},
+            "POST /v1/mcp": {"scope": "mixed (depends on tool)"},
+            "POST /v1/write": {"scope": "write:* by write_namespace"},
+            "POST /v1/append": {"scope": "write:* by write_namespace"},
+            "GET /v1/read": {"scope": "read:files"},
+            "POST /v1/index/rebuild": {"scope": "read:index"},
+            "POST /v1/index/rebuild-incremental": {"scope": "read:index"},
+            "GET /v1/index/status": {"scope": "read:index"},
+            "GET /v1/peers": {"scope": "read:files"},
+            "POST /v1/peers/register": {"scope": "admin:peers"},
+            "POST /v1/peers/{peer_id}/trust": {"scope": "admin:peers"},
+            "GET /v1/peers/{peer_id}/manifest": {"scope": "read:files"},
+            "POST /v1/search": {"scope": "search"},
+            "POST /v1/recent": {"scope": "search"},
+            "POST /v1/context/retrieve": {"scope": "search"},
+            "POST /v1/continuity/upsert": {"scope": "write:projects"},
+            "POST /v1/context/snapshot": {"scope": "search + write:projects"},
+            "GET /v1/context/snapshot/{snapshot_id}": {"scope": "read:files"},
+            "POST /v1/tasks": {"scope": "write:projects"},
+            "PATCH /v1/tasks/{task_id}": {"scope": "write:projects"},
+            "GET /v1/tasks/query": {"scope": "read:files"},
+            "POST /v1/docs/patch/propose": {"scope": "write:projects"},
+            "POST /v1/docs/patch/apply": {"scope": "write:projects"},
+            "POST /v1/code/patch/propose": {"scope": "write:projects"},
+            "POST /v1/code/checks/run": {"scope": "write:projects"},
+            "POST /v1/code/merge": {"scope": "write:projects"},
+            "GET /v1/security/tokens": {"scope": "admin:peers"},
+            "POST /v1/security/tokens/issue": {"scope": "admin:peers"},
+            "POST /v1/security/tokens/revoke": {"scope": "admin:peers"},
+            "POST /v1/security/tokens/rotate": {"scope": "admin:peers"},
+            "POST /v1/security/keys/rotate": {"scope": "admin:peers"},
+            "POST /v1/messages/verify": {"scope": "write:messages"},
+            "GET /v1/metrics": {"scope": "read:index"},
+            "POST /v1/replay/messages": {"scope": "write:messages"},
+            "POST /v1/replication/pull": {"scope": "admin:peers"},
+            "POST /v1/replication/push": {"scope": "admin:peers"},
+            "POST /v1/messages/send": {"scope": "write:messages"},
+            "POST /v1/messages/ack": {"scope": "write:messages"},
+            "GET /v1/messages/pending": {"scope": "read:files"},
+            "GET /v1/messages/inbox": {"scope": "read:files"},
+            "GET /v1/messages/thread": {"scope": "read:files"},
+            "POST /v1/relay/forward": {"scope": "write:messages"},
+            "POST /v1/compact/run": {"scope": "compact:trigger"},
+            "POST /v1/backup/create": {"scope": "admin:peers"},
+            "POST /v1/backup/restore-test": {"scope": "admin:peers"},
+            "GET /v1/ops/catalog": {"scope": "admin:peers (local-only)"},
+            "GET /v1/ops/status": {"scope": "admin:peers (local-only)"},
+            "POST /v1/ops/run": {"scope": "admin:peers (local-only)"},
+            "GET /v1/ops/schedule/export": {"scope": "admin:peers (local-only)"},
+        },
+    }
+
+
+def contracts_payload(*, contract_version: str, tools: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "contract_version": contract_version,
+        "compatibility": {
+            "policy": "backward-compatible additive changes within same contract_version",
+            "breaking_change_rule": "increment contract_version before breaking fields/methods",
+        },
+        "tool_catalog_hash": hashlib.sha256(_canonical_json(tools).encode("utf-8")).hexdigest(),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,20 @@ from .audit import append_audit
 from .auth import AuthContext, require_auth
 from .continuity import build_continuity_state, continuity_upsert_service
 from .config import ALL_SCOPES, get_settings, sha256_token
+from .discovery import (
+    capabilities_payload,
+    contracts_payload,
+    discovery_payload,
+    discovery_tools_payload,
+    discovery_workflows_payload,
+    handle_mcp_rpc_request,
+    health_payload,
+    manifest_payload,
+    tool_catalog,
+    well_known_cognirelay_payload,
+    well_known_mcp_payload,
+    workflow_catalog,
+)
 from .git_manager import GitManager
 from .indexer import (
     incremental_rebuild_index,
@@ -116,658 +130,11 @@ def _schema_for_model(model_cls: Any) -> dict[str, Any]:
 
 
 def _tool_catalog() -> list[dict[str, Any]]:
-    return [
-        {
-            "name": "system.health",
-            "description": "Check service liveness and git state.",
-            "method": "GET",
-            "path": "/health",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "system.capabilities",
-            "description": "Return high-level feature flags.",
-            "method": "GET",
-            "path": "/capabilities",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "system.manifest",
-            "description": "Return endpoint map and auth expectations.",
-            "method": "GET",
-            "path": "/v1/manifest",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "system.contracts",
-            "description": "Return frozen API/tool contract version and compatibility policy.",
-            "method": "GET",
-            "path": "/v1/contracts",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "system.governance_policy",
-            "description": "Return machine-readable governance policy pack.",
-            "method": "GET",
-            "path": "/v1/governance/policy",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "system.discovery",
-            "description": "Return machine guidance and entrypoints (MCP-like metadata).",
-            "method": "GET",
-            "path": "/v1/discovery",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "system.discovery_tools",
-            "description": "Return machine-usable tool catalog with schemas.",
-            "method": "GET",
-            "path": "/v1/discovery/tools",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "system.discovery_workflows",
-            "description": "Return recommended autonomous workflows.",
-            "method": "GET",
-            "path": "/v1/discovery/workflows",
-            "scopes": [],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "memory.write",
-            "description": "Write text content to a repo-relative path and commit.",
-            "method": "POST",
-            "path": "/v1/write",
-            "scopes": ["write:journal|write:messages|write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(WriteRequest),
-        },
-        {
-            "name": "memory.append_jsonl",
-            "description": "Append one JSON object as a JSONL record and commit.",
-            "method": "POST",
-            "path": "/v1/append",
-            "scopes": ["write:journal|write:messages|write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(AppendRequest),
-        },
-        {
-            "name": "memory.read",
-            "description": "Read a file by path.",
-            "method": "GET",
-            "path": "/v1/read",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {"path": {"type": "string"}},
-                "required": ["path"],
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "index.rebuild_full",
-            "description": "Rebuild derived indexes and SQLite FTS from repo files.",
-            "method": "POST",
-            "path": "/v1/index/rebuild",
-            "scopes": ["read:index"],
-            "idempotent": False,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "index.rebuild_incremental",
-            "description": "Incrementally rebuild indexes from mtime state.",
-            "method": "POST",
-            "path": "/v1/index/rebuild-incremental",
-            "scopes": ["read:index"],
-            "idempotent": False,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "index.status",
-            "description": "Inspect current index status and derived artifacts.",
-            "method": "GET",
-            "path": "/v1/index/status",
-            "scopes": ["read:index"],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "peers.list",
-            "description": "List known peer records from registry.",
-            "method": "GET",
-            "path": "/v1/peers",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "peers.register",
-            "description": "Create or update a peer registry record.",
-            "method": "POST",
-            "path": "/v1/peers/register",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(PeerRegisterRequest),
-        },
-        {
-            "name": "peers.trust_transition",
-            "description": "Apply explicit peer trust-level transition with reason and fingerprint guard.",
-            "method": "POST",
-            "path": "/v1/peers/{peer_id}/trust",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "peer_id": {"type": "string"},
-                    **_schema_for_model(PeerTrustTransitionRequest).get("properties", {}),
-                },
-                "required": ["peer_id", "trust_level", "reason"],
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "peers.fetch_manifest",
-            "description": "Fetch and return a peer's advertised manifest.",
-            "method": "GET",
-            "path": "/v1/peers/{peer_id}/manifest",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {"peer_id": {"type": "string"}},
-                "required": ["peer_id"],
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "search.query",
-            "description": "Search indexed repo content.",
-            "method": "POST",
-            "path": "/v1/search",
-            "scopes": ["search", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": _schema_for_model(SearchRequest),
-        },
-        {
-            "name": "recent.list",
-            "description": "List recently modified indexed content without a query string.",
-            "method": "POST",
-            "path": "/v1/recent",
-            "scopes": ["search", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": _schema_for_model(RecentRequest),
-        },
-        {
-            "name": "context.retrieve",
-            "description": "Build a compact context bundle for task continuation.",
-            "method": "POST",
-            "path": "/v1/context/retrieve",
-            "scopes": ["search", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": _schema_for_model(ContextRetrieveRequest),
-        },
-        {
-            "name": "continuity.upsert",
-            "description": "Create or replace one continuity capsule atomically.",
-            "method": "POST",
-            "path": "/v1/continuity/upsert",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(ContinuityUpsertRequest),
-        },
-        {
-            "name": "context.snapshot_create",
-            "description": "Create deterministic context snapshot and persist it.",
-            "method": "POST",
-            "path": "/v1/context/snapshot",
-            "scopes": ["search", "write:projects", "write_namespaces", "read_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(ContextSnapshotRequest),
-        },
-        {
-            "name": "context.snapshot_get",
-            "description": "Load persisted context snapshot by id.",
-            "method": "GET",
-            "path": "/v1/context/snapshot/{snapshot_id}",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {"snapshot_id": {"type": "string"}},
-                "required": ["snapshot_id"],
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "tasks.create",
-            "description": "Create a collaborative task record.",
-            "method": "POST",
-            "path": "/v1/tasks",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(TaskCreateRequest),
-        },
-        {
-            "name": "tasks.update",
-            "description": "Update a task and enforce status transitions.",
-            "method": "PATCH",
-            "path": "/v1/tasks/{task_id}",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": {
-                "type": "object",
-                "properties": {"task_id": {"type": "string"}, **_schema_for_model(TaskUpdateRequest).get("properties", {})},
-                "required": ["task_id"],
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "tasks.query",
-            "description": "Query task records by status/owner/collaborator/thread.",
-            "method": "GET",
-            "path": "/v1/tasks/query",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "status": {"type": "string"},
-                    "owner_peer": {"type": "string"},
-                    "collaborator": {"type": "string"},
-                    "thread_id": {"type": "string"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 500},
-                },
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "docs.patch_propose",
-            "description": "Propose unified diff patch for docs/content target.",
-            "method": "POST",
-            "path": "/v1/docs/patch/propose",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(PatchProposeRequest),
-        },
-        {
-            "name": "docs.patch_apply",
-            "description": "Apply proposed docs/content patch with base-ref checks.",
-            "method": "POST",
-            "path": "/v1/docs/patch/apply",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(PatchApplyRequest),
-        },
-        {
-            "name": "code.patch_propose",
-            "description": "Propose unified diff patch for code target.",
-            "method": "POST",
-            "path": "/v1/code/patch/propose",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(PatchProposeRequest),
-        },
-        {
-            "name": "code.checks_run",
-            "description": "Run configured check profile on a git ref and persist artifact.",
-            "method": "POST",
-            "path": "/v1/code/checks/run",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(CodeCheckRunRequest),
-        },
-        {
-            "name": "code.merge",
-            "description": "Fast-forward merge a source ref into HEAD after required checks pass.",
-            "method": "POST",
-            "path": "/v1/code/merge",
-            "scopes": ["write:projects", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(CodeMergeRequest),
-        },
-        {
-            "name": "security.tokens_list",
-            "description": "List token entries with status and expiry metadata.",
-            "method": "GET",
-            "path": "/v1/security/tokens",
-            "scopes": ["admin:peers", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "peer_id": {"type": "string"},
-                    "status": {"type": "string"},
-                    "include_inactive": {"type": "boolean"}
-                },
-                "additionalProperties": False
-            },
-        },
-        {
-            "name": "security.tokens_issue",
-            "description": "Issue a new peer token with scopes/namespaces and optional expiry.",
-            "method": "POST",
-            "path": "/v1/security/tokens/issue",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(SecurityTokenIssueRequest),
-        },
-        {
-            "name": "security.tokens_revoke",
-            "description": "Revoke a token by id/sha or revoke all tokens for a peer.",
-            "method": "POST",
-            "path": "/v1/security/tokens/revoke",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(SecurityTokenRevokeRequest),
-        },
-        {
-            "name": "security.tokens_rotate",
-            "description": "Rotate token credentials by revoking old token and issuing a replacement atomically.",
-            "method": "POST",
-            "path": "/v1/security/tokens/rotate",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(SecurityTokenRotateRequest),
-        },
-        {
-            "name": "security.keys_rotate",
-            "description": "Rotate message verification key material.",
-            "method": "POST",
-            "path": "/v1/security/keys/rotate",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(SecurityKeysRotateRequest),
-        },
-        {
-            "name": "messages.verify",
-            "description": "Verify signed message envelope and optionally consume nonce.",
-            "method": "POST",
-            "path": "/v1/messages/verify",
-            "scopes": ["write:messages", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(MessageVerifyRequest),
-        },
-        {
-            "name": "metrics.get",
-            "description": "Return operational metrics summary.",
-            "method": "GET",
-            "path": "/v1/metrics",
-            "scopes": ["read:index"],
-            "idempotent": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "messages.replay",
-            "description": "Replay a tracked dead-letter message back into delivery flow.",
-            "method": "POST",
-            "path": "/v1/replay/messages",
-            "scopes": ["write:messages", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(MessageReplayRequest),
-        },
-        {
-            "name": "replication.pull",
-            "description": "Ingest replicated file bundle from peer.",
-            "method": "POST",
-            "path": "/v1/replication/pull",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(ReplicationPullRequest),
-        },
-        {
-            "name": "replication.push",
-            "description": "Build and optionally push replication bundle to peer endpoint.",
-            "method": "POST",
-            "path": "/v1/replication/push",
-            "scopes": ["admin:peers", "read_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(ReplicationPushRequest),
-        },
-        {
-            "name": "messages.send",
-            "description": "Write message to recipient inbox/outbox/thread.",
-            "method": "POST",
-            "path": "/v1/messages/send",
-            "scopes": ["write:messages", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(MessageSendRequest),
-        },
-        {
-            "name": "messages.ack",
-            "description": "Acknowledge/defer/reject tracked message delivery.",
-            "method": "POST",
-            "path": "/v1/messages/ack",
-            "scopes": ["write:messages", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(MessageAckRequest),
-        },
-        {
-            "name": "messages.pending",
-            "description": "Inspect pending and terminal delivery states.",
-            "method": "GET",
-            "path": "/v1/messages/pending",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "recipient": {"type": "string"},
-                    "status": {"type": "string"},
-                    "include_terminal": {"type": "boolean"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 500},
-                },
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "messages.inbox",
-            "description": "Read recipient inbox messages.",
-            "method": "GET",
-            "path": "/v1/messages/inbox",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "recipient": {"type": "string"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 200},
-                },
-                "required": ["recipient"],
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "messages.thread",
-            "description": "Read thread messages by thread_id.",
-            "method": "GET",
-            "path": "/v1/messages/thread",
-            "scopes": ["read:files", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "thread_id": {"type": "string"},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": 1000},
-                },
-                "required": ["thread_id"],
-                "additionalProperties": False,
-            },
-        },
-        {
-            "name": "messages.relay_forward",
-            "description": "Forward a message via relay log + inbox + thread write.",
-            "method": "POST",
-            "path": "/v1/relay/forward",
-            "scopes": ["write:messages", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(RelayForwardRequest),
-        },
-        {
-            "name": "memory.compaction_plan",
-            "description": "Generate compaction planning report (planner only).",
-            "method": "POST",
-            "path": "/v1/compact/run",
-            "scopes": ["compact:trigger", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(CompactRequest),
-        },
-        {
-            "name": "backup.create",
-            "description": "Create deterministic tar.gz backup bundle and manifest.",
-            "method": "POST",
-            "path": "/v1/backup/create",
-            "scopes": ["admin:peers", "write_namespaces"],
-            "idempotent": False,
-            "input_schema": _schema_for_model(BackupCreateRequest),
-        },
-        {
-            "name": "backup.restore_test",
-            "description": "Run backup restore validation in temporary directory.",
-            "method": "POST",
-            "path": "/v1/backup/restore-test",
-            "scopes": ["admin:peers", "read_namespaces"],
-            "idempotent": True,
-            "input_schema": _schema_for_model(BackupRestoreTestRequest),
-        },
-        {
-            "name": "ops.catalog",
-            "description": "List host-ops automation jobs and local security constraints.",
-            "method": "GET",
-            "path": "/v1/ops/catalog",
-            "scopes": ["admin:peers"],
-            "idempotent": True,
-            "local_only": True,
-            "input_schema": {"type": "object", "properties": {}, "additionalProperties": False},
-        },
-        {
-            "name": "ops.status",
-            "description": "Inspect recent host-ops runs and active job locks.",
-            "method": "GET",
-            "path": "/v1/ops/status",
-            "scopes": ["admin:peers"],
-            "idempotent": True,
-            "local_only": True,
-            "input_schema": {"type": "object", "properties": {"limit": {"type": "integer", "minimum": 1, "maximum": 500}}, "additionalProperties": False},
-        },
-        {
-            "name": "ops.run",
-            "description": "Run one host-ops job locally with lock/audit controls.",
-            "method": "POST",
-            "path": "/v1/ops/run",
-            "scopes": ["admin:peers"],
-            "idempotent": False,
-            "local_only": True,
-            "input_schema": _schema_for_model(OpsRunRequest),
-        },
-        {
-            "name": "ops.schedule_export",
-            "description": "Export suggested systemd/cron schedule for host-ops jobs.",
-            "method": "GET",
-            "path": "/v1/ops/schedule/export",
-            "scopes": ["admin:peers"],
-            "idempotent": True,
-            "local_only": True,
-            "input_schema": {"type": "object", "properties": {"format": {"type": "string", "enum": ["systemd", "cron"]}}, "additionalProperties": False},
-        },
-    ]
+    return tool_catalog(_schema_for_model)
 
 
 def _workflow_catalog() -> list[dict[str, Any]]:
-    return [
-        {
-            "name": "bootstrap_cycle",
-            "description": "Recommended autonomous startup/loop sequence.",
-            "steps": [
-                {"order": 1, "tool": "system.discovery"},
-                {"order": 2, "tool": "system.manifest"},
-                {"order": 3, "tool": "system.health"},
-                {"order": 4, "tool": "index.rebuild_incremental"},
-                {"order": 5, "tool": "context.retrieve"},
-            ],
-        },
-        {
-            "name": "collaborative_writing",
-            "description": "Message exchange workflow with delivery acknowledgement.",
-            "steps": [
-                {"order": 1, "tool": "messages.send"},
-                {"order": 2, "tool": "messages.pending"},
-                {"order": 3, "tool": "messages.ack"},
-                {"order": 4, "tool": "messages.thread"},
-                {"order": 5, "tool": "memory.append_jsonl"},
-                {"order": 6, "tool": "context.retrieve"},
-            ],
-        },
-        {
-            "name": "collaborative_tasks_and_code",
-            "description": "Task graph + patch proposal + checks/merge sequence.",
-            "steps": [
-                {"order": 1, "tool": "tasks.query"},
-                {"order": 2, "tool": "tasks.create"},
-                {"order": 3, "tool": "tasks.update"},
-                {"order": 4, "tool": "docs.patch_propose"},
-                {"order": 5, "tool": "docs.patch_apply"},
-                {"order": 6, "tool": "code.patch_propose"},
-                {"order": 7, "tool": "code.checks_run"},
-                {"order": 8, "tool": "code.merge"},
-            ],
-        },
-        {
-            "name": "federation_hardening",
-            "description": "Signed envelope verification and replication operations.",
-            "steps": [
-                {"order": 1, "tool": "security.tokens_list"},
-                {"order": 2, "tool": "security.tokens_issue"},
-                {"order": 3, "tool": "security.tokens_rotate"},
-                {"order": 4, "tool": "security.tokens_revoke"},
-                {"order": 5, "tool": "peers.trust_transition"},
-                {"order": 6, "tool": "security.keys_rotate"},
-                {"order": 7, "tool": "messages.verify"},
-                {"order": 8, "tool": "metrics.get"},
-                {"order": 9, "tool": "messages.replay"},
-                {"order": 10, "tool": "replication.push"},
-                {"order": 11, "tool": "replication.pull"},
-            ],
-        },
-        {
-            "name": "maintenance_compaction",
-            "description": "Periodic maintenance for index freshness and compaction planning.",
-            "steps": [
-                {"order": 1, "tool": "index.rebuild_incremental"},
-                {"order": 2, "tool": "backup.create"},
-                {"order": 3, "tool": "backup.restore_test"},
-                {"order": 4, "tool": "memory.compaction_plan"},
-                {"order": 5, "tool": "memory.write"},
-            ],
-        },
-        {
-            "name": "host_ops_automation",
-            "description": "Local-only host automation runner for maintenance and safety jobs.",
-            "steps": [
-                {"order": 1, "tool": "ops.catalog"},
-                {"order": 2, "tool": "ops.status"},
-                {"order": 3, "tool": "ops.run"},
-                {"order": 4, "tool": "ops.schedule_export"},
-            ],
-        },
-    ]
+    return workflow_catalog()
 
 
 @app.get("/v1/discovery")
@@ -775,144 +142,31 @@ def discovery() -> dict:
     settings = get_settings()
     tools = _tool_catalog()
     workflows = _workflow_catalog()
-    return {
-        "ok": True,
-        "protocol": {
-            "name": "cognirelay-http",
-            "style": "mcp-like",
-            "version": settings.contract_version,
-            "transport": "http+json",
-        },
-        "auth": {
-            "type": "bearer",
-            "header": "Authorization: Bearer <token>",
-            "notes": [
-                "Scopes and namespace restrictions are enforced per token.",
-                "Use /v1/manifest for endpoint-level scope requirements.",
-                "If strict signed ingress is enabled, message ingress requires signed_envelope.",
-                "Rate limits and payload caps are enforced per token/IP.",
-                "Host ops endpoints are local-only and intended for daemon/scheduler use on hosting machine.",
-            ],
-        },
-        "entrypoints": {
-            "manifest": "/v1/manifest",
-            "contracts": "/v1/contracts",
-            "governance_policy": "/v1/governance/policy",
-            "ops_catalog": "/v1/ops/catalog",
-            "ops_status": "/v1/ops/status",
-            "tools": "/v1/discovery/tools",
-            "workflows": "/v1/discovery/workflows",
-            "mcp_rpc": "/v1/mcp",
-            "mcp_well_known": "/.well-known/mcp.json",
-        },
-        "agent_guidance": {
-            "first_calls": ["GET /v1/discovery", "GET /v1/manifest", "GET /health"],
-            "mcp_first_calls": [
-                "POST /v1/mcp {\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}",
-                "POST /v1/mcp {\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}",
-                "POST /v1/mcp {\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}",
-            ],
-            "loop_hint": "Prefer /v1/index/rebuild-incremental over full rebuild in frequent loops.",
-            "write_hint": "Prefer append-only JSONL for events/messages and frequent commits.",
-        },
-        "counts": {"tools": len(tools), "workflows": len(workflows)},
-    }
+    return discovery_payload(settings.contract_version, tools=tools, workflows=workflows)
 
 
 @app.get("/v1/discovery/tools")
 def discovery_tools() -> dict:
     settings = get_settings()
     tools = _tool_catalog()
-    return {
-        "ok": True,
-        "protocol": {"name": "cognirelay-http", "style": "mcp-like", "version": settings.contract_version},
-        "count": len(tools),
-        "tools": tools,
-    }
+    return discovery_tools_payload(settings.contract_version, tools=tools)
 
 
 @app.get("/v1/discovery/workflows")
 def discovery_workflows() -> dict:
     workflows = _workflow_catalog()
-    return {"ok": True, "count": len(workflows), "workflows": workflows}
+    return discovery_workflows_payload(workflows=workflows)
 
 
 @app.get("/.well-known/cognirelay.json")
 def well_known_cognirelay() -> dict:
-    return discovery()
+    return well_known_cognirelay_payload(discovery())
 
 
 @app.get("/.well-known/mcp.json")
 def well_known_mcp() -> dict:
     settings = get_settings()
-    return {
-        "ok": True,
-        "protocol": "jsonrpc-2.0",
-        "style": "mcp-compatible",
-        "transport": "http+json",
-        "endpoint": "/v1/mcp",
-        "contract_version": settings.contract_version,
-        "methods": ["initialize", "notifications/initialized", "ping", "tools/list", "tools/call"],
-        "auth": {"type": "bearer", "header": "Authorization: Bearer <token>"},
-    }
-
-
-def _rpc_ok(request_id: Any, result: dict[str, Any]) -> dict[str, Any]:
-    return {"jsonrpc": "2.0", "id": request_id, "result": result}
-
-
-def _rpc_error(request_id: Any, code: int, message: str, data: Any | None = None) -> dict[str, Any]:
-    err: dict[str, Any] = {"code": code, "message": message}
-    if data is not None:
-        err["data"] = data
-    return {"jsonrpc": "2.0", "id": request_id, "error": err}
-
-
-def _mcp_list_tools_result() -> dict[str, Any]:
-    tools = []
-    for t in _tool_catalog():
-        tools.append(
-            {
-                "name": t["name"],
-                "description": t["description"],
-                "inputSchema": t["input_schema"],
-                "metadata": {
-                    "method": t["method"],
-                    "path": t["path"],
-                    "scopes": t["scopes"],
-                    "idempotent": t["idempotent"],
-                    "local_only": bool(t.get("local_only", False)),
-                },
-            }
-        )
-    return {"tools": tools}
-
-
-def _mcp_initialize_result(params: dict[str, Any]) -> dict[str, Any]:
-    settings = get_settings()
-    requested_protocol = params.get("protocolVersion", settings.contract_version)
-    return {
-        "protocolVersion": str(requested_protocol),
-        "capabilities": {
-            "tools": {"listChanged": False},
-            "sampling": {},
-        },
-        "serverInfo": {
-            "name": "cognirelay",
-            "version": get_settings().contract_version,
-        },
-        "instructions": (
-            "Use tools/list to discover tool schemas, then tools/call for execution. "
-            "Prefer /v1/discovery for supplemental HTTP-native guidance."
-        ),
-    }
-
-
-def _tool_by_name(name: str) -> dict[str, Any] | None:
-    for t in _tool_catalog():
-        if t["name"] == name:
-            return t
-    return None
+    return well_known_mcp_payload(settings.contract_version)
 
 
 def _resolve_auth_context(
@@ -1089,77 +343,16 @@ def _handle_mcp_rpc_request(
     x_real_ip: str | None = None,
     request: FastAPIRequest | None = None,
 ) -> dict[str, Any] | None:
-    if not isinstance(request_payload, dict):
-        return _rpc_error(None, -32600, "Invalid Request")
-
-    request_id = request_payload.get("id")
-    is_notification = "id" not in request_payload
-    if request_payload.get("jsonrpc") != "2.0":
-        return _rpc_error(request_id, -32600, "Invalid Request: jsonrpc must be '2.0'")
-
-    method = request_payload.get("method")
-    params = request_payload.get("params", {})
-    if not isinstance(params, dict):
-        return _rpc_error(request_id, -32602, "Invalid params: params must be an object")
-
-    if method == "initialize":
-        return _rpc_ok(request_id, _mcp_initialize_result(params))
-
-    if method == "notifications/initialized":
-        # JSON-RPC notifications should not produce a response body.
-        if is_notification:
-            return None
-        return _rpc_ok(request_id, {"acknowledged": True})
-
-    if method == "ping":
-        return _rpc_ok(request_id, {"ok": True, "ts": datetime.now(timezone.utc).isoformat()})
-
-    if method == "tools/list":
-        return _rpc_ok(request_id, _mcp_list_tools_result())
-    if method != "tools/call":
-        return _rpc_error(request_id, -32601, f"Method not found: {method}")
-
-    name = params.get("name")
-    arguments = params.get("arguments", {})
-    if not isinstance(name, str) or not name:
-        return _rpc_error(request_id, -32602, "Invalid params: 'name' is required")
-
-    tool = _tool_by_name(name)
-    if tool is None:
-        return _rpc_error(request_id, -32602, f"Unknown tool: {name}")
-
-    auth_required = bool(tool.get("scopes"))
-    try:
-        auth = _resolve_auth_context(
-            authorization,
-            required=auth_required,
-            x_forwarded_for=x_forwarded_for,
-            x_real_ip=x_real_ip,
-            request=request,
-        )
-        result = _invoke_tool_by_name(name, arguments, auth)
-    except ValidationError as e:
-        return _rpc_error(request_id, -32602, "Invalid params", data=e.errors())
-    except HTTPException as e:
-        if e.status_code == 401:
-            return _rpc_error(request_id, -32001, "Unauthorized", data=e.detail)
-        if e.status_code == 403:
-            return _rpc_error(request_id, -32002, "Forbidden", data=e.detail)
-        if e.status_code == 404:
-            return _rpc_error(request_id, -32004, "Not Found", data=e.detail)
-        return _rpc_error(request_id, -32003, "Tool execution failed", data=e.detail)
-    except (KeyError, TypeError, ValueError) as e:
-        return _rpc_error(request_id, -32602, "Invalid params", data=str(e))
-    except Exception as e:
-        return _rpc_error(request_id, -32003, "Tool execution failed", data=str(e))
-
-    return _rpc_ok(
-        request_id,
-        {
-            "toolName": name,
-            "content": [{"type": "text", "text": f"Executed {name}"}],
-            "structuredContent": result,
-        },
+    return handle_mcp_rpc_request(
+        request_payload,
+        authorization=authorization,
+        x_forwarded_for=x_forwarded_for,
+        x_real_ip=x_real_ip,
+        request=request,
+        contract_version=get_settings().contract_version,
+        tools=_tool_catalog(),
+        resolve_auth_context=_resolve_auth_context,
+        invoke_tool_by_name=_invoke_tool_by_name,
     )
 
 
@@ -1206,148 +399,32 @@ def mcp_rpc(
 @app.get("/health")
 def health() -> dict:
     settings, gm = _services()
-    return {
-        "ok": True,
-        "service": "cognirelay",
-        "version": app.version,
-        "contract_version": settings.contract_version,
-        "repo_root": str(settings.repo_root),
-        "git_initialized": gm.is_repo(),
-        "latest_commit": gm.latest_commit(),
-        "signed_ingress_required": bool(settings.require_signed_ingress),
-        "time": datetime.now(timezone.utc).isoformat(),
-    }
+    return health_payload(
+        app_version=app.version,
+        contract_version=settings.contract_version,
+        repo_root=str(settings.repo_root),
+        git_initialized=gm.is_repo(),
+        latest_commit=gm.latest_commit(),
+        signed_ingress_required=bool(settings.require_signed_ingress),
+    )
 
 
 @app.get("/capabilities")
 def capabilities() -> dict:
-    return {
-        "features": [
-            "write",
-            "read",
-            "append_jsonl",
-            "index_rebuild",
-            "search",
-            "context_retrieve",
-            "continuity_state",
-            "context_snapshot",
-            "messages_send_inbox",
-            "compact_summary",
-            "audit_log",
-            "peer_tokens_json",
-            "peers_registry",
-            "sqlite_fts_search",
-            "index_incremental",
-            "relay_forward",
-            "messages_reliable_delivery",
-            "discovery_manifest",
-            "discovery_tools",
-            "discovery_workflows",
-            "mcp_jsonrpc",
-            "tasks_workflows",
-            "patch_proposals",
-            "checks_and_merge_policy",
-            "security_keys_rotation",
-            "security_token_lifecycle",
-            "messages_signature_verify",
-            "strict_signed_ingress",
-            "metrics_endpoint",
-            "messages_replay",
-            "replication_push_pull",
-            "trust_policy_transitions",
-            "backup_restore_validation",
-            "api_contract_versioning",
-            "governance_policy_pack",
-            "abuse_controls",
-            "host_ops_orchestration",
-        ]
-    }
+    return capabilities_payload()
 
 
 @app.get("/v1/manifest")
 def manifest() -> dict:
     """Machine-first endpoint map for autonomous clients."""
-    settings = get_settings()
-    return {
-        "service": "cognirelay",
-        "version": app.version,
-        "auth": {"type": "bearer", "header": "Authorization: Bearer <token>"},
-        "endpoints": {
-            "GET /health": {"scope": None},
-            "GET /capabilities": {"scope": None},
-            "GET /v1/manifest": {"scope": None},
-            "GET /v1/contracts": {"scope": None},
-            "GET /v1/governance/policy": {"scope": None},
-            "GET /v1/discovery": {"scope": None},
-            "GET /v1/discovery/tools": {"scope": None},
-            "GET /v1/discovery/workflows": {"scope": None},
-            "GET /.well-known/cognirelay.json": {"scope": None},
-            "GET /.well-known/mcp.json": {"scope": None},
-            "POST /v1/mcp": {"scope": "mixed (depends on tool)"},
-            "POST /v1/write": {"scope": "write:* by write_namespace"},
-            "POST /v1/append": {"scope": "write:* by write_namespace"},
-            "GET /v1/read": {"scope": "read:files"},
-            "POST /v1/index/rebuild": {"scope": "read:index"},
-            "POST /v1/index/rebuild-incremental": {"scope": "read:index"},
-            "GET /v1/index/status": {"scope": "read:index"},
-            "GET /v1/peers": {"scope": "read:files"},
-            "POST /v1/peers/register": {"scope": "admin:peers"},
-            "POST /v1/peers/{peer_id}/trust": {"scope": "admin:peers"},
-            "GET /v1/peers/{peer_id}/manifest": {"scope": "read:files"},
-            "POST /v1/search": {"scope": "search"},
-            "POST /v1/recent": {"scope": "search"},
-            "POST /v1/context/retrieve": {"scope": "search"},
-            "POST /v1/continuity/upsert": {"scope": "write:projects"},
-            "POST /v1/context/snapshot": {"scope": "search + write:projects"},
-            "GET /v1/context/snapshot/{snapshot_id}": {"scope": "read:files"},
-            "POST /v1/tasks": {"scope": "write:projects"},
-            "PATCH /v1/tasks/{task_id}": {"scope": "write:projects"},
-            "GET /v1/tasks/query": {"scope": "read:files"},
-            "POST /v1/docs/patch/propose": {"scope": "write:projects"},
-            "POST /v1/docs/patch/apply": {"scope": "write:projects"},
-            "POST /v1/code/patch/propose": {"scope": "write:projects"},
-            "POST /v1/code/checks/run": {"scope": "write:projects"},
-            "POST /v1/code/merge": {"scope": "write:projects"},
-            "GET /v1/security/tokens": {"scope": "admin:peers"},
-            "POST /v1/security/tokens/issue": {"scope": "admin:peers"},
-            "POST /v1/security/tokens/revoke": {"scope": "admin:peers"},
-            "POST /v1/security/tokens/rotate": {"scope": "admin:peers"},
-            "POST /v1/security/keys/rotate": {"scope": "admin:peers"},
-            "POST /v1/messages/verify": {"scope": "write:messages"},
-            "GET /v1/metrics": {"scope": "read:index"},
-            "POST /v1/replay/messages": {"scope": "write:messages"},
-            "POST /v1/replication/pull": {"scope": "admin:peers"},
-            "POST /v1/replication/push": {"scope": "admin:peers"},
-            "POST /v1/messages/send": {"scope": "write:messages"},
-            "POST /v1/messages/ack": {"scope": "write:messages"},
-            "GET /v1/messages/pending": {"scope": "read:files"},
-            "GET /v1/messages/inbox": {"scope": "read:files"},
-            "GET /v1/messages/thread": {"scope": "read:files"},
-            "POST /v1/relay/forward": {"scope": "write:messages"},
-            "POST /v1/compact/run": {"scope": "compact:trigger"},
-            "POST /v1/backup/create": {"scope": "admin:peers"},
-            "POST /v1/backup/restore-test": {"scope": "admin:peers"},
-            "GET /v1/ops/catalog": {"scope": "admin:peers (local-only)"},
-            "GET /v1/ops/status": {"scope": "admin:peers (local-only)"},
-            "POST /v1/ops/run": {"scope": "admin:peers (local-only)"},
-            "GET /v1/ops/schedule/export": {"scope": "admin:peers (local-only)"},
-        },
-    }
+    return manifest_payload(app_version=app.version)
 
 
 
 @app.get("/v1/contracts")
 def contracts() -> dict:
     settings = get_settings()
-    return {
-        "ok": True,
-        "contract_version": settings.contract_version,
-        "compatibility": {
-            "policy": "backward-compatible additive changes within same contract_version",
-            "breaking_change_rule": "increment contract_version before breaking fields/methods",
-        },
-        "tool_catalog_hash": hashlib.sha256(_canonical_json(_tool_catalog()).encode("utf-8")).hexdigest(),
-    }
+    return contracts_payload(contract_version=settings.contract_version, tools=_tool_catalog())
 
 
 @app.get("/v1/governance/policy")


### PR DESCRIPTION
## Summary
- extract discovery, manifest, and MCP service logic from `app/main.py` into `app/discovery/service.py`
- keep `app/main.py` focused on route wiring and thin wrappers for this slice
- preserve the existing API surface while establishing the first refactor boundary from #12

## Testing
- `./.venv/bin/python -m unittest tests.test_discovery tests.test_mcp_rpc -v`
- `./.venv/bin/python -m unittest discover -s tests -v`

Refs #12
