### PR TITLE
Integrate Ruff baseline checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,10 @@ For agent integration details, including the MCP bootstrap flow and tool mapping
 ## Development
 
 Tests are in `tests/`. Discovery and manifest behavior are covered in `tests/test_discovery.py`.
+
+Local quality commands:
+
+```bash
+./.venv/bin/python -m unittest discover -s tests -v
+ruff check app tests tools_hash_token.py
+```

--- a/app/context/service.py
+++ b/app/context/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4

--- a/app/indexer.py
+++ b/app/indexer.py
@@ -116,8 +116,10 @@ def _upsert_sqlite(repo_root: Path, records: list[dict[str, Any]], removed_paths
         for r in records:
             conn.execute(
                 'INSERT INTO files(path,type,modified_at,mtime_ns,size,importance,snippet) VALUES(?,?,?,?,?,?,?) '
-                'ON CONFLICT(path) DO UPDATE SET type=excluded.type, modified_at=excluded.modified_at, mtime_ns=excluded.mtime_ns, size=excluded.size, importance=excluded.importance, snippet=excluded.snippet',
-                (r['path'], r['type'], r['modified_at'], r['mtime_ns'], r['size'], r.get('importance'), r['snippet'])
+                'ON CONFLICT(path) DO UPDATE SET '
+                'type=excluded.type, modified_at=excluded.modified_at, mtime_ns=excluded.mtime_ns, '
+                'size=excluded.size, importance=excluded.importance, snippet=excluded.snippet',
+                (r['path'], r['type'], r['modified_at'], r['mtime_ns'], r['size'], r.get('importance'), r['snippet']),
             )
             conn.execute('DELETE FROM tags WHERE path = ?', (r['path'],))
             conn.executemany('INSERT OR IGNORE INTO tags(tag,path) VALUES(?,?)', [(t, r['path']) for t in r.get('tags', [])])

--- a/app/main.py
+++ b/app/main.py
@@ -108,7 +108,18 @@ from .runtime import (
     scope_for_path as _scope_for_path,
     verification_failure_count as _verification_failure_count,
 )
-from .security import governance_policy_service, load_token_config, load_security_keys, messages_verify_service, security_keys_rotate_service, security_tokens_issue_service, security_tokens_list_service, security_tokens_revoke_service, security_tokens_rotate_service, verify_signed_payload_service
+from .security import (
+    governance_policy_service,
+    load_security_keys,
+    load_token_config,
+    messages_verify_service,
+    security_keys_rotate_service,
+    security_tokens_issue_service,
+    security_tokens_list_service,
+    security_tokens_revoke_service,
+    security_tokens_rotate_service,
+    verify_signed_payload_service,
+)
 from .tasks import (
     code_checks_run_service,
     code_merge_service,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 200
+
+[tool.ruff.lint]
+select = ["E", "F"]

--- a/tests/test_token_lifecycle.py
+++ b/tests/test_token_lifecycle.py
@@ -168,7 +168,7 @@ class TestTokenLifecycle(unittest.TestCase):
 
             with patch("app.main._services", return_value=(settings, gm)):
                 a = security_tokens_issue(req=SecurityTokenIssueRequest(peer_id="peer-a"), auth=_AuthStub())
-                b = security_tokens_issue(req=SecurityTokenIssueRequest(peer_id="peer-b"), auth=_AuthStub())
+                security_tokens_issue(req=SecurityTokenIssueRequest(peer_id="peer-b"), auth=_AuthStub())
                 security_tokens_revoke(req=SecurityTokenRevokeRequest(token_id=a["token_meta"]["token_id"]), auth=_AuthStub())
                 active_only = security_tokens_list(include_inactive=False, auth=_AuthStub())
                 all_tokens = security_tokens_list(include_inactive=True, auth=_AuthStub())


### PR DESCRIPTION
Refs #26

Summary:
- add a conservative Ruff baseline in pyproject.toml
- fix the current baseline findings in app and tests
- document the standard local quality commands in README.md

Validation:
- ruff check app tests tools_hash_token.py
- ./.venv/bin/python -m unittest discover -s tests -v