### PR TITLE
build: add ruff to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,15 @@ For agent integration details, including the MCP bootstrap flow and tool mapping
 
 Tests are in `tests/`. Discovery and manifest behavior are covered in `tests/test_discovery.py`.
 
+Install development-only tooling with:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
 Local quality commands:
 
 ```bash
 ./.venv/bin/python -m unittest discover -s tests -v
-ruff check app tests tools_hash_token.py
+./.venv/bin/python -m ruff check app tests tools_hash_token.py
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 httpx>=0.27,<1
+ruff>=0.11,<1


### PR DESCRIPTION
## Summary
- add `ruff` to `requirements-dev.txt` so the documented lint command is installable in `.venv`
- keep the existing `httpx` dev dependency intact
- update README development setup and quality commands to use the project virtualenv explicitly

## Verification
- `./.venv/bin/python -m ruff check app tests tools_hash_token.py`
- `./.venv/bin/python -m unittest discover -s tests -v`