### PR TITLE
Refactor maintenance services out of main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -104,6 +104,20 @@ from .messages import (
     relay_forward_service,
     replay_messages_service,
 )
+from .maintenance import (
+    BACKUPS_DIR_REL,
+    REPLICATION_ALLOWED_PREFIXES,
+    REPLICATION_STATE_REL,
+    REPLICATION_TOMBSTONES_REL,
+    backup_create_service,
+    backup_restore_test_service,
+    compact_run_service,
+    iter_replication_files,
+    load_replication_state,
+    metrics_service,
+    replication_pull_service,
+    replication_push_service,
+)
 from .storage import StorageError, append_jsonl, read_text_file, safe_path, write_text_file
 from .security import (
     GOVERNANCE_POLICY_REL,
@@ -869,13 +883,8 @@ def code_merge(req: CodeMergeRequest, auth: AuthContext = Depends(require_auth))
 
 
 DELIVERY_STATE_REL = "messages/state/delivery_index.json"
-REPLICATION_STATE_REL = "peers/replication_state.json"
-REPLICATION_ALLOWED_PREFIXES = {"journal", "essays", "projects", "memory", "messages", "tasks", "patches", "runs", "snapshots", "archive"}
-
 RATE_LIMIT_STATE_REL = "logs/rate_limit_state.json"
 TRUST_POLICIES_REL = "peers/trust_policies.json"
-REPLICATION_TOMBSTONES_REL = "peers/replication_tombstones.json"
-BACKUPS_DIR_REL = "backups"
 def _estimate_payload_bytes(payload: Any) -> int:
     try:
         encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -1037,131 +1046,12 @@ def _verification_failure_count(settings, auth: AuthContext) -> int:
     return count
 
 
-def _load_replication_tombstones(repo_root: Path) -> dict[str, Any]:
-    p = safe_path(repo_root, REPLICATION_TOMBSTONES_REL)
-    if not p.exists():
-        return {"schema_version": "1.0", "entries": {}}
-    try:
-        data = json.loads(p.read_text(encoding="utf-8"))
-    except Exception:
-        return {"schema_version": "1.0", "entries": {}}
-    if not isinstance(data, dict):
-        return {"schema_version": "1.0", "entries": {}}
-    entries = data.get("entries")
-    if not isinstance(entries, dict):
-        entries = {}
-    return {"schema_version": "1.0", "entries": entries}
-
-
-def _write_replication_tombstones(repo_root: Path, payload: dict[str, Any]) -> Path:
-    p = safe_path(repo_root, REPLICATION_TOMBSTONES_REL)
-    write_text_file(p, json.dumps(payload, ensure_ascii=False, indent=2))
-    return p
-
-
-def _parse_dt_or_epoch(iso_value: str | None, fallback_epoch: float) -> float:
-    dt = _parse_iso(iso_value)
-    if dt is None:
-        return fallback_epoch
-    return dt.timestamp()
-
 def _canonical_json(data: Any) -> str:
     return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
 
 
 def _sha256_text(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
-
-
-def _load_replication_state(repo_root: Path) -> dict[str, Any]:
-    p = safe_path(repo_root, REPLICATION_STATE_REL)
-    if not p.exists():
-        return {"schema_version": "1.0", "last_pull_by_source": {}, "last_push": None, "pull_idempotency": {}}
-    try:
-        data = json.loads(p.read_text(encoding="utf-8"))
-    except Exception:
-        return {"schema_version": "1.0", "last_pull_by_source": {}, "last_push": None, "pull_idempotency": {}}
-    if not isinstance(data, dict):
-        return {"schema_version": "1.0", "last_pull_by_source": {}, "last_push": None, "pull_idempotency": {}}
-    if not isinstance(data.get("last_pull_by_source"), dict):
-        data["last_pull_by_source"] = {}
-    if not isinstance(data.get("pull_idempotency"), dict):
-        data["pull_idempotency"] = {}
-    return data
-
-
-def _write_replication_state(repo_root: Path, payload: dict[str, Any]) -> Path:
-    p = safe_path(repo_root, REPLICATION_STATE_REL)
-    write_text_file(p, json.dumps(payload, ensure_ascii=False, indent=2))
-    return p
-
-
-def _iter_replication_files(repo_root: Path, include_prefixes: list[str], max_files: int, include_deleted: bool = True) -> list[dict[str, Any]]:
-    prefixes = []
-    for raw in include_prefixes:
-        rel = str(raw or "").strip().strip("/")
-        if not rel:
-            continue
-        top = Path(rel).parts[0] if Path(rel).parts else ""
-        if top not in REPLICATION_ALLOWED_PREFIXES:
-            continue
-        prefixes.append(rel)
-    if not prefixes:
-        prefixes = ["memory", "messages", "projects", "essays", "journal", "tasks", "patches", "runs", "snapshots"]
-
-    items = []
-    for prefix in prefixes:
-        base = safe_path(repo_root, prefix)
-        if not base.exists():
-            continue
-        for p in sorted(base.rglob("*")):
-            if not p.is_file() or ".git" in p.parts:
-                continue
-            rel = str(p.relative_to(repo_root))
-            try:
-                content = p.read_text(encoding="utf-8")
-            except Exception:
-                continue
-            stat = p.stat()
-            items.append(
-                {
-                    "path": rel,
-                    "content": content,
-                    "sha256": _sha256_text(content),
-                    "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
-                    "deleted": False,
-                    "tombstone_at": None,
-                }
-            )
-            if len(items) >= max_files:
-                return items
-
-    if include_deleted and len(items) < max_files:
-        tombstones = _load_replication_tombstones(repo_root)
-        entries = tombstones.get("entries", {})
-        if isinstance(entries, dict):
-            for path, row in sorted(entries.items(), key=lambda x: x[0]):
-                top = Path(str(path)).parts[0] if Path(str(path)).parts else ""
-                if top not in REPLICATION_ALLOWED_PREFIXES:
-                    continue
-                if prefixes and not any(str(path).startswith(f"{p}/") or str(path) == p for p in prefixes):
-                    continue
-                if not isinstance(row, dict):
-                    continue
-                items.append(
-                    {
-                        "path": str(path),
-                        "content": None,
-                        "sha256": None,
-                        "modified_at": row.get("tombstone_at"),
-                        "deleted": True,
-                        "tombstone_at": row.get("tombstone_at"),
-                    }
-                )
-                if len(items) >= max_files:
-                    return items
-
-    return items
 
 
 @app.post("/v1/messages/send")
@@ -1351,146 +1241,15 @@ def messages_verify(req: MessageVerifyRequest, auth: AuthContext = Depends(requi
 @app.get("/v1/metrics")
 def metrics(auth: AuthContext = Depends(require_auth)) -> dict:
     settings, _ = _services()
-    auth.require("read:index")
-    auth.require_read_path(DELIVERY_STATE_REL)
-    auth.require_read_path("logs/api_audit.jsonl")
-    now = datetime.now(timezone.utc)
-
-    state = load_delivery_state(settings.repo_root)
-    delivery_summary: dict[str, int] = {}
-    by_recipient: dict[str, dict[str, int]] = {}
-    for row in state.get("records", {}).values():
-        if not isinstance(row, dict):
-            continue
-        view = delivery_record_view(row, now, parse_iso=_parse_iso)
-        eff = str(view.get("effective_status") or "unknown")
-        delivery_summary[eff] = delivery_summary.get(eff, 0) + 1
-        recipient = str(view.get("to") or "unknown")
-        rec = by_recipient.setdefault(recipient, {"total": 0, "pending": 0, "acked": 0, "dead_letter": 0})
-        rec["total"] += 1
-        if eff == "pending_ack":
-            rec["pending"] += 1
-        elif eff == "acked":
-            rec["acked"] += 1
-        elif eff == "dead_letter":
-            rec["dead_letter"] += 1
-
-    acked = delivery_summary.get("acked", 0)
-    dead_letter = delivery_summary.get("dead_letter", 0)
-    ack_denom = acked + dead_letter
-    ack_success_ratio = (acked / ack_denom) if ack_denom > 0 else 1.0
-
-    event_counts: dict[str, int] = {}
-    peer_counts: dict[str, int] = {}
-    audit_path = settings.repo_root / "logs" / "api_audit.jsonl"
-    if audit_path.exists():
-        for line in audit_path.read_text(encoding="utf-8", errors="ignore").splitlines()[-10000:]:
-            try:
-                item = json.loads(line)
-            except Exception:
-                continue
-            ev = str(item.get("event") or "unknown")
-            event_counts[ev] = event_counts.get(ev, 0) + 1
-            peer = str(item.get("peer_id") or "unknown")
-            peer_counts[peer] = peer_counts.get(peer, 0) + 1
-
-    check_artifacts = load_check_artifacts(settings.repo_root)
-    check_summary: dict[str, int] = {}
-    for row in check_artifacts:
-        profile = str(row.get("profile") or "unknown")
-        status = str(row.get("status") or "unknown")
-        key = f"{profile}:{status}"
-        check_summary[key] = check_summary.get(key, 0) + 1
-
-    replication_state = _load_replication_state(settings.repo_root)
-
-    rate_state = _load_rate_limit_state(settings.repo_root)
-    verification_failures_recent = 0
-    fail_cutoff = now - timedelta(seconds=int(settings.verify_failure_window_seconds))
-    for row in rate_state.get("verification_failures", []):
-        if not isinstance(row, dict):
-            continue
-        at = _parse_iso(row.get("at"))
-        if at is not None and at >= fail_cutoff:
-            verification_failures_recent += 1
-
-    alarms: list[dict[str, Any]] = []
-    backlog_depth = delivery_summary.get("pending_ack", 0)
-    if backlog_depth > int(settings.backlog_alarm_threshold):
-        alarms.append(
-            {
-                "type": "delivery_backlog_growth",
-                "severity": "warning",
-                "message": f"Pending backlog depth {backlog_depth} exceeds threshold {settings.backlog_alarm_threshold}",
-                "metric": "delivery.backlog_depth",
-            }
-        )
-
-    if verification_failures_recent > int(settings.verification_alarm_threshold):
-        alarms.append(
-            {
-                "type": "verification_failures",
-                "severity": "warning",
-                "message": (
-                    f"Verification failures in last {settings.verify_failure_window_seconds}s: "
-                    f"{verification_failures_recent} (threshold {settings.verification_alarm_threshold})"
-                ),
-                "metric": "security.verification_failures_recent",
-            }
-        )
-
-    drift_threshold = int(settings.replication_drift_max_age_seconds)
-    last_push = replication_state.get("last_push")
-    if isinstance(last_push, dict):
-        pushed_at = _parse_iso(last_push.get("pushed_at"))
-        if pushed_at is not None and (now - pushed_at).total_seconds() > drift_threshold:
-            alarms.append(
-                {
-                    "type": "replication_drift",
-                    "severity": "warning",
-                    "message": f"Last replication push is stale (> {drift_threshold}s)",
-                    "metric": "replication.last_push",
-                }
-            )
-
-    pulls = replication_state.get("last_pull_by_source", {})
-    if isinstance(pulls, dict):
-        for source, row in pulls.items():
-            if not isinstance(row, dict):
-                continue
-            pulled_at = _parse_iso(row.get("pulled_at"))
-            if pulled_at is not None and (now - pulled_at).total_seconds() > drift_threshold:
-                alarms.append(
-                    {
-                        "type": "replication_drift",
-                        "severity": "warning",
-                        "message": f"Replication pull from {source} is stale (> {drift_threshold}s)",
-                        "metric": "replication.last_pull_by_source",
-                        "source_peer": source,
-                    }
-                )
-
-    return {
-        "ok": True,
-        "generated_at": now.isoformat(),
-        "delivery": {
-            "summary": delivery_summary,
-            "backlog_depth": backlog_depth,
-            "ack_success_ratio": round(ack_success_ratio, 4),
-            "by_recipient": by_recipient,
-        },
-        "checks": {"summary": check_summary, "artifact_count": len(check_artifacts)},
-        "audit": {"event_counts": event_counts, "peer_counts": peer_counts},
-        "security": {
-            "verification_failures_recent": verification_failures_recent,
-            "verification_failure_window_seconds": int(settings.verify_failure_window_seconds),
-        },
-        "replication": {
-            "last_push": replication_state.get("last_push"),
-            "last_pull_by_source": replication_state.get("last_pull_by_source", {}),
-        },
-        "alarms": alarms,
-    }
+    return metrics_service(
+        settings=settings,
+        auth=auth,
+        load_delivery_state=load_delivery_state,
+        delivery_record_view=lambda row, now: delivery_record_view(row, now, parse_iso=_parse_iso),
+        load_check_artifacts=load_check_artifacts,
+        load_rate_limit_state=_load_rate_limit_state,
+        parse_iso=_parse_iso,
+    )
 
 
 @app.post("/v1/replay/messages")
@@ -1509,454 +1268,62 @@ def replay_messages(req: MessageReplayRequest, auth: AuthContext = Depends(requi
 @app.post("/v1/replication/pull")
 def replication_pull(req: ReplicationPullRequest, auth: AuthContext = Depends(require_auth)) -> dict:
     settings, gm = _services()
-    _enforce_rate_limit(settings, auth, "replication_pull")
-    _enforce_payload_limit(settings, req.model_dump(), "replication_pull")
-    auth.require("admin:peers")
-
-    state = _load_replication_state(settings.repo_root)
-    idempotency_key = (req.idempotency_key or "").strip() or None
-    idem_ref = f"{req.source_peer}|{idempotency_key}" if idempotency_key else None
-    if idem_ref:
-        previous = state.get("pull_idempotency", {}).get(idem_ref)
-        if isinstance(previous, dict):
-            return {
-                "ok": True,
-                "idempotent_replay": True,
-                "source_peer": req.source_peer,
-                "received_count": int(previous.get("received_count") or 0),
-                "changed_count": int(previous.get("changed_count") or 0),
-                "deleted_count": int(previous.get("deleted_count") or 0),
-                "conflict_count": int(previous.get("conflict_count") or 0),
-                "skipped_count": int(previous.get("skipped_count") or 0),
-                "committed_files": [],
-                "latest_commit": gm.latest_commit(),
-            }
-
-    committed_files: list[str] = []
-    changed = 0
-    deleted = 0
-    skipped = 0
-    conflicts = 0
-    tombstones = _load_replication_tombstones(settings.repo_root)
-    tomb_entries = tombstones.setdefault("entries", {})
-    if not isinstance(tomb_entries, dict):
-        tomb_entries = {}
-        tombstones["entries"] = tomb_entries
-
-    now = datetime.now(timezone.utc)
-    for file_row in req.files:
-        top = Path(file_row.path).parts[0] if Path(file_row.path).parts else ""
-        if top not in REPLICATION_ALLOWED_PREFIXES:
-            raise HTTPException(status_code=400, detail=f"Replication path namespace not allowed: {file_row.path}")
-        auth.require_write_path(file_row.path)
-
-        p = safe_path(settings.repo_root, file_row.path)
-        local_exists = p.exists() and p.is_file()
-        local_content = read_text_file(p) if local_exists else None
-        local_epoch = p.stat().st_mtime if local_exists else 0.0
-        remote_epoch = _parse_dt_or_epoch(file_row.modified_at, now.timestamp())
-
-        if file_row.deleted:
-            if req.conflict_policy == "target_wins" and local_exists:
-                conflicts += 1
-                skipped += 1
-                continue
-            if req.conflict_policy == "error" and local_exists:
-                raise HTTPException(status_code=409, detail=f"Replication conflict on delete: {file_row.path}")
-
-            if local_exists:
-                try:
-                    p.unlink()
-                    deleted += 1
-                    changed += 1
-                except Exception as e:
-                    raise HTTPException(status_code=500, detail=f"Failed to delete replicated path {file_row.path}: {e}") from e
-            else:
-                skipped += 1
-
-            tomb_entries[file_row.path] = {
-                "tombstone_at": file_row.tombstone_at or now.isoformat(),
-                "source_peer": req.source_peer,
-                "idempotency_key": idempotency_key,
-            }
-            continue
-
-        if file_row.content is None or file_row.sha256 is None:
-            raise HTTPException(status_code=400, detail=f"Replication file payload requires content+sha256 for upsert: {file_row.path}")
-        if _sha256_text(file_row.content) != file_row.sha256:
-            raise HTTPException(status_code=400, detail=f"Replication sha256 mismatch for {file_row.path}")
-
-        if req.mode == "upsert" and local_exists and local_content == file_row.content:
-            skipped += 1
-            continue
-
-        should_write = True
-        if local_exists and local_content != file_row.content:
-            if req.conflict_policy == "target_wins":
-                should_write = False
-                conflicts += 1
-            elif req.conflict_policy == "error":
-                raise HTTPException(status_code=409, detail=f"Replication conflict on path: {file_row.path}")
-            elif req.conflict_policy == "last_write_wins" and remote_epoch < local_epoch:
-                should_write = False
-                conflicts += 1
-
-        if not should_write:
-            skipped += 1
-            continue
-
-        write_text_file(p, file_row.content)
-        changed += 1
-        tomb_entries.pop(file_row.path, None)
-        msg = req.commit_message or f"replication: pull {req.source_peer} {file_row.path}"
-        if gm.commit_file(p, msg):
-            committed_files.append(file_row.path)
-
-    tomb_path = _write_replication_tombstones(settings.repo_root, tombstones)
-    if gm.commit_file(tomb_path, f"replication: update tombstones {req.source_peer}"):
-        committed_files.append(REPLICATION_TOMBSTONES_REL)
-
-    state.setdefault("last_pull_by_source", {})[req.source_peer] = {
-        "pulled_at": now.isoformat(),
-        "received_count": len(req.files),
-        "changed_count": changed,
-        "deleted_count": deleted,
-        "conflict_count": conflicts,
-        "mode": req.mode,
-        "conflict_policy": req.conflict_policy,
-        "idempotency_key": idempotency_key,
-    }
-    if idem_ref:
-        pull_map = state.setdefault("pull_idempotency", {})
-        if not isinstance(pull_map, dict):
-            pull_map = {}
-            state["pull_idempotency"] = pull_map
-        pull_map[idem_ref] = {
-            "at": now.isoformat(),
-            "received_count": len(req.files),
-            "changed_count": changed,
-            "deleted_count": deleted,
-            "conflict_count": conflicts,
-            "skipped_count": skipped,
-        }
-
-    state_path = _write_replication_state(settings.repo_root, state)
-    if gm.commit_file(state_path, f"replication: update pull state {req.source_peer}"):
-        committed_files.append(REPLICATION_STATE_REL)
-
-    _audit(
-        settings,
-        auth,
-        "replication_pull",
-        {
-            "source_peer": req.source_peer,
-            "received": len(req.files),
-            "changed": changed,
-            "deleted": deleted,
-            "conflicts": conflicts,
-            "mode": req.mode,
-            "conflict_policy": req.conflict_policy,
-            "idempotency_key": idempotency_key,
-        },
+    return replication_pull_service(
+        settings=settings,
+        gm=gm,
+        auth=auth,
+        req=req,
+        enforce_rate_limit=_enforce_rate_limit,
+        enforce_payload_limit=_enforce_payload_limit,
+        parse_iso=_parse_iso,
+        audit=lambda auth_ctx, event, detail: _audit(settings, auth_ctx, event, detail),
     )
-    return {
-        "ok": True,
-        "idempotent_replay": False,
-        "source_peer": req.source_peer,
-        "received_count": len(req.files),
-        "changed_count": changed,
-        "deleted_count": deleted,
-        "conflict_count": conflicts,
-        "skipped_count": skipped,
-        "committed_files": committed_files,
-        "latest_commit": gm.latest_commit(),
-    }
 
 
 @app.post("/v1/replication/push")
 def replication_push(req: ReplicationPushRequest, auth: AuthContext = Depends(require_auth)) -> dict:
     settings, gm = _services()
-    _enforce_rate_limit(settings, auth, "replication_push")
-    auth.require("admin:peers")
-
-    files = _iter_replication_files(
-        settings.repo_root,
-        req.include_prefixes,
-        req.max_files,
-        include_deleted=req.include_deleted,
+    return replication_push_service(
+        settings=settings,
+        gm=gm,
+        auth=auth,
+        req=req,
+        enforce_rate_limit=_enforce_rate_limit,
+        enforce_payload_limit=_enforce_payload_limit,
+        load_peers_registry=load_peers_registry,
+        urlopen_fn=urlopen,
+        url_request_factory=UrlRequest,
+        audit=lambda auth_ctx, event, detail: _audit(settings, auth_ctx, event, detail),
     )
-    for row in files:
-        auth.require_read_path(str(row.get("path", "")))
-
-    by_prefix: dict[str, int] = {}
-    for row in files:
-        top = Path(str(row["path"])).parts[0] if Path(str(row["path"])).parts else ""
-        by_prefix[top] = by_prefix.get(top, 0) + 1
-
-    target_base = req.base_url
-    if not target_base and req.peer_id:
-        registry = load_peers_registry(settings.repo_root)
-        peer = registry.get("peers", {}).get(req.peer_id)
-        if isinstance(peer, dict):
-            target_base = str(peer.get("base_url") or "").strip() or None
-
-    push_id_source = req.idempotency_key or _canonical_json(
-        {
-            "peer": auth.peer_id,
-            "target": target_base,
-            "path": req.target_path,
-            "policy": req.conflict_policy,
-            "files": [{"path": f.get("path"), "sha256": f.get("sha256"), "deleted": bool(f.get("deleted"))} for f in files],
-        }
-    )
-    push_id = "push_" + hashlib.sha256(push_id_source.encode("utf-8")).hexdigest()[:24]
-
-    if req.dry_run or not target_base:
-        return {
-            "ok": True,
-            "dry_run": True,
-            "idempotency_key": push_id,
-            "file_count": len(files),
-            "by_prefix": by_prefix,
-            "target_base_url": target_base,
-            "target_path": req.target_path,
-            "sample_paths": [row["path"] for row in files[:20]],
-            "include_deleted": req.include_deleted,
-            "conflict_policy": req.conflict_policy,
-        }
-
-    target_url = urljoin(target_base.rstrip("/") + "/", req.target_path.lstrip("/"))
-    request_payload = {
-        "source_peer": auth.peer_id,
-        "files": files,
-        "mode": "upsert",
-        "conflict_policy": req.conflict_policy,
-        "idempotency_key": push_id,
-    }
-    _enforce_payload_limit(settings, request_payload, "replication_push")
-
-    body = _canonical_json(request_payload).encode("utf-8")
-    headers = {"Content-Type": "application/json", "Accept": "application/json"}
-    if req.target_token:
-        headers["Authorization"] = f"Bearer {req.target_token}"
-    try:
-        with urlopen(UrlRequest(target_url, data=body, headers=headers, method="POST"), timeout=30) as resp:
-            raw = resp.read().decode("utf-8", errors="ignore")
-            remote_payload = json.loads(raw) if raw else {"ok": True}
-    except HTTPException:
-        raise
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Failed replication push: {e}") from e
-
-    auth.require_write_path(REPLICATION_STATE_REL)
-    state = _load_replication_state(settings.repo_root)
-    state["last_push"] = {
-        "pushed_at": datetime.now(timezone.utc).isoformat(),
-        "target_url": target_url,
-        "file_count": len(files),
-        "by_prefix": by_prefix,
-        "idempotency_key": push_id,
-        "conflict_policy": req.conflict_policy,
-        "include_deleted": req.include_deleted,
-    }
-    committed_files = []
-    state_path = _write_replication_state(settings.repo_root, state)
-    if gm.commit_file(state_path, "replication: update push state"):
-        committed_files.append(REPLICATION_STATE_REL)
-
-    _audit(
-        settings,
-        auth,
-        "replication_push",
-        {
-            "target_url": target_url,
-            "file_count": len(files),
-            "idempotency_key": push_id,
-            "conflict_policy": req.conflict_policy,
-            "include_deleted": req.include_deleted,
-        },
-    )
-    return {
-        "ok": True,
-        "dry_run": False,
-        "idempotency_key": push_id,
-        "target_url": target_url,
-        "file_count": len(files),
-        "by_prefix": by_prefix,
-        "remote": remote_payload,
-        "committed_files": committed_files,
-        "latest_commit": gm.latest_commit(),
-    }
 
 
 
 @app.post("/v1/backup/create")
 def backup_create(req: BackupCreateRequest, auth: AuthContext = Depends(require_auth)) -> dict:
     settings, gm = _services()
-    _enforce_rate_limit(settings, auth, "backup_create")
-    _enforce_payload_limit(settings, req.model_dump(), "backup_create")
-    auth.require("admin:peers")
-
-    allowed = set(REPLICATION_ALLOWED_PREFIXES) | {"config", "logs", "peers"}
-    include = []
-    for raw in req.include_prefixes:
-        rel = str(raw or "").strip().strip("/")
-        if not rel:
-            continue
-        top = Path(rel).parts[0] if Path(rel).parts else ""
-        if top in allowed:
-            include.append(rel)
-    if not include:
-        include = ["memory", "messages", "tasks", "patches", "runs", "projects", "essays", "journal", "snapshots", "peers", "config", "logs"]
-
-    now = datetime.now(timezone.utc)
-    backup_id = f"backup_{now.strftime('%Y%m%dT%H%M%SZ')}_{uuid4().hex[:8]}"
-    backup_rel = f"{BACKUPS_DIR_REL}/{backup_id}.tar.gz"
-    manifest_rel = f"{BACKUPS_DIR_REL}/{backup_id}.json"
-    backup_path = safe_path(settings.repo_root, backup_rel)
-    manifest_path = safe_path(settings.repo_root, manifest_rel)
-    backup_path.parent.mkdir(parents=True, exist_ok=True)
-
-    included_paths: list[str] = []
-    with tarfile.open(backup_path, mode="w:gz") as tf:
-        for prefix in include:
-            p = safe_path(settings.repo_root, prefix)
-            if not p.exists():
-                continue
-            tf.add(p, arcname=prefix)
-            included_paths.append(prefix)
-
-    manifest_payload = {
-        "schema_version": "1.0",
-        "backup_id": backup_id,
-        "created_at": now.isoformat(),
-        "created_by": auth.peer_id,
-        "include_prefixes": included_paths,
-        "note": req.note,
-        "contract_version": settings.contract_version,
-    }
-    write_text_file(manifest_path, json.dumps(manifest_payload, ensure_ascii=False, indent=2))
-
-    committed_files = []
-    if gm.commit_file(backup_path, f"backup: create {backup_id}"):
-        committed_files.append(backup_rel)
-    if gm.commit_file(manifest_path, f"backup: manifest {backup_id}"):
-        committed_files.append(manifest_rel)
-
-    _audit(settings, auth, "backup_create", {"backup_id": backup_id, "include_prefixes": included_paths})
-    return {
-        "ok": True,
-        "backup_id": backup_id,
-        "backup_path": backup_rel,
-        "manifest_path": manifest_rel,
-        "committed_files": committed_files,
-        "latest_commit": gm.latest_commit(),
-    }
+    return backup_create_service(
+        settings=settings,
+        gm=gm,
+        auth=auth,
+        req=req,
+        enforce_rate_limit=_enforce_rate_limit,
+        enforce_payload_limit=_enforce_payload_limit,
+        audit=lambda auth_ctx, event, detail: _audit(settings, auth_ctx, event, detail),
+    )
 
 
 @app.post("/v1/backup/restore-test")
 def backup_restore_test(req: BackupRestoreTestRequest, auth: AuthContext = Depends(require_auth)) -> dict:
     settings, _ = _services()
-    _enforce_rate_limit(settings, auth, "backup_restore_test")
-    _enforce_payload_limit(settings, req.model_dump(), "backup_restore_test")
-    auth.require("admin:peers")
-
-    rel = str(req.backup_path or "").strip()
-    if not rel:
-        raise HTTPException(status_code=400, detail="backup_path is required")
-    if Path(rel).is_absolute():
-        raise HTTPException(status_code=400, detail="backup_path must be repo-relative")
-    if not rel.startswith(f"{BACKUPS_DIR_REL}/"):
-        raise HTTPException(status_code=400, detail="backup_path must be under backups/")
-
-    backup_path = safe_path(settings.repo_root, rel)
-    if not backup_path.exists() or not backup_path.is_file():
-        raise HTTPException(status_code=404, detail="Backup file not found")
-
-    extracted_files = 0
-    extracted_prefixes: set[str] = set()
-    with tempfile.TemporaryDirectory() as td:
-        restore_root = Path(td) / "restore"
-        restore_root.mkdir(parents=True, exist_ok=True)
-        try:
-            with tarfile.open(backup_path, mode="r:gz") as tf:
-                members = tf.getmembers()
-                restore_root_resolved = restore_root.resolve()
-                for m in members:
-                    if m.issym() or m.islnk():
-                        raise HTTPException(status_code=400, detail=f"Invalid backup archive: symbolic links are not allowed ({m.name})")
-                    target = (restore_root / m.name).resolve()
-                    if target != restore_root_resolved and restore_root_resolved not in target.parents:
-                        raise HTTPException(status_code=400, detail=f"Invalid backup archive: unsafe path ({m.name})")
-                tf.extractall(path=restore_root, filter="data")
-        except HTTPException:
-            raise
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=f"Invalid backup archive: {e}") from e
-
-        for m in members:
-            if not m.isfile():
-                continue
-            extracted_files += 1
-            top = Path(m.name).parts[0] if Path(m.name).parts else ""
-            if top:
-                extracted_prefixes.add(top)
-
-        index_validation = None
-        if req.verify_index_rebuild:
-            try:
-                payload = rebuild_index(restore_root)
-                index_validation = {"ok": True, "file_count": int(payload.get("file_count") or 0)}
-            except Exception as e:
-                index_validation = {"ok": False, "error": str(e)}
-
-    ok = extracted_files > 0 and (index_validation is None or bool(index_validation.get("ok")))
-    _audit(settings, auth, "backup_restore_test", {"backup_path": rel, "ok": ok, "extracted_files": extracted_files})
-    return {
-        "ok": ok,
-        "backup_path": rel,
-        "extracted_files": extracted_files,
-        "extracted_prefixes": sorted(extracted_prefixes),
-        "index_validation": index_validation,
-    }
-
-
-def _load_access_stats(repo_root: Path) -> dict[str, dict]:
-    """Very small access stats from audit log for compaction heuristics."""
-    out: dict[str, dict] = {}
-    p = repo_root / "logs" / "api_audit.jsonl"
-    if not p.exists():
-        return out
-    now = datetime.now(timezone.utc)
-    for line in p.read_text(encoding="utf-8", errors="ignore").splitlines()[-5000:]:
-        try:
-            row = json.loads(line)
-        except Exception:
-            continue
-        if row.get("event") not in {"read", "messages_inbox", "search", "context_retrieve"}:
-            continue
-        detail = row.get("detail") or {}
-        path = detail.get("path")
-        if not path:
-            continue
-        stat = out.setdefault(path, {"access_count": 0, "last_access_at": None})
-        stat["access_count"] += 1
-        ts = row.get("ts")
-        if ts and (stat["last_access_at"] is None or ts > stat["last_access_at"]):
-            stat["last_access_at"] = ts
-    return out
-
-
-def _memory_class_for_path(rel: str) -> str:
-    if rel.startswith("memory/core/"):
-        return "core"
-    if rel.startswith("memory/summaries/") or rel.startswith("messages/threads/") or rel.startswith("projects/"):
-        return "durable" if rel.startswith("memory/summaries/") else "working"
-    if rel.startswith("journal/") or rel.startswith("messages/inbox/") or rel.startswith("messages/outbox/") or rel.startswith("logs/"):
-        return "ephemeral"
-    if rel.startswith("memory/episodic/"):
-        return "ephemeral"
-    return "working"
+    return backup_restore_test_service(
+        settings=settings,
+        auth=auth,
+        req=req,
+        enforce_rate_limit=_enforce_rate_limit,
+        enforce_payload_limit=_enforce_payload_limit,
+        rebuild_index=rebuild_index,
+        audit=lambda auth_ctx, event, detail: _audit(settings, auth_ctx, event, detail),
+    )
 
 
 def _parse_iso(sv: str | None):
@@ -1968,247 +1335,17 @@ def _parse_iso(sv: str | None):
         return None
 
 
-def _candidate_policy(repo_root: Path, path: Path, access_stats: dict[str, dict]) -> dict | None:
-    rel = str(path.relative_to(repo_root))
-    if rel.startswith("index/") or ".git" in path.parts:
-        return None
-    try:
-        st = path.stat()
-    except Exception:
-        return None
-    now = datetime.now(timezone.utc)
-    age_days = max(0.0, (now - datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)).total_seconds() / 86400.0)
-    size_bytes = int(st.st_size)
-    ns = Path(rel).parts[0] if Path(rel).parts else ""
-    mem_class = _memory_class_for_path(rel)
-    importance = 0.0
-    snippet = ""
-    text = ""
-    if path.suffix.lower() in {".md", ".json", ".jsonl", ".txt"}:
-        try:
-            text = path.read_text(encoding="utf-8", errors="ignore")
-            snippet = " ".join(text.split())[:240]
-        except Exception:
-            text = ""
-        if path.suffix.lower() == ".md":
-            m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
-            if m:
-                for line in m.group(1).splitlines():
-                    if line.strip().startswith("importance:"):
-                        try:
-                            importance = float(line.split(":",1)[1].strip())
-                        except Exception:
-                            pass
-    a = access_stats.get(rel, {})
-    access_count = int(a.get("access_count") or 0)
-    last_access_dt = _parse_iso(a.get("last_access_at"))
-    last_access_days = 9999.0 if not last_access_dt else max(0.0, (now - last_access_dt).total_seconds() / 86400.0)
-
-    type_weight = {"ephemeral": 1.0, "working": 0.35, "durable": 0.12, "core": -5.0}.get(mem_class, 0.2)
-    age_pressure = min(1.5, age_days / 14.0)
-    size_pressure = min(1.0, math.log10(max(10, size_bytes)) / 8.0)
-    recency_relief = 0.9 if last_access_days < 3 else (0.35 if last_access_days < 14 else 0.0)
-    frequency_relief = min(1.0, access_count / 12.0) * 0.75
-    importance_relief = min(1.0, max(0.0, importance)) * 1.2
-    active_link_relief = 0.6 if rel.startswith("messages/threads/") or rel.startswith("projects/") else 0.0
-
-    candidate_score = round(type_weight + age_pressure + size_pressure - recency_relief - frequency_relief - importance_relief - active_link_relief, 4)
-
-    promote_signals = []
-    low = (text or "").lower()
-    for kw in ["identity", "relationship", "trusted", "values", "preference", "decision"]:
-        if kw in low:
-            promote_signals.append(kw)
-    if access_count >= 5:
-        promote_signals.append("reused")
-    if importance >= 0.7:
-        promote_signals.append("high_importance")
-    if mem_class in {"core"}:
-        promote_signals.append("core_namespace")
-
-    return {
-        "path": rel,
-        "namespace": ns,
-        "memory_class": mem_class,
-        "age_days": round(age_days, 2),
-        "size_bytes": size_bytes,
-        "importance": importance if importance else None,
-        "access_count": access_count,
-        "last_access_days": None if last_access_days >= 9999 else round(last_access_days, 2),
-        "candidate_score": candidate_score,
-        "promote_signals": sorted(set(promote_signals)),
-        "snippet": snippet,
-    }
-
-
 @app.post("/v1/compact/run")
 def compact_run(req: CompactRequest, auth: AuthContext = Depends(require_auth)) -> dict:
     settings, gm = _services()
-    auth.require("compact:trigger")
-    auth.require_write_path("memory/summaries/weekly/x.md")
-
-    now = datetime.now(timezone.utc)
-    report_id = f"compact_{now.strftime('%Y%m%dT%H%M%SZ')}"
-    source_rel = req.source_path or "(policy-scan)"
-
-    access_stats = _load_access_stats(settings.repo_root)
-    candidates = []
-    for p in settings.repo_root.rglob("*"):
-        if not p.is_file():
-            continue
-        if p.suffix.lower() not in {".md", ".json", ".jsonl", ".txt"}:
-            continue
-        c = _candidate_policy(settings.repo_root, p, access_stats)
-        if c:
-            candidates.append(c)
-
-    # class-aware categorization (compaction is not deletion; this only proposes actions)
-    summarize_now = []
-    archive_after_summary = []
-    promote_to_core_candidates = []
-    keep_hot = []
-    review_manually = []
-
-    for c in sorted(candidates, key=lambda x: (-float(x["candidate_score"]), x["path"])):
-        cls = c["memory_class"]
-        score = float(c["candidate_score"])
-        if cls == "core":
-            keep_hot.append(c)
-            continue
-        if c.get("promote_signals") and cls in {"working", "durable"}:
-            promote_to_core_candidates.append(c)
-            if score > 0.4:
-                summarize_now.append(c)
-            else:
-                keep_hot.append(c)
-            continue
-        if cls == "ephemeral":
-            if score >= 0.4:
-                summarize_now.append(c)
-                if score >= 0.9:
-                    archive_after_summary.append(c)
-            else:
-                keep_hot.append(c)
-        elif cls == "working":
-            if score >= 0.8:
-                summarize_now.append(c)
-            elif score >= 0.4:
-                review_manually.append(c)
-            else:
-                keep_hot.append(c)
-        elif cls == "durable":
-            if score >= 1.0:
-                review_manually.append(c)
-            else:
-                keep_hot.append(c)
-        else:
-            review_manually.append(c)
-
-    summary_paths = [x["path"] for x in summarize_now[:20]]
-    promote_paths = [x["path"] for x in promote_to_core_candidates[:10]]
-    archive_paths = [x["path"] for x in archive_after_summary[:20]]
-    keep_hot_paths = [x["path"] for x in keep_hot[:20]]
-
-    report_md_rel = f"memory/summaries/weekly/{report_id}.md"
-    report_json_rel = f"memory/summaries/weekly/{report_id}.json"
-    report_path = safe_path(settings.repo_root, report_md_rel)
-    report_json_path = safe_path(settings.repo_root, report_json_rel)
-    body = f"""---
-id: {report_id}
-type: compaction_report
-created_at: {now.isoformat()}
-source: {source_rel}
----
-
-# Compaction Report
-
-This endpoint is an **orchestrator/planner**, not an LLM summarizer. It proposes candidates and categories.
-
-## Policy (class-aware decay + promotion)
-- Inputs: age, size, namespace/class, declared importance, access count, access recency
-- Classes: ephemeral / working / durable / core
-- Core is kept hot; durable is rarely compacted; ephemeral decays fastest
-- Promotion candidates can *increase* in importance over time (identity/relationship/decision facts)
-
-## Summary counts
-- Candidates scanned: {len(candidates)}
-- summarize_now: {len(summarize_now)}
-- archive_after_summary: {len(archive_after_summary)}
-- promote_to_core_candidates: {len(promote_to_core_candidates)}
-- keep_hot: {len(keep_hot)}
-- review_manually: {len(review_manually)}
-
-## Summarize now (top)
-{chr(10).join(f"- `{p}`" for p in summary_paths) if summary_paths else "- None"}
-
-## Promote to core candidates (top)
-{chr(10).join(f"- `{p}`" for p in promote_paths) if promote_paths else "- None"}
-
-## Archive after summary (top)
-{chr(10).join(f"- `{p}`" for p in archive_paths) if archive_paths else "- None"}
-
-## Keep hot (sample)
-{chr(10).join(f"- `{p}`" for p in keep_hot_paths) if keep_hot_paths else "- None"}
-
-## Operator note
-{req.note or 'N/A'}
-"""
-
-    payload = {
-        "id": report_id,
-        "type": "compaction_report",
-        "created_at": now.isoformat(),
-        "source": source_rel,
-        "planner_only": True,
-        "compaction_semantics": {
-            "summarizes_content": False,
-            "expected_ai_action": "Read candidate lists, generate summaries, then POST /v1/write or /v1/append",
-        },
-        "indexing_note": {
-            "incremental_index_default": "working_tree",
-            "can_include_uncommitted_changes": True,
-            "future_mode": ["working_tree", "head_commit"],
-        },
-        "policy": {
-            "inputs": ["age_days", "size_bytes", "memory_class", "importance", "access_count", "last_access_days"],
-            "classes": ["ephemeral", "working", "durable", "core"],
-            "decay": {
-                "ephemeral": "fast",
-                "working": "slow-while-active, faster-after-inactive",
-                "durable": "very_slow",
-                "core": "no_age_decay_retrieval_only",
-            },
-            "promotion_principle": "some memories gain importance over time via reuse/identity/relationship signals",
-        },
-        "summary_counts": {
-            "candidates_scanned": len(candidates),
-            "summarize_now": len(summarize_now),
-            "archive_after_summary": len(archive_after_summary),
-            "promote_to_core_candidates": len(promote_to_core_candidates),
-            "keep_hot": len(keep_hot),
-            "review_manually": len(review_manually),
-        },
-        "actions": {
-            "summarize_now": summarize_now[:20],
-            "archive_after_summary": archive_after_summary[:20],
-            "promote_to_core_candidates": promote_to_core_candidates[:15],
-            "keep_hot": keep_hot[:20],
-            "review_manually": review_manually[:20],
-        },
-        "operator_note": req.note,
-    }
-
-    write_text_file(report_path, body)
-    write_text_file(report_json_path, json.dumps(payload, ensure_ascii=False, indent=2))
-
-    committed = []
-    for rel in [report_md_rel, report_json_rel]:
-        p = safe_path(settings.repo_root, rel)
-        if gm.commit_file(p, f"memory: add compaction {report_id}"):
-            committed.append(rel)
-
-    _audit(settings, auth, "compact_run", {"report_id": report_id, "source": source_rel, "candidates": len(candidates)})
-    return {"ok": True, "report_id": report_id, "paths": [report_md_rel, report_json_rel], "committed_files": committed, "latest_commit": gm.latest_commit(), "planner_only": True, "summary_counts": payload["summary_counts"]}
+    return compact_run_service(
+        settings=settings,
+        gm=gm,
+        auth=auth,
+        req=req,
+        parse_iso=_parse_iso,
+        audit=lambda auth_ctx, event, detail: _audit(settings, auth_ctx, event, detail),
+    )
 
 
 @app.exception_handler(Exception)

--- a/app/maintenance/__init__.py
+++ b/app/maintenance/__init__.py
@@ -1,0 +1,29 @@
+from .service import (
+    BACKUPS_DIR_REL,
+    REPLICATION_ALLOWED_PREFIXES,
+    REPLICATION_STATE_REL,
+    REPLICATION_TOMBSTONES_REL,
+    backup_create_service,
+    backup_restore_test_service,
+    compact_run_service,
+    iter_replication_files,
+    load_replication_state,
+    metrics_service,
+    replication_pull_service,
+    replication_push_service,
+)
+
+__all__ = [
+    "BACKUPS_DIR_REL",
+    "REPLICATION_ALLOWED_PREFIXES",
+    "REPLICATION_STATE_REL",
+    "REPLICATION_TOMBSTONES_REL",
+    "backup_create_service",
+    "backup_restore_test_service",
+    "compact_run_service",
+    "iter_replication_files",
+    "load_replication_state",
+    "metrics_service",
+    "replication_pull_service",
+    "replication_push_service",
+]

--- a/app/maintenance/service.py
+++ b/app/maintenance/service.py
@@ -1,0 +1,1035 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import tarfile
+import tempfile
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urljoin
+from urllib.request import Request as UrlRequest, urlopen
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+from app.auth import AuthContext
+from app.models import BackupCreateRequest, BackupRestoreTestRequest, CompactRequest, ReplicationPullRequest, ReplicationPushRequest
+from app.storage import read_text_file, safe_path, write_text_file
+
+REPLICATION_STATE_REL = "peers/replication_state.json"
+REPLICATION_ALLOWED_PREFIXES = {"journal", "essays", "projects", "memory", "messages", "tasks", "patches", "runs", "snapshots", "archive"}
+REPLICATION_TOMBSTONES_REL = "peers/replication_tombstones.json"
+BACKUPS_DIR_REL = "backups"
+
+
+def _load_replication_tombstones(repo_root: Path) -> dict[str, Any]:
+    path = safe_path(repo_root, REPLICATION_TOMBSTONES_REL)
+    if not path.exists():
+        return {"schema_version": "1.0", "entries": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"schema_version": "1.0", "entries": {}}
+    if not isinstance(data, dict):
+        return {"schema_version": "1.0", "entries": {}}
+    entries = data.get("entries")
+    if not isinstance(entries, dict):
+        entries = {}
+    return {"schema_version": "1.0", "entries": entries}
+
+
+def _write_replication_tombstones(repo_root: Path, payload: dict[str, Any]) -> Path:
+    path = safe_path(repo_root, REPLICATION_TOMBSTONES_REL)
+    write_text_file(path, json.dumps(payload, ensure_ascii=False, indent=2))
+    return path
+
+
+def _parse_dt_or_epoch(iso_value: str | None, fallback_epoch: float, *, parse_iso: Callable[[str | None], datetime | None]) -> float:
+    dt = parse_iso(iso_value)
+    if dt is None:
+        return fallback_epoch
+    return dt.timestamp()
+
+
+def load_replication_state(repo_root: Path) -> dict[str, Any]:
+    path = safe_path(repo_root, REPLICATION_STATE_REL)
+    if not path.exists():
+        return {"schema_version": "1.0", "last_pull_by_source": {}, "last_push": None, "pull_idempotency": {}}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {"schema_version": "1.0", "last_pull_by_source": {}, "last_push": None, "pull_idempotency": {}}
+    if not isinstance(data, dict):
+        return {"schema_version": "1.0", "last_pull_by_source": {}, "last_push": None, "pull_idempotency": {}}
+    if not isinstance(data.get("last_pull_by_source"), dict):
+        data["last_pull_by_source"] = {}
+    if not isinstance(data.get("pull_idempotency"), dict):
+        data["pull_idempotency"] = {}
+    return data
+
+
+def _write_replication_state(repo_root: Path, payload: dict[str, Any]) -> Path:
+    path = safe_path(repo_root, REPLICATION_STATE_REL)
+    write_text_file(path, json.dumps(payload, ensure_ascii=False, indent=2))
+    return path
+
+
+def _sha256_text(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def iter_replication_files(repo_root: Path, include_prefixes: list[str], max_files: int, include_deleted: bool = True) -> list[dict[str, Any]]:
+    prefixes = []
+    for raw in include_prefixes:
+        rel = str(raw or "").strip().strip("/")
+        if not rel:
+            continue
+        top = Path(rel).parts[0] if Path(rel).parts else ""
+        if top not in REPLICATION_ALLOWED_PREFIXES:
+            continue
+        prefixes.append(rel)
+    if not prefixes:
+        prefixes = ["memory", "messages", "projects", "essays", "journal", "tasks", "patches", "runs", "snapshots"]
+
+    items = []
+    for prefix in prefixes:
+        base = safe_path(repo_root, prefix)
+        if not base.exists():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file() or ".git" in path.parts:
+                continue
+            rel = str(path.relative_to(repo_root))
+            try:
+                content = path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            stat = path.stat()
+            items.append(
+                {
+                    "path": rel,
+                    "content": content,
+                    "sha256": _sha256_text(content),
+                    "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+                    "deleted": False,
+                    "tombstone_at": None,
+                }
+            )
+            if len(items) >= max_files:
+                return items
+
+    if include_deleted and len(items) < max_files:
+        tombstones = _load_replication_tombstones(repo_root)
+        entries = tombstones.get("entries", {})
+        if isinstance(entries, dict):
+            for path, row in sorted(entries.items(), key=lambda x: x[0]):
+                top = Path(str(path)).parts[0] if Path(str(path)).parts else ""
+                if top not in REPLICATION_ALLOWED_PREFIXES:
+                    continue
+                if prefixes and not any(str(path).startswith(f"{p}/") or str(path) == p for p in prefixes):
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                items.append(
+                    {
+                        "path": str(path),
+                        "content": None,
+                        "sha256": None,
+                        "modified_at": row.get("tombstone_at"),
+                        "deleted": True,
+                        "tombstone_at": row.get("tombstone_at"),
+                    }
+                )
+                if len(items) >= max_files:
+                    return items
+    return items
+
+
+def metrics_service(
+    *,
+    settings: Any,
+    auth: AuthContext,
+    load_delivery_state: Callable[[Path], dict[str, Any]],
+    delivery_record_view: Callable[[dict[str, Any], datetime], dict[str, Any]],
+    load_check_artifacts: Callable[[Path], list[dict[str, Any]]],
+    load_rate_limit_state: Callable[[Path], dict[str, Any]],
+    parse_iso: Callable[[str | None], datetime | None],
+) -> dict:
+    auth.require("read:index")
+    auth.require_read_path("messages/state/delivery_index.json")
+    auth.require_read_path("logs/api_audit.jsonl")
+    now = datetime.now(timezone.utc)
+
+    state = load_delivery_state(settings.repo_root)
+    delivery_summary: dict[str, int] = {}
+    by_recipient: dict[str, dict[str, int]] = {}
+    for row in state.get("records", {}).values():
+        if not isinstance(row, dict):
+            continue
+        view = delivery_record_view(row, now)
+        eff = str(view.get("effective_status") or "unknown")
+        delivery_summary[eff] = delivery_summary.get(eff, 0) + 1
+        recipient = str(view.get("to") or "unknown")
+        rec = by_recipient.setdefault(recipient, {"total": 0, "pending": 0, "acked": 0, "dead_letter": 0})
+        rec["total"] += 1
+        if eff == "pending_ack":
+            rec["pending"] += 1
+        elif eff == "acked":
+            rec["acked"] += 1
+        elif eff == "dead_letter":
+            rec["dead_letter"] += 1
+
+    acked = delivery_summary.get("acked", 0)
+    dead_letter = delivery_summary.get("dead_letter", 0)
+    ack_denom = acked + dead_letter
+    ack_success_ratio = (acked / ack_denom) if ack_denom > 0 else 1.0
+
+    event_counts: dict[str, int] = {}
+    peer_counts: dict[str, int] = {}
+    audit_path = settings.repo_root / "logs" / "api_audit.jsonl"
+    if audit_path.exists():
+        for line in audit_path.read_text(encoding="utf-8", errors="ignore").splitlines()[-10000:]:
+            try:
+                item = json.loads(line)
+            except Exception:
+                continue
+            ev = str(item.get("event") or "unknown")
+            event_counts[ev] = event_counts.get(ev, 0) + 1
+            peer = str(item.get("peer_id") or "unknown")
+            peer_counts[peer] = peer_counts.get(peer, 0) + 1
+
+    check_artifacts = load_check_artifacts(settings.repo_root)
+    check_summary: dict[str, int] = {}
+    for row in check_artifacts:
+        profile = str(row.get("profile") or "unknown")
+        status = str(row.get("status") or "unknown")
+        key = f"{profile}:{status}"
+        check_summary[key] = check_summary.get(key, 0) + 1
+
+    replication_state = load_replication_state(settings.repo_root)
+
+    rate_state = load_rate_limit_state(settings.repo_root)
+    verification_failures_recent = 0
+    fail_cutoff = now - timedelta(seconds=int(settings.verify_failure_window_seconds))
+    for row in rate_state.get("verification_failures", []):
+        if not isinstance(row, dict):
+            continue
+        at = parse_iso(row.get("at"))
+        if at is not None and at >= fail_cutoff:
+            verification_failures_recent += 1
+
+    alarms: list[dict[str, Any]] = []
+    backlog_depth = delivery_summary.get("pending_ack", 0)
+    if backlog_depth > int(settings.backlog_alarm_threshold):
+        alarms.append(
+            {
+                "type": "delivery_backlog_growth",
+                "severity": "warning",
+                "message": f"Pending backlog depth {backlog_depth} exceeds threshold {settings.backlog_alarm_threshold}",
+                "metric": "delivery.backlog_depth",
+            }
+        )
+
+    if verification_failures_recent > int(settings.verification_alarm_threshold):
+        alarms.append(
+            {
+                "type": "verification_failures",
+                "severity": "warning",
+                "message": (
+                    f"Verification failures in last {settings.verify_failure_window_seconds}s: "
+                    f"{verification_failures_recent} (threshold {settings.verification_alarm_threshold})"
+                ),
+                "metric": "security.verification_failures_recent",
+            }
+        )
+
+    drift_threshold = int(settings.replication_drift_max_age_seconds)
+    last_push = replication_state.get("last_push")
+    if isinstance(last_push, dict):
+        pushed_at = parse_iso(last_push.get("pushed_at"))
+        if pushed_at is not None and (now - pushed_at).total_seconds() > drift_threshold:
+            alarms.append(
+                {
+                    "type": "replication_drift",
+                    "severity": "warning",
+                    "message": f"Last replication push is stale (> {drift_threshold}s)",
+                    "metric": "replication.last_push",
+                }
+            )
+
+    pulls = replication_state.get("last_pull_by_source", {})
+    if isinstance(pulls, dict):
+        for source, row in pulls.items():
+            if not isinstance(row, dict):
+                continue
+            pulled_at = parse_iso(row.get("pulled_at"))
+            if pulled_at is not None and (now - pulled_at).total_seconds() > drift_threshold:
+                alarms.append(
+                    {
+                        "type": "replication_drift",
+                        "severity": "warning",
+                        "message": f"Replication pull from {source} is stale (> {drift_threshold}s)",
+                        "metric": "replication.last_pull_by_source",
+                        "source_peer": source,
+                    }
+                )
+
+    return {
+        "ok": True,
+        "generated_at": now.isoformat(),
+        "delivery": {
+            "summary": delivery_summary,
+            "backlog_depth": backlog_depth,
+            "ack_success_ratio": round(ack_success_ratio, 4),
+            "by_recipient": by_recipient,
+        },
+        "checks": {"summary": check_summary, "artifact_count": len(check_artifacts)},
+        "audit": {"event_counts": event_counts, "peer_counts": peer_counts},
+        "security": {
+            "verification_failures_recent": verification_failures_recent,
+            "verification_failure_window_seconds": int(settings.verify_failure_window_seconds),
+        },
+        "replication": {
+            "last_push": replication_state.get("last_push"),
+            "last_pull_by_source": replication_state.get("last_pull_by_source", {}),
+        },
+        "alarms": alarms,
+    }
+
+
+def replication_pull_service(
+    *,
+    settings: Any,
+    gm: Any,
+    auth: AuthContext,
+    req: ReplicationPullRequest,
+    enforce_rate_limit: Callable[[Any, AuthContext, str], None],
+    enforce_payload_limit: Callable[[Any, Any, str], None],
+    parse_iso: Callable[[str | None], datetime | None],
+    audit: Callable[[AuthContext, str, dict[str, Any]], None],
+) -> dict:
+    enforce_rate_limit(settings, auth, "replication_pull")
+    enforce_payload_limit(settings, req.model_dump(), "replication_pull")
+    auth.require("admin:peers")
+
+    state = load_replication_state(settings.repo_root)
+    idempotency_key = (req.idempotency_key or "").strip() or None
+    idem_ref = f"{req.source_peer}|{idempotency_key}" if idempotency_key else None
+    if idem_ref:
+        previous = state.get("pull_idempotency", {}).get(idem_ref)
+        if isinstance(previous, dict):
+            return {
+                "ok": True,
+                "idempotent_replay": True,
+                "source_peer": req.source_peer,
+                "received_count": int(previous.get("received_count") or 0),
+                "changed_count": int(previous.get("changed_count") or 0),
+                "deleted_count": int(previous.get("deleted_count") or 0),
+                "conflict_count": int(previous.get("conflict_count") or 0),
+                "skipped_count": int(previous.get("skipped_count") or 0),
+                "committed_files": [],
+                "latest_commit": gm.latest_commit(),
+            }
+
+    committed_files: list[str] = []
+    changed = 0
+    deleted = 0
+    skipped = 0
+    conflicts = 0
+    tombstones = _load_replication_tombstones(settings.repo_root)
+    tomb_entries = tombstones.setdefault("entries", {})
+    if not isinstance(tomb_entries, dict):
+        tomb_entries = {}
+        tombstones["entries"] = tomb_entries
+
+    now = datetime.now(timezone.utc)
+    for file_row in req.files:
+        top = Path(file_row.path).parts[0] if Path(file_row.path).parts else ""
+        if top not in REPLICATION_ALLOWED_PREFIXES:
+            raise HTTPException(status_code=400, detail=f"Replication path namespace not allowed: {file_row.path}")
+        auth.require_write_path(file_row.path)
+
+        path = safe_path(settings.repo_root, file_row.path)
+        local_exists = path.exists() and path.is_file()
+        local_content = read_text_file(path) if local_exists else None
+        local_epoch = path.stat().st_mtime if local_exists else 0.0
+        remote_epoch = _parse_dt_or_epoch(file_row.modified_at, now.timestamp(), parse_iso=parse_iso)
+
+        if file_row.deleted:
+            if req.conflict_policy == "target_wins" and local_exists:
+                conflicts += 1
+                skipped += 1
+                continue
+            if req.conflict_policy == "error" and local_exists:
+                raise HTTPException(status_code=409, detail=f"Replication conflict on delete: {file_row.path}")
+
+            if local_exists:
+                try:
+                    path.unlink()
+                    deleted += 1
+                    changed += 1
+                except Exception as e:
+                    raise HTTPException(status_code=500, detail=f"Failed to delete replicated path {file_row.path}: {e}") from e
+            else:
+                skipped += 1
+
+            tomb_entries[file_row.path] = {
+                "tombstone_at": file_row.tombstone_at or now.isoformat(),
+                "source_peer": req.source_peer,
+                "idempotency_key": idempotency_key,
+            }
+            continue
+
+        if file_row.content is None or file_row.sha256 is None:
+            raise HTTPException(status_code=400, detail=f"Replication file payload requires content+sha256 for upsert: {file_row.path}")
+        if _sha256_text(file_row.content) != file_row.sha256:
+            raise HTTPException(status_code=400, detail=f"Replication sha256 mismatch for {file_row.path}")
+
+        if req.mode == "upsert" and local_exists and local_content == file_row.content:
+            skipped += 1
+            continue
+
+        should_write = True
+        if local_exists and local_content != file_row.content:
+            if req.conflict_policy == "target_wins":
+                should_write = False
+                conflicts += 1
+            elif req.conflict_policy == "error":
+                raise HTTPException(status_code=409, detail=f"Replication conflict on path: {file_row.path}")
+            elif req.conflict_policy == "last_write_wins" and remote_epoch < local_epoch:
+                should_write = False
+                conflicts += 1
+
+        if not should_write:
+            skipped += 1
+            continue
+
+        write_text_file(path, file_row.content)
+        changed += 1
+        tomb_entries.pop(file_row.path, None)
+        msg = req.commit_message or f"replication: pull {req.source_peer} {file_row.path}"
+        if gm.commit_file(path, msg):
+            committed_files.append(file_row.path)
+
+    tomb_path = _write_replication_tombstones(settings.repo_root, tombstones)
+    if gm.commit_file(tomb_path, f"replication: update tombstones {req.source_peer}"):
+        committed_files.append(REPLICATION_TOMBSTONES_REL)
+
+    state.setdefault("last_pull_by_source", {})[req.source_peer] = {
+        "pulled_at": now.isoformat(),
+        "received_count": len(req.files),
+        "changed_count": changed,
+        "deleted_count": deleted,
+        "conflict_count": conflicts,
+        "mode": req.mode,
+        "conflict_policy": req.conflict_policy,
+        "idempotency_key": idempotency_key,
+    }
+    if idem_ref:
+        pull_map = state.setdefault("pull_idempotency", {})
+        if not isinstance(pull_map, dict):
+            pull_map = {}
+            state["pull_idempotency"] = pull_map
+        pull_map[idem_ref] = {
+            "at": now.isoformat(),
+            "received_count": len(req.files),
+            "changed_count": changed,
+            "deleted_count": deleted,
+            "conflict_count": conflicts,
+            "skipped_count": skipped,
+        }
+
+    state_path = _write_replication_state(settings.repo_root, state)
+    if gm.commit_file(state_path, f"replication: update pull state {req.source_peer}"):
+        committed_files.append(REPLICATION_STATE_REL)
+
+    audit(
+        auth,
+        "replication_pull",
+        {
+            "source_peer": req.source_peer,
+            "received": len(req.files),
+            "changed": changed,
+            "deleted": deleted,
+            "conflicts": conflicts,
+            "mode": req.mode,
+            "conflict_policy": req.conflict_policy,
+            "idempotency_key": idempotency_key,
+        },
+    )
+    return {
+        "ok": True,
+        "idempotent_replay": False,
+        "source_peer": req.source_peer,
+        "received_count": len(req.files),
+        "changed_count": changed,
+        "deleted_count": deleted,
+        "conflict_count": conflicts,
+        "skipped_count": skipped,
+        "committed_files": committed_files,
+        "latest_commit": gm.latest_commit(),
+    }
+
+
+def replication_push_service(
+    *,
+    settings: Any,
+    gm: Any,
+    auth: AuthContext,
+    req: ReplicationPushRequest,
+    enforce_rate_limit: Callable[[Any, AuthContext, str], None],
+    enforce_payload_limit: Callable[[Any, Any, str], None],
+    load_peers_registry: Callable[[Path], dict[str, Any]],
+    urlopen_fn: Callable[..., Any] = urlopen,
+    url_request_factory: Callable[..., Any] = UrlRequest,
+    audit: Callable[[AuthContext, str, dict[str, Any]], None],
+) -> dict:
+    enforce_rate_limit(settings, auth, "replication_push")
+    auth.require("admin:peers")
+
+    files = iter_replication_files(settings.repo_root, req.include_prefixes, req.max_files, include_deleted=req.include_deleted)
+    for row in files:
+        auth.require_read_path(str(row.get("path", "")))
+
+    by_prefix: dict[str, int] = {}
+    for row in files:
+        top = Path(str(row["path"])).parts[0] if Path(str(row["path"])).parts else ""
+        by_prefix[top] = by_prefix.get(top, 0) + 1
+
+    target_base = req.base_url
+    if not target_base and req.peer_id:
+        registry = load_peers_registry(settings.repo_root)
+        peer = registry.get("peers", {}).get(req.peer_id)
+        if isinstance(peer, dict):
+            target_base = str(peer.get("base_url") or "").strip() or None
+
+    push_id_source = req.idempotency_key or _canonical_json(
+        {
+            "peer": auth.peer_id,
+            "target": target_base,
+            "path": req.target_path,
+            "policy": req.conflict_policy,
+            "files": [{"path": f.get("path"), "sha256": f.get("sha256"), "deleted": bool(f.get("deleted"))} for f in files],
+        }
+    )
+    push_id = "push_" + hashlib.sha256(push_id_source.encode("utf-8")).hexdigest()[:24]
+
+    if req.dry_run or not target_base:
+        return {
+            "ok": True,
+            "dry_run": True,
+            "idempotency_key": push_id,
+            "file_count": len(files),
+            "by_prefix": by_prefix,
+            "target_base_url": target_base,
+            "target_path": req.target_path,
+            "sample_paths": [row["path"] for row in files[:20]],
+            "include_deleted": req.include_deleted,
+            "conflict_policy": req.conflict_policy,
+        }
+
+    target_url = urljoin(target_base.rstrip("/") + "/", req.target_path.lstrip("/"))
+    request_payload = {
+        "source_peer": auth.peer_id,
+        "files": files,
+        "mode": "upsert",
+        "conflict_policy": req.conflict_policy,
+        "idempotency_key": push_id,
+    }
+    enforce_payload_limit(settings, request_payload, "replication_push")
+
+    body = _canonical_json(request_payload).encode("utf-8")
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if req.target_token:
+        headers["Authorization"] = f"Bearer {req.target_token}"
+    try:
+        with urlopen_fn(url_request_factory(target_url, data=body, headers=headers, method="POST"), timeout=30) as resp:
+            raw = resp.read().decode("utf-8", errors="ignore")
+            remote_payload = json.loads(raw) if raw else {"ok": True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Failed replication push: {e}") from e
+
+    auth.require_write_path(REPLICATION_STATE_REL)
+    state = load_replication_state(settings.repo_root)
+    state["last_push"] = {
+        "pushed_at": datetime.now(timezone.utc).isoformat(),
+        "target_url": target_url,
+        "file_count": len(files),
+        "by_prefix": by_prefix,
+        "idempotency_key": push_id,
+        "conflict_policy": req.conflict_policy,
+        "include_deleted": req.include_deleted,
+    }
+    committed_files = []
+    state_path = _write_replication_state(settings.repo_root, state)
+    if gm.commit_file(state_path, "replication: update push state"):
+        committed_files.append(REPLICATION_STATE_REL)
+
+    audit(
+        auth,
+        "replication_push",
+        {
+            "target_url": target_url,
+            "file_count": len(files),
+            "idempotency_key": push_id,
+            "conflict_policy": req.conflict_policy,
+            "include_deleted": req.include_deleted,
+        },
+    )
+    return {
+        "ok": True,
+        "dry_run": False,
+        "idempotency_key": push_id,
+        "target_url": target_url,
+        "file_count": len(files),
+        "by_prefix": by_prefix,
+        "remote": remote_payload,
+        "committed_files": committed_files,
+        "latest_commit": gm.latest_commit(),
+    }
+
+
+def backup_create_service(
+    *,
+    settings: Any,
+    gm: Any,
+    auth: AuthContext,
+    req: BackupCreateRequest,
+    enforce_rate_limit: Callable[[Any, AuthContext, str], None],
+    enforce_payload_limit: Callable[[Any, Any, str], None],
+    audit: Callable[[AuthContext, str, dict[str, Any]], None],
+) -> dict:
+    enforce_rate_limit(settings, auth, "backup_create")
+    enforce_payload_limit(settings, req.model_dump(), "backup_create")
+    auth.require("admin:peers")
+
+    allowed = set(REPLICATION_ALLOWED_PREFIXES) | {"config", "logs", "peers"}
+    include = []
+    for raw in req.include_prefixes:
+        rel = str(raw or "").strip().strip("/")
+        if not rel:
+            continue
+        top = Path(rel).parts[0] if Path(rel).parts else ""
+        if top in allowed:
+            include.append(rel)
+    if not include:
+        include = ["memory", "messages", "tasks", "patches", "runs", "projects", "essays", "journal", "snapshots", "peers", "config", "logs"]
+
+    now = datetime.now(timezone.utc)
+    backup_id = f"backup_{now.strftime('%Y%m%dT%H%M%SZ')}_{uuid4().hex[:8]}"
+    backup_rel = f"{BACKUPS_DIR_REL}/{backup_id}.tar.gz"
+    manifest_rel = f"{BACKUPS_DIR_REL}/{backup_id}.json"
+    backup_path = safe_path(settings.repo_root, backup_rel)
+    manifest_path = safe_path(settings.repo_root, manifest_rel)
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+
+    included_paths: list[str] = []
+    with tarfile.open(backup_path, mode="w:gz") as tf:
+        for prefix in include:
+            path = safe_path(settings.repo_root, prefix)
+            if not path.exists():
+                continue
+            tf.add(path, arcname=prefix)
+            included_paths.append(prefix)
+
+    manifest_payload = {
+        "schema_version": "1.0",
+        "backup_id": backup_id,
+        "created_at": now.isoformat(),
+        "created_by": auth.peer_id,
+        "include_prefixes": included_paths,
+        "note": req.note,
+        "contract_version": settings.contract_version,
+    }
+    write_text_file(manifest_path, json.dumps(manifest_payload, ensure_ascii=False, indent=2))
+
+    committed_files = []
+    if gm.commit_file(backup_path, f"backup: create {backup_id}"):
+        committed_files.append(backup_rel)
+    if gm.commit_file(manifest_path, f"backup: manifest {backup_id}"):
+        committed_files.append(manifest_rel)
+
+    audit(auth, "backup_create", {"backup_id": backup_id, "include_prefixes": included_paths})
+    return {
+        "ok": True,
+        "backup_id": backup_id,
+        "backup_path": backup_rel,
+        "manifest_path": manifest_rel,
+        "committed_files": committed_files,
+        "latest_commit": gm.latest_commit(),
+    }
+
+
+def backup_restore_test_service(
+    *,
+    settings: Any,
+    auth: AuthContext,
+    req: BackupRestoreTestRequest,
+    enforce_rate_limit: Callable[[Any, AuthContext, str], None],
+    enforce_payload_limit: Callable[[Any, Any, str], None],
+    rebuild_index: Callable[[Path], dict[str, Any]],
+    audit: Callable[[AuthContext, str, dict[str, Any]], None],
+) -> dict:
+    enforce_rate_limit(settings, auth, "backup_restore_test")
+    enforce_payload_limit(settings, req.model_dump(), "backup_restore_test")
+    auth.require("admin:peers")
+
+    rel = str(req.backup_path or "").strip()
+    if not rel:
+        raise HTTPException(status_code=400, detail="backup_path is required")
+    if Path(rel).is_absolute():
+        raise HTTPException(status_code=400, detail="backup_path must be repo-relative")
+    if not rel.startswith(f"{BACKUPS_DIR_REL}/"):
+        raise HTTPException(status_code=400, detail="backup_path must be under backups/")
+
+    backup_path = safe_path(settings.repo_root, rel)
+    if not backup_path.exists() or not backup_path.is_file():
+        raise HTTPException(status_code=404, detail="Backup file not found")
+
+    extracted_files = 0
+    extracted_prefixes: set[str] = set()
+    with tempfile.TemporaryDirectory() as td:
+        restore_root = Path(td) / "restore"
+        restore_root.mkdir(parents=True, exist_ok=True)
+        try:
+            with tarfile.open(backup_path, mode="r:gz") as tf:
+                members = tf.getmembers()
+                restore_root_resolved = restore_root.resolve()
+                for m in members:
+                    if m.issym() or m.islnk():
+                        raise HTTPException(status_code=400, detail=f"Invalid backup archive: symbolic links are not allowed ({m.name})")
+                    target = (restore_root / m.name).resolve()
+                    if target != restore_root_resolved and restore_root_resolved not in target.parents:
+                        raise HTTPException(status_code=400, detail=f"Invalid backup archive: unsafe path ({m.name})")
+                tf.extractall(path=restore_root, filter="data")
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Invalid backup archive: {e}") from e
+
+        for m in members:
+            if not m.isfile():
+                continue
+            extracted_files += 1
+            top = Path(m.name).parts[0] if Path(m.name).parts else ""
+            if top:
+                extracted_prefixes.add(top)
+
+        index_validation = None
+        if req.verify_index_rebuild:
+            try:
+                payload = rebuild_index(restore_root)
+                index_validation = {"ok": True, "file_count": int(payload.get("file_count") or 0)}
+            except Exception as e:
+                index_validation = {"ok": False, "error": str(e)}
+
+    ok = extracted_files > 0 and (index_validation is None or bool(index_validation.get("ok")))
+    audit(auth, "backup_restore_test", {"backup_path": rel, "ok": ok, "extracted_files": extracted_files})
+    return {
+        "ok": ok,
+        "backup_path": rel,
+        "extracted_files": extracted_files,
+        "extracted_prefixes": sorted(extracted_prefixes),
+        "index_validation": index_validation,
+    }
+
+
+def _load_access_stats(repo_root: Path) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    path = repo_root / "logs" / "api_audit.jsonl"
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines()[-5000:]:
+        try:
+            row = json.loads(line)
+        except Exception:
+            continue
+        if row.get("event") not in {"read", "messages_inbox", "search", "context_retrieve"}:
+            continue
+        detail = row.get("detail") or {}
+        rel = detail.get("path")
+        if not rel:
+            continue
+        stat = out.setdefault(rel, {"access_count": 0, "last_access_at": None})
+        stat["access_count"] += 1
+        ts = row.get("ts")
+        if ts and (stat["last_access_at"] is None or ts > stat["last_access_at"]):
+            stat["last_access_at"] = ts
+    return out
+
+
+def _memory_class_for_path(rel: str) -> str:
+    if rel.startswith("memory/core/"):
+        return "core"
+    if rel.startswith("memory/summaries/") or rel.startswith("messages/threads/") or rel.startswith("projects/"):
+        return "durable" if rel.startswith("memory/summaries/") else "working"
+    if rel.startswith("journal/") or rel.startswith("messages/inbox/") or rel.startswith("messages/outbox/") or rel.startswith("logs/"):
+        return "ephemeral"
+    if rel.startswith("memory/episodic/"):
+        return "ephemeral"
+    return "working"
+
+
+def _candidate_policy(repo_root: Path, path: Path, access_stats: dict[str, dict], *, parse_iso: Callable[[str | None], datetime | None]) -> dict | None:
+    rel = str(path.relative_to(repo_root))
+    if rel.startswith("index/") or ".git" in path.parts:
+        return None
+    try:
+        st = path.stat()
+    except Exception:
+        return None
+    now = datetime.now(timezone.utc)
+    age_days = max(0.0, (now - datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)).total_seconds() / 86400.0)
+    size_bytes = int(st.st_size)
+    ns = Path(rel).parts[0] if Path(rel).parts else ""
+    mem_class = _memory_class_for_path(rel)
+    importance = 0.0
+    snippet = ""
+    text = ""
+    if path.suffix.lower() in {".md", ".json", ".jsonl", ".txt"}:
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            snippet = " ".join(text.split())[:240]
+        except Exception:
+            text = ""
+        if path.suffix.lower() == ".md":
+            m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+            if m:
+                for line in m.group(1).splitlines():
+                    if line.strip().startswith("importance:"):
+                        try:
+                            importance = float(line.split(":", 1)[1].strip())
+                        except Exception:
+                            pass
+    a = access_stats.get(rel, {})
+    access_count = int(a.get("access_count") or 0)
+    last_access_dt = parse_iso(a.get("last_access_at"))
+    last_access_days = 9999.0 if not last_access_dt else max(0.0, (now - last_access_dt).total_seconds() / 86400.0)
+
+    type_weight = {"ephemeral": 1.0, "working": 0.35, "durable": 0.12, "core": -5.0}.get(mem_class, 0.2)
+    age_pressure = min(1.5, age_days / 14.0)
+    size_pressure = min(1.0, math.log10(max(10, size_bytes)) / 8.0)
+    recency_relief = 0.9 if last_access_days < 3 else (0.35 if last_access_days < 14 else 0.0)
+    frequency_relief = min(1.0, access_count / 12.0) * 0.75
+    importance_relief = min(1.0, max(0.0, importance)) * 1.2
+    active_link_relief = 0.6 if rel.startswith("messages/threads/") or rel.startswith("projects/") else 0.0
+
+    candidate_score = round(type_weight + age_pressure + size_pressure - recency_relief - frequency_relief - importance_relief - active_link_relief, 4)
+
+    promote_signals = []
+    low = (text or "").lower()
+    for kw in ["identity", "relationship", "trusted", "values", "preference", "decision"]:
+        if kw in low:
+            promote_signals.append(kw)
+    if access_count >= 5:
+        promote_signals.append("reused")
+    if importance >= 0.7:
+        promote_signals.append("high_importance")
+    if mem_class in {"core"}:
+        promote_signals.append("core_namespace")
+
+    return {
+        "path": rel,
+        "namespace": ns,
+        "memory_class": mem_class,
+        "age_days": round(age_days, 2),
+        "size_bytes": size_bytes,
+        "importance": importance if importance else None,
+        "access_count": access_count,
+        "last_access_days": None if last_access_days >= 9999 else round(last_access_days, 2),
+        "candidate_score": candidate_score,
+        "promote_signals": sorted(set(promote_signals)),
+        "snippet": snippet,
+    }
+
+
+def compact_run_service(
+    *,
+    settings: Any,
+    gm: Any,
+    auth: AuthContext,
+    req: CompactRequest,
+    parse_iso: Callable[[str | None], datetime | None],
+    audit: Callable[[AuthContext, str, dict[str, Any]], None],
+) -> dict:
+    auth.require("compact:trigger")
+    auth.require_write_path("memory/summaries/weekly/x.md")
+
+    now = datetime.now(timezone.utc)
+    report_id = f"compact_{now.strftime('%Y%m%dT%H%M%SZ')}"
+    source_rel = req.source_path or "(policy-scan)"
+
+    access_stats = _load_access_stats(settings.repo_root)
+    candidates = []
+    for path in settings.repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in {".md", ".json", ".jsonl", ".txt"}:
+            continue
+        c = _candidate_policy(settings.repo_root, path, access_stats, parse_iso=parse_iso)
+        if c:
+            candidates.append(c)
+
+    summarize_now = []
+    archive_after_summary = []
+    promote_to_core_candidates = []
+    keep_hot = []
+    review_manually = []
+
+    for c in sorted(candidates, key=lambda x: (-float(x["candidate_score"]), x["path"])):
+        cls = c["memory_class"]
+        score = float(c["candidate_score"])
+        if cls == "core":
+            keep_hot.append(c)
+            continue
+        if c.get("promote_signals") and cls in {"working", "durable"}:
+            promote_to_core_candidates.append(c)
+            if score > 0.4:
+                summarize_now.append(c)
+            else:
+                keep_hot.append(c)
+            continue
+        if cls == "ephemeral":
+            if score >= 0.4:
+                summarize_now.append(c)
+                if score >= 0.9:
+                    archive_after_summary.append(c)
+            else:
+                keep_hot.append(c)
+        elif cls == "working":
+            if score >= 0.8:
+                summarize_now.append(c)
+            elif score >= 0.4:
+                review_manually.append(c)
+            else:
+                keep_hot.append(c)
+        elif cls == "durable":
+            if score >= 1.0:
+                review_manually.append(c)
+            else:
+                keep_hot.append(c)
+        else:
+            review_manually.append(c)
+
+    summary_paths = [x["path"] for x in summarize_now[:20]]
+    promote_paths = [x["path"] for x in promote_to_core_candidates[:10]]
+    archive_paths = [x["path"] for x in archive_after_summary[:20]]
+    keep_hot_paths = [x["path"] for x in keep_hot[:20]]
+
+    report_md_rel = f"memory/summaries/weekly/{report_id}.md"
+    report_json_rel = f"memory/summaries/weekly/{report_id}.json"
+    report_path = safe_path(settings.repo_root, report_md_rel)
+    report_json_path = safe_path(settings.repo_root, report_json_rel)
+    body = f"""---
+id: {report_id}
+type: compaction_report
+created_at: {now.isoformat()}
+source: {source_rel}
+---
+
+# Compaction Report
+
+This endpoint is an **orchestrator/planner**, not an LLM summarizer. It proposes candidates and categories.
+
+## Policy (class-aware decay + promotion)
+- Inputs: age, size, namespace/class, declared importance, access count, access recency
+- Classes: ephemeral / working / durable / core
+- Core is kept hot; durable is rarely compacted; ephemeral decays fastest
+- Promotion candidates can *increase* in importance over time (identity/relationship/decision facts)
+
+## Summary counts
+- Candidates scanned: {len(candidates)}
+- summarize_now: {len(summarize_now)}
+- archive_after_summary: {len(archive_after_summary)}
+- promote_to_core_candidates: {len(promote_to_core_candidates)}
+- keep_hot: {len(keep_hot)}
+- review_manually: {len(review_manually)}
+
+## Summarize now (top)
+{chr(10).join(f"- `{p}`" for p in summary_paths) if summary_paths else "- None"}
+
+## Promote to core candidates (top)
+{chr(10).join(f"- `{p}`" for p in promote_paths) if promote_paths else "- None"}
+
+## Archive after summary (top)
+{chr(10).join(f"- `{p}`" for p in archive_paths) if archive_paths else "- None"}
+
+## Keep hot (sample)
+{chr(10).join(f"- `{p}`" for p in keep_hot_paths) if keep_hot_paths else "- None"}
+
+## Operator note
+{req.note or 'N/A'}
+"""
+
+    payload = {
+        "id": report_id,
+        "type": "compaction_report",
+        "created_at": now.isoformat(),
+        "source": source_rel,
+        "planner_only": True,
+        "compaction_semantics": {
+            "summarizes_content": False,
+            "expected_ai_action": "Read candidate lists, generate summaries, then POST /v1/write or /v1/append",
+        },
+        "indexing_note": {
+            "incremental_index_default": "working_tree",
+            "can_include_uncommitted_changes": True,
+            "future_mode": ["working_tree", "head_commit"],
+        },
+        "policy": {
+            "inputs": ["age_days", "size_bytes", "memory_class", "importance", "access_count", "last_access_days"],
+            "classes": ["ephemeral", "working", "durable", "core"],
+            "decay": {
+                "ephemeral": "fast",
+                "working": "slow-while-active, faster-after-inactive",
+                "durable": "very_slow",
+                "core": "no_age_decay_retrieval_only",
+            },
+            "promotion_principle": "some memories gain importance over time via reuse/identity/relationship signals",
+        },
+        "summary_counts": {
+            "candidates_scanned": len(candidates),
+            "summarize_now": len(summarize_now),
+            "archive_after_summary": len(archive_after_summary),
+            "promote_to_core_candidates": len(promote_to_core_candidates),
+            "keep_hot": len(keep_hot),
+            "review_manually": len(review_manually),
+        },
+        "actions": {
+            "summarize_now": summarize_now[:20],
+            "archive_after_summary": archive_after_summary[:20],
+            "promote_to_core_candidates": promote_to_core_candidates[:15],
+            "keep_hot": keep_hot[:20],
+            "review_manually": review_manually[:20],
+        },
+        "operator_note": req.note,
+    }
+
+    write_text_file(report_path, body)
+    write_text_file(report_json_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    committed = []
+    for rel in [report_md_rel, report_json_rel]:
+        path = safe_path(settings.repo_root, rel)
+        if gm.commit_file(path, f"memory: add compaction {report_id}"):
+            committed.append(rel)
+
+    audit(auth, "compact_run", {"report_id": report_id, "source": source_rel, "candidates": len(candidates)})
+    return {
+        "ok": True,
+        "report_id": report_id,
+        "paths": [report_md_rel, report_json_rel],
+        "committed_files": committed,
+        "latest_commit": gm.latest_commit(),
+        "planner_only": True,
+        "summary_counts": payload["summary_counts"],
+    }


### PR DESCRIPTION
## Summary
- extract replication, backup, metrics, and compaction logic out of app/main.py into app/maintenance/service.py
- keep the existing API surface in app/main.py as thin wrappers and preserve shared callers like ops through injected dependencies
- preserve replication transport patch points and backup/compaction behavior while reducing maintenance-specific coupling in the main router

## Testing
- python -m compileall app
- ./.venv/bin/python -m unittest tests.test_p2_security_replication tests.test_go_live_hardening tests.test_ops_host_local -v
- ./.venv/bin/python -m unittest discover -s tests -v

Refs #12