### PR TITLE
Realign test patch boundaries after main refactor

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Any
-from urllib.request import Request as UrlRequest, urlopen
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request as FastAPIRequest, Response
 from fastapi.responses import JSONResponse
@@ -1036,8 +1035,6 @@ def replication_push(req: ReplicationPushRequest, auth: AuthContext = Depends(re
         enforce_rate_limit=_enforce_rate_limit,
         enforce_payload_limit=_enforce_payload_limit,
         load_peers_registry=load_peers_registry,
-        urlopen_fn=urlopen,
-        url_request_factory=UrlRequest,
         audit=lambda auth_ctx, event, detail: _audit(settings, auth_ctx, event, detail),
     )
 

--- a/app/maintenance/service.py
+++ b/app/maintenance/service.py
@@ -487,10 +487,15 @@ def replication_push_service(
     enforce_rate_limit: Callable[[Any, AuthContext, str], None],
     enforce_payload_limit: Callable[[Any, Any, str], None],
     load_peers_registry: Callable[[Path], dict[str, Any]],
-    urlopen_fn: Callable[..., Any] = urlopen,
-    url_request_factory: Callable[..., Any] = UrlRequest,
+    urlopen_fn: Callable[..., Any] | None = None,
+    url_request_factory: Callable[..., Any] | None = None,
     audit: Callable[[AuthContext, str, dict[str, Any]], None],
 ) -> dict:
+    if urlopen_fn is None:
+        urlopen_fn = urlopen
+    if url_request_factory is None:
+        url_request_factory = UrlRequest
+
     enforce_rate_limit(settings, auth, "replication_push")
     auth.require("admin:peers")
 

--- a/tests/test_main_index_rebuild.py
+++ b/tests/test_main_index_rebuild.py
@@ -55,7 +55,7 @@ class TestIndexRebuildEndpoint(unittest.TestCase):
                 return {"file_count": 1}
 
             with patch("app.main._services", return_value=(settings, gm)):
-                with patch("app.main.rebuild_index", side_effect=_fake_rebuild):
+                with patch("app.context.service.rebuild_index", side_effect=_fake_rebuild):
                     result = index_rebuild(auth=_AuthStub())
 
             expected = {

--- a/tests/test_p2_security_replication.py
+++ b/tests/test_p2_security_replication.py
@@ -406,7 +406,7 @@ class TestP2SecurityReplication(unittest.TestCase):
             self.assertGreaterEqual(dry["file_count"], 2)
 
             with patch("app.main._services", return_value=(settings, gm)):
-                with patch("app.main.urlopen", return_value=_FakeHTTPResponse({"ok": True, "accepted": True})):
+                with patch("app.maintenance.service.urlopen", return_value=_FakeHTTPResponse({"ok": True, "accepted": True})):
                     pushed = replication_push(
                         req=ReplicationPushRequest(
                             dry_run=False,
@@ -437,7 +437,7 @@ class TestP2SecurityReplication(unittest.TestCase):
                     req=PeerRegisterRequest(peer_id="peer-beta", base_url="https://peer-beta.example.net"),
                     auth=_AuthStub(),
                 )
-                with patch("app.main.urlopen", return_value=_FakeHTTPResponse({"ok": True, "accepted": True})):
+                with patch("app.maintenance.service.urlopen", return_value=_FakeHTTPResponse({"ok": True, "accepted": True})):
                     pushed = replication_push(
                         req=ReplicationPushRequest(peer_id="peer-beta", include_prefixes=["memory"], target_token="tok"),
                         auth=_AuthStub(),


### PR DESCRIPTION
Refs #12

## Summary
- retarget the remaining test-only internal patch points from `app.main` to the extracted service modules
- remove the no-longer-needed `urlopen`/`UrlRequest` threading from `app.main`
- make replication push dependency injection in `app.maintenance.service` resolve at call time so module-level patching is deterministic

## Testing
- `python -m compileall app`
- `./.venv/bin/python -m unittest tests.test_main_index_rebuild tests.test_p2_security_replication -v`
- `./.venv/bin/python -m unittest discover -s tests -v`