### PR TITLE
Serialize continuity mutations per subject to prevent stale rollback overwrite

### DIFF
--- a/app/continuity/service.py
+++ b/app/continuity/service.py
@@ -178,6 +178,23 @@ def continuity_fallback_rel_path(subject_kind: str, subject_id: str) -> str:
     return f"{CONTINUITY_DIR_REL}/fallback/{subject_kind}-{normalized}.json"
 
 
+def _continuity_subject_lock_id(subject_kind: str, subject_id: str) -> str:
+    """Return a safe per-subject lock id shared by all continuity mutation endpoints."""
+    normalized = _normalize_subject_id(subject_id)
+    digest = hashlib.sha256(f"{subject_kind}:{normalized}".encode("utf-8")).hexdigest()
+    return f"continuity_{digest}"
+
+
+def _continuity_subject_lock(*, repo_root: Path, subject_kind: str, subject_id: str):
+    """Return the shared per-subject mutation lock context for one selector."""
+    from app.coordination.locking import artifact_lock
+
+    return artifact_lock(
+        _continuity_subject_lock_id(subject_kind, subject_id),
+        lock_dir=repo_root / ".locks",
+    )
+
+
 def _validate_repo_relative_paths(repo_root: Path, paths: list[str], field_name: str) -> None:
     """Validate that repo-relative paths stay within the repository root."""
     for rel in paths:
@@ -1043,44 +1060,45 @@ def continuity_upsert_service(
     auth.require_write_path(rel)
     _validate_capsule(repo_root, capsule)
     path = safe_path(repo_root, rel)
-    canonical = canonical_json(capsule.model_dump(mode="json", exclude_none=True))
-    new_bytes = canonical.encode("utf-8")
-    old_bytes = path.read_bytes() if path.exists() else None
-    if old_bytes != new_bytes:
-        stripped_req = ContinuityUpsertRequest(
-            subject_kind=req.subject_kind,
-            subject_id=req.subject_id,
-            capsule=capsule,
-            commit_message=req.commit_message,
-            idempotency_key=req.idempotency_key,
-        )
-        _reject_stale_or_conflicting_write(path, stripped_req)
-    capsule_sha256 = hashlib.sha256(new_bytes).hexdigest()
-    created = not path.exists()
-    changed = old_bytes != new_bytes
-    committed = False
-    fallback_warning: str | None = None
-    fallback_warning_detail: str | None = None
-    if changed:
-        _persist_active_capsule(
-            repo_root=repo_root,
-            gm=gm,
-            path=path,
-            canonical=canonical,
-            commit_message=req.commit_message or f"continuity: upsert {req.subject_kind} {req.subject_id}",
-        )
-        committed = True
-        fallback_rel, fallback_status, fallback_warning_detail = _persist_fallback_snapshot(
-            repo_root=repo_root,
-            gm=gm,
-            subject_kind=req.subject_kind,
-            subject_id=req.subject_id,
-            capsule=capsule.model_dump(mode="json", exclude_none=True),
-        )
-        if fallback_status == "failed":
-            fallback_warning = CONTINUITY_WARNING_FALLBACK_WRITE_FAILED
-    else:
-        fallback_rel = continuity_fallback_rel_path(req.subject_kind, req.subject_id)
+    with _continuity_subject_lock(repo_root=repo_root, subject_kind=req.subject_kind, subject_id=req.subject_id):
+        canonical = canonical_json(capsule.model_dump(mode="json", exclude_none=True))
+        new_bytes = canonical.encode("utf-8")
+        old_bytes = path.read_bytes() if path.exists() else None
+        if old_bytes != new_bytes:
+            stripped_req = ContinuityUpsertRequest(
+                subject_kind=req.subject_kind,
+                subject_id=req.subject_id,
+                capsule=capsule,
+                commit_message=req.commit_message,
+                idempotency_key=req.idempotency_key,
+            )
+            _reject_stale_or_conflicting_write(path, stripped_req)
+        capsule_sha256 = hashlib.sha256(new_bytes).hexdigest()
+        created = not path.exists()
+        changed = old_bytes != new_bytes
+        committed = False
+        fallback_warning: str | None = None
+        fallback_warning_detail: str | None = None
+        if changed:
+            _persist_active_capsule(
+                repo_root=repo_root,
+                gm=gm,
+                path=path,
+                canonical=canonical,
+                commit_message=req.commit_message or f"continuity: upsert {req.subject_kind} {req.subject_id}",
+            )
+            committed = True
+            fallback_rel, fallback_status, fallback_warning_detail = _persist_fallback_snapshot(
+                repo_root=repo_root,
+                gm=gm,
+                subject_kind=req.subject_kind,
+                subject_id=req.subject_id,
+                capsule=capsule.model_dump(mode="json", exclude_none=True),
+            )
+            if fallback_status == "failed":
+                fallback_warning = CONTINUITY_WARNING_FALLBACK_WRITE_FAILED
+        else:
+            fallback_rel = continuity_fallback_rel_path(req.subject_kind, req.subject_id)
     audit(
         auth,
         "continuity_upsert",
@@ -1349,87 +1367,87 @@ def continuity_delete_service(
     fallback_rel = continuity_fallback_rel_path(req.subject_kind, req.subject_id)
     archive_prefix = f"{req.subject_kind}-{_normalize_subject_id(req.subject_id)}-"
     archive_base = repo_root / CONTINUITY_DIR_REL / "archive"
+    with _continuity_subject_lock(repo_root=repo_root, subject_kind=req.subject_kind, subject_id=req.subject_id):
+        selected_rels: list[str] = []
+        missing_paths: list[str] = []
+        paths_to_stage: list[Path] = []
+        original_bytes: dict[Path, bytes] = {}
 
-    selected_rels: list[str] = []
-    missing_paths: list[str] = []
-    paths_to_stage: list[Path] = []
-    original_bytes: dict[Path, bytes] = {}
+        if req.delete_active:
+            auth.require_write_path(active_rel)
+            active_path = safe_path(repo_root, active_rel)
+            if active_path.exists():
+                selected_rels.append(active_rel)
+                paths_to_stage.append(active_path)
+                original_bytes[active_path] = active_path.read_bytes()
+            else:
+                missing_paths.append(active_rel)
 
-    if req.delete_active:
-        auth.require_write_path(active_rel)
-        active_path = safe_path(repo_root, active_rel)
-        if active_path.exists():
-            selected_rels.append(active_rel)
-            paths_to_stage.append(active_path)
-            original_bytes[active_path] = active_path.read_bytes()
-        else:
-            missing_paths.append(active_rel)
+        if req.delete_fallback:
+            auth.require_write_path(fallback_rel)
+            fallback_path = safe_path(repo_root, fallback_rel)
+            if fallback_path.exists():
+                selected_rels.append(fallback_rel)
+                paths_to_stage.append(fallback_path)
+                original_bytes[fallback_path] = fallback_path.read_bytes()
+            else:
+                missing_paths.append(fallback_rel)
 
-    if req.delete_fallback:
-        auth.require_write_path(fallback_rel)
-        fallback_path = safe_path(repo_root, fallback_rel)
-        if fallback_path.exists():
-            selected_rels.append(fallback_rel)
-            paths_to_stage.append(fallback_path)
-            original_bytes[fallback_path] = fallback_path.read_bytes()
-        else:
-            missing_paths.append(fallback_rel)
+        if req.delete_archive and archive_base.exists() and archive_base.is_dir():
+            archive_paths: list[tuple[str, Path]] = []
+            for path in sorted(archive_base.iterdir(), key=lambda item: item.name):
+                stem = path.stem
+                if path.is_dir() or path.suffix.lower() != ".json" or not stem.startswith(archive_prefix):
+                    continue
+                archive_suffix = stem[len(archive_prefix):]
+                if re.fullmatch(r"\d{8}T\d{6}Z", archive_suffix) is None:
+                    continue
+                rel = str(path.relative_to(repo_root))
+                auth.require_write_path(rel)
+                archive_paths.append((rel, path))
+            for rel, path in archive_paths:
+                selected_rels.append(rel)
+                paths_to_stage.append(path)
+                original_bytes[path] = path.read_bytes()
 
-    if req.delete_archive and archive_base.exists() and archive_base.is_dir():
-        archive_paths: list[tuple[str, Path]] = []
-        for path in sorted(archive_base.iterdir(), key=lambda item: item.name):
-            stem = path.stem
-            if path.is_dir() or path.suffix.lower() != ".json" or not stem.startswith(archive_prefix):
-                continue
-            archive_suffix = stem[len(archive_prefix):]
-            if re.fullmatch(r"\d{8}T\d{6}Z", archive_suffix) is None:
-                continue
-            rel = str(path.relative_to(repo_root))
-            auth.require_write_path(rel)
-            archive_paths.append((rel, path))
-        for rel, path in archive_paths:
-            selected_rels.append(rel)
-            paths_to_stage.append(path)
-            original_bytes[path] = path.read_bytes()
-
-    if not paths_to_stage:
-        audit(
-            auth,
-            "continuity_delete",
-            {
-                "subject_kind": req.subject_kind,
-                "subject_id": req.subject_id,
+        if not paths_to_stage:
+            audit(
+                auth,
+                "continuity_delete",
+                {
+                    "subject_kind": req.subject_kind,
+                    "subject_id": req.subject_id,
+                    "deleted_paths": [],
+                    "missing_paths": missing_paths,
+                    "reason": req.reason,
+                },
+            )
+            return {
+                "ok": True,
                 "deleted_paths": [],
                 "missing_paths": missing_paths,
-                "reason": req.reason,
-            },
-        )
-        return {
-            "ok": True,
-            "deleted_paths": [],
-            "missing_paths": missing_paths,
-            "latest_commit": gm.latest_commit(),
-        }
+                "latest_commit": gm.latest_commit(),
+            }
 
-    try:
-        for path in paths_to_stage:
-            path.unlink()
-        committed = gm.commit_paths(paths_to_stage, _delete_commit_message(req.subject_kind, req.subject_id, req.reason))
-        if not committed:
-            raise RuntimeError("Continuity delete commit produced no changes")
-    except Exception as exc:
-        restore_errors: list[str] = []
-        for path, data in original_bytes.items():
-            try:
-                write_bytes_file(path, data)
-            except Exception as restore_exc:
-                restore_errors.append(f"{path}: {restore_exc}")
-        if restore_errors:
-            raise HTTPException(
-                status_code=500,
-                detail=f"Continuity delete failed: {exc}; rollback failed for {', '.join(restore_errors)}",
-            ) from exc
-        raise HTTPException(status_code=500, detail=f"Continuity delete failed: {exc}") from exc
+        try:
+            for path in paths_to_stage:
+                path.unlink()
+            committed = gm.commit_paths(paths_to_stage, _delete_commit_message(req.subject_kind, req.subject_id, req.reason))
+            if not committed:
+                raise RuntimeError("Continuity delete commit produced no changes")
+        except Exception as exc:
+            restore_errors: list[str] = []
+            for path, data in original_bytes.items():
+                try:
+                    write_bytes_file(path, data)
+                except Exception as restore_exc:
+                    restore_errors.append(f"{path}: {restore_exc}")
+            if restore_errors:
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Continuity delete failed: {exc}; rollback failed for {', '.join(restore_errors)}",
+                ) from exc
+            raise HTTPException(status_code=500, detail=f"Continuity delete failed: {exc}") from exc
     audit(
         auth,
         "continuity_delete",
@@ -1688,91 +1706,92 @@ def continuity_revalidate_service(
     auth.require_read_path(rel)
     auth.require_write_path(rel)
     active_path = safe_path(repo_root, rel)
-    active = ContinuityCapsule.model_validate(
-        _load_capsule(repo_root, rel, expected_subject=(req.subject_kind, req.subject_id))
-    )
-    now = datetime.now(timezone.utc).replace(microsecond=0)
-    now_iso = now.isoformat().replace("+00:00", "Z")
-    strongest_signal = _strongest_signal_kind(req.signals)
-    derived_status = CONTINUITY_SIGNAL_STATUS[strongest_signal]
-    evidence_refs = _signals_to_evidence_refs(req.signals)
-    compare_changed_fields: list[str] = []
-    result_outcome = req.outcome
-    updated = False
-
-    if req.outcome == "correct":
-        candidate = req.candidate_capsule
-        if candidate is None:
-            raise HTTPException(status_code=400, detail="candidate_capsule is required for outcome=correct")
-        compare_changed_fields = _compare_capsules(
-            _normalize_compare_payload(repo_root, active),
-            _normalize_compare_payload(repo_root, candidate),
+    with _continuity_subject_lock(repo_root=repo_root, subject_kind=req.subject_kind, subject_id=req.subject_id):
+        active = ContinuityCapsule.model_validate(
+            _load_capsule(repo_root, rel, expected_subject=(req.subject_kind, req.subject_id))
         )
-        if not compare_changed_fields:
-            result_outcome = "confirm"
-            final_capsule = active.model_copy(deep=True)
+        now = datetime.now(timezone.utc).replace(microsecond=0)
+        now_iso = now.isoformat().replace("+00:00", "Z")
+        strongest_signal = _strongest_signal_kind(req.signals)
+        derived_status = CONTINUITY_SIGNAL_STATUS[strongest_signal]
+        evidence_refs = _signals_to_evidence_refs(req.signals)
+        compare_changed_fields: list[str] = []
+        result_outcome = req.outcome
+        updated = False
+
+        if req.outcome == "correct":
+            candidate = req.candidate_capsule
+            if candidate is None:
+                raise HTTPException(status_code=400, detail="candidate_capsule is required for outcome=correct")
+            compare_changed_fields = _compare_capsules(
+                _normalize_compare_payload(repo_root, active),
+                _normalize_compare_payload(repo_root, candidate),
+            )
+            if not compare_changed_fields:
+                result_outcome = "confirm"
+                final_capsule = active.model_copy(deep=True)
+            else:
+                updated = True
+                final_capsule = candidate.model_copy(deep=True)
         else:
-            updated = True
-            final_capsule = candidate.model_copy(deep=True)
-    else:
-        final_capsule = active.model_copy(deep=True)
+            final_capsule = active.model_copy(deep=True)
 
-    final_capsule.verified_at = now_iso
-    final_capsule.verification_kind = strongest_signal  # type: ignore[assignment]
+        final_capsule.verified_at = now_iso
+        final_capsule.verification_kind = strongest_signal  # type: ignore[assignment]
 
-    if result_outcome == "conflict":
-        final_capsule.verification_state = ContinuityVerificationState.model_validate({
-            "status": "conflicted",
-            "last_revalidated_at": now_iso,
-            "strongest_signal": strongest_signal,
-            "evidence_refs": evidence_refs,
-            "conflict_summary": req.reason,
-        })
-        final_capsule.capsule_health = ContinuityCapsuleHealth.model_validate({
-            "status": "conflicted",
-            "reasons": [req.reason],
-            "last_checked_at": now_iso,
-        })
-    elif result_outcome == "degrade":
-        final_capsule.verification_state = ContinuityVerificationState.model_validate({
-            "status": derived_status,
-            "last_revalidated_at": now_iso,
-            "strongest_signal": strongest_signal,
-            "evidence_refs": evidence_refs,
-        })
-        final_capsule.capsule_health = ContinuityCapsuleHealth.model_validate({
-            "status": "degraded",
-            "reasons": [req.reason],
-            "last_checked_at": now_iso,
-        })
-    else:
-        final_capsule.verification_state = ContinuityVerificationState.model_validate({
-            "status": derived_status,
-            "last_revalidated_at": now_iso,
-            "strongest_signal": strongest_signal,
-            "evidence_refs": evidence_refs,
-        })
-        final_capsule.capsule_health = ContinuityCapsuleHealth.model_validate({
-            "status": "healthy",
-            "reasons": [],
-            "last_checked_at": now_iso,
-        })
+        if result_outcome == "conflict":
+            final_capsule.verification_state = ContinuityVerificationState.model_validate({
+                "status": "conflicted",
+                "last_revalidated_at": now_iso,
+                "strongest_signal": strongest_signal,
+                "evidence_refs": evidence_refs,
+                "conflict_summary": req.reason,
+            })
+            final_capsule.capsule_health = ContinuityCapsuleHealth.model_validate({
+                "status": "conflicted",
+                "reasons": [req.reason],
+                "last_checked_at": now_iso,
+            })
+        elif result_outcome == "degrade":
+            final_capsule.verification_state = ContinuityVerificationState.model_validate({
+                "status": derived_status,
+                "last_revalidated_at": now_iso,
+                "strongest_signal": strongest_signal,
+                "evidence_refs": evidence_refs,
+            })
+            final_capsule.capsule_health = ContinuityCapsuleHealth.model_validate({
+                "status": "degraded",
+                "reasons": [req.reason],
+                "last_checked_at": now_iso,
+            })
+        else:
+            final_capsule.verification_state = ContinuityVerificationState.model_validate({
+                "status": derived_status,
+                "last_revalidated_at": now_iso,
+                "strongest_signal": strongest_signal,
+                "evidence_refs": evidence_refs,
+            })
+            final_capsule.capsule_health = ContinuityCapsuleHealth.model_validate({
+                "status": "healthy",
+                "reasons": [],
+                "last_checked_at": now_iso,
+            })
 
-    _, canonical = _final_capsule_payload(repo_root, final_capsule)
-    _persist_active_capsule(
-        repo_root=repo_root,
-        gm=gm,
-        path=active_path,
-        canonical=canonical,
-        commit_message=f"continuity: revalidate {req.subject_kind} {req.subject_id}",
-    )
-    fallback_rel, fallback_status, fallback_warning_detail = _persist_fallback_snapshot(
-        repo_root=repo_root,
-        gm=gm,
-        subject_kind=req.subject_kind,
-        subject_id=req.subject_id,
-        capsule=final_capsule.model_dump(mode="json", exclude_none=True),
-    )
+        _, canonical = _final_capsule_payload(repo_root, final_capsule)
+        _persist_active_capsule(
+            repo_root=repo_root,
+            gm=gm,
+            path=active_path,
+            canonical=canonical,
+            commit_message=f"continuity: revalidate {req.subject_kind} {req.subject_id}",
+        )
+        fallback_rel, fallback_status, fallback_warning_detail = _persist_fallback_snapshot(
+            repo_root=repo_root,
+            gm=gm,
+            subject_kind=req.subject_kind,
+            subject_id=req.subject_id,
+            capsule=final_capsule.model_dump(mode="json", exclude_none=True),
+        )
     audit(
         auth,
         "continuity_revalidate",
@@ -1818,45 +1837,45 @@ def continuity_archive_service(
     auth.require_read_path(rel)
     auth.require_write_path(rel)
     auth.require_write_path(archive_rel)
+    with _continuity_subject_lock(repo_root=repo_root, subject_kind=req.subject_kind, subject_id=req.subject_id):
+        capsule = _load_capsule(repo_root, rel, expected_subject=(req.subject_kind, req.subject_id))
+        archive_payload = {
+            "schema_type": CONTINUITY_ARCHIVE_SCHEMA_TYPE,
+            "schema_version": CONTINUITY_ARCHIVE_SCHEMA_VERSION,
+            "archived_at": now.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "archived_by": auth.peer_id,
+            "reason": req.reason,
+            "active_path": rel,
+            "capsule": capsule,
+        }
 
-    capsule = _load_capsule(repo_root, rel, expected_subject=(req.subject_kind, req.subject_id))
-    archive_payload = {
-        "schema_type": CONTINUITY_ARCHIVE_SCHEMA_TYPE,
-        "schema_version": CONTINUITY_ARCHIVE_SCHEMA_VERSION,
-        "archived_at": now.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
-        "archived_by": auth.peer_id,
-        "reason": req.reason,
-        "active_path": rel,
-        "capsule": capsule,
-    }
-
-    archive_path = safe_path(repo_root, archive_rel)
-    archive_path.parent.mkdir(parents=True, exist_ok=True)
-    active_path = safe_path(repo_root, rel)
-    active_bytes = active_path.read_bytes()
-    write_text_file(archive_path, canonical_json(archive_payload))
-    # The active-path deletion must be staged before the git commit can atomically
-    # record the archive write plus active-file removal. If the commit step fails,
-    # restore the active capsule and discard the archive envelope immediately.
-    active_path.unlink()
-    try:
-        committed = gm.commit_paths([archive_path, active_path], f"continuity: archive {req.subject_kind} {req.subject_id}")
-    except Exception as exc:
+        archive_path = safe_path(repo_root, archive_rel)
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+        active_path = safe_path(repo_root, rel)
+        active_bytes = active_path.read_bytes()
+        write_text_file(archive_path, canonical_json(archive_payload))
+        # The active-path deletion must be staged before the git commit can atomically
+        # record the archive write plus active-file removal. If the commit step fails,
+        # restore the active capsule and discard the archive envelope immediately.
+        active_path.unlink()
         try:
-            _restore_failed_archive(active_path, archive_path, active_bytes)
-        except Exception as restore_exc:
-            raise RuntimeError(
-                f"Continuity archive commit failed: {exc}; rollback failed: {restore_exc}"
-            ) from exc
-        raise
-    if not committed:
-        try:
-            _restore_failed_archive(active_path, archive_path, active_bytes)
-        except Exception as restore_exc:
-            raise RuntimeError(
-                f"Continuity archive commit produced no changes; rollback failed: {restore_exc}"
-            ) from restore_exc
-        raise RuntimeError("Continuity archive commit produced no changes")
+            committed = gm.commit_paths([archive_path, active_path], f"continuity: archive {req.subject_kind} {req.subject_id}")
+        except Exception as exc:
+            try:
+                _restore_failed_archive(active_path, archive_path, active_bytes)
+            except Exception as restore_exc:
+                raise RuntimeError(
+                    f"Continuity archive commit failed: {exc}; rollback failed: {restore_exc}"
+                ) from exc
+            raise
+        if not committed:
+            try:
+                _restore_failed_archive(active_path, archive_path, active_bytes)
+            except Exception as restore_exc:
+                raise RuntimeError(
+                    f"Continuity archive commit produced no changes; rollback failed: {restore_exc}"
+                ) from restore_exc
+            raise RuntimeError("Continuity archive commit produced no changes")
 
     audit(
         auth,

--- a/tests/test_continuity_97_locking.py
+++ b/tests/test_continuity_97_locking.py
@@ -1,0 +1,381 @@
+"""Regression tests for Issue #97 subject-level continuity mutation locking."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from app.continuity.service import (
+    continuity_archive_service,
+    continuity_delete_service,
+    continuity_revalidate_service,
+    continuity_upsert_service,
+)
+from app.models import (
+    ContinuityArchiveRequest,
+    ContinuityDeleteRequest,
+    ContinuityRevalidateRequest,
+    ContinuityUpsertRequest,
+)
+from tests.helpers import AllowAllAuthStub, SimpleGitManagerStub
+
+
+class _ControlledGitManager(SimpleGitManagerStub):
+    """Git stub that can block or fail selected commit messages deterministically."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.file_calls: list[tuple[str, str]] = []
+        self.path_calls: list[tuple[list[str], str]] = []
+        self._file_controls: dict[str, dict[str, Any]] = {}
+        self._path_controls: dict[str, dict[str, Any]] = {}
+
+    def control_file_commit(
+        self, message: str, *, fail_with: Exception | None = None
+    ) -> tuple[threading.Event, threading.Event]:
+        """Return entered/release events for a controlled single-file commit."""
+        entered = threading.Event()
+        release = threading.Event()
+        self._file_controls[message] = {"entered": entered, "release": release, "fail_with": fail_with}
+        return entered, release
+
+    def control_path_commit(
+        self, message: str, *, fail_with: Exception | None = None
+    ) -> tuple[threading.Event, threading.Event]:
+        """Return entered/release events for a controlled multi-path commit."""
+        entered = threading.Event()
+        release = threading.Event()
+        self._path_controls[message] = {"entered": entered, "release": release, "fail_with": fail_with}
+        return entered, release
+
+    def commit_file(self, path: Path, message: str) -> bool:
+        """Record the file commit and optionally block or fail it."""
+        self.file_calls.append((str(path), message))
+        control = self._file_controls.get(message)
+        if control is not None:
+            control["entered"].set()
+            if not control["release"].wait(timeout=5):
+                raise RuntimeError(f"Timed out waiting to release file commit: {message}")
+            if control["fail_with"] is not None:
+                raise control["fail_with"]
+        return True
+
+    def commit_paths(self, paths: list[Path], message: str) -> bool:
+        """Record the path commit and optionally block or fail it."""
+        self.path_calls.append(([str(path) for path in paths], message))
+        control = self._path_controls.get(message)
+        if control is not None:
+            control["entered"].set()
+            if not control["release"].wait(timeout=5):
+                raise RuntimeError(f"Timed out waiting to release path commit: {message}")
+            if control["fail_with"] is not None:
+                raise control["fail_with"]
+        return True
+
+
+class TestContinuitySubjectLocking(unittest.TestCase):
+    """Validate same-subject serialization across continuity mutation endpoints."""
+
+    def _capsule_payload(self, *, subject_id: str = "stef", updated_at: str) -> dict[str, Any]:
+        """Return a minimal valid continuity capsule payload."""
+        return {
+            "schema_version": "1.0",
+            "subject_kind": "user",
+            "subject_id": subject_id,
+            "updated_at": updated_at,
+            "verified_at": updated_at,
+            "verification_kind": "self_review",
+            "source": {
+                "producer": "handoff-hook",
+                "update_reason": "pre_compaction",
+                "inputs": ["memory/core/identity.md"],
+            },
+            "continuity": {
+                "top_priorities": [f"priority at {updated_at}"],
+                "active_concerns": [f"concern at {updated_at}"],
+                "active_constraints": [f"constraint at {updated_at}"],
+                "open_loops": [f"loop at {updated_at}"],
+                "stance_summary": f"stance at {updated_at}",
+                "drift_signals": [],
+            },
+            "confidence": {"continuity": 0.82, "relationship_model": 0.0},
+            "freshness": {"freshness_class": "situational"},
+        }
+
+    def _signals(self, *, observed_at: str) -> list[dict[str, str]]:
+        """Return one strong verification signal list for revalidate tests."""
+        return [
+            {
+                "kind": "system_check",
+                "source_ref": "memory/logs/system-check.json",
+                "observed_at": observed_at,
+                "summary": "System check passed.",
+            }
+        ]
+
+    def _write_active(self, repo_root: Path, payload: dict[str, Any]) -> Path:
+        """Write one active capsule directly to disk."""
+        path = repo_root / "memory" / "continuity" / f"user-{payload['subject_id']}.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return path
+
+    def _read_active(self, repo_root: Path, *, subject_id: str = "stef") -> dict[str, Any]:
+        """Load one active capsule payload from disk."""
+        path = repo_root / "memory" / "continuity" / f"user-{subject_id}.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def _run_thread(self, target: Any) -> tuple[threading.Thread, dict[str, Any], dict[str, BaseException]]:
+        """Start one worker thread and capture exactly one result or exception."""
+        result: dict[str, Any] = {}
+        error: dict[str, BaseException] = {}
+
+        def runner() -> None:
+            try:
+                result["value"] = target()
+            except BaseException as exc:  # noqa: BLE001 - tests capture service failures directly
+                error["value"] = exc
+
+        thread = threading.Thread(target=runner)
+        thread.start()
+        return thread, result, error
+
+    def test_failed_upsert_cannot_rollback_over_later_successful_upsert(self) -> None:
+        """A failed upsert must not restore stale bytes after a newer upsert commits."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            gm = _ControlledGitManager()
+            auth = AllowAllAuthStub()
+            base = self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:00:00Z")
+            self._write_active(repo_root, base)
+            entered_a, release_a = gm.control_file_commit("continuity: concurrent A", fail_with=RuntimeError("boom A"))
+            entered_b, release_b = gm.control_file_commit("continuity: concurrent B")
+
+            upsert_a = ContinuityUpsertRequest(
+                subject_kind="user",
+                subject_id="stef",
+                capsule=self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:01:00Z"),
+                commit_message="continuity: concurrent A",
+            )
+            upsert_b = ContinuityUpsertRequest(
+                subject_kind="user",
+                subject_id="stef",
+                capsule=self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:02:00Z"),
+                commit_message="continuity: concurrent B",
+            )
+
+            thread_a, _result_a, error_a = self._run_thread(
+                lambda: continuity_upsert_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=upsert_a,
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertTrue(entered_a.wait(timeout=5))
+            thread_b, result_b, error_b = self._run_thread(
+                lambda: continuity_upsert_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=upsert_b,
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertFalse(entered_b.wait(timeout=0.2))
+            release_a.set()
+            self.assertTrue(entered_b.wait(timeout=5))
+            release_b.set()
+            thread_a.join(timeout=5)
+            thread_b.join(timeout=5)
+
+            self.assertIn("value", error_a)
+            self.assertNotIn("value", error_b)
+            self.assertTrue(result_b["value"]["ok"])
+            active = self._read_active(repo_root)
+            self.assertEqual(active["updated_at"], "2026-03-18T10:02:00Z")
+            self.assertEqual(active["continuity"]["top_priorities"], ["priority at 2026-03-18T10:02:00Z"])
+
+    def test_failed_upsert_cannot_rollback_over_later_revalidate(self) -> None:
+        """A failed upsert must not erase a later same-subject revalidate result."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            gm = _ControlledGitManager()
+            auth = AllowAllAuthStub()
+            base = self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:00:00Z")
+            self._write_active(repo_root, base)
+            entered_upsert, release_upsert = gm.control_file_commit(
+                "continuity: concurrent upsert", fail_with=RuntimeError("boom upsert")
+            )
+            entered_revalidate, release_revalidate = gm.control_file_commit("continuity: revalidate user stef")
+
+            upsert_req = ContinuityUpsertRequest(
+                subject_kind="user",
+                subject_id="stef",
+                capsule=self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:01:00Z"),
+                commit_message="continuity: concurrent upsert",
+            )
+            revalidate_req = ContinuityRevalidateRequest(
+                subject_kind="user",
+                subject_id="stef",
+                outcome="confirm",
+                signals=self._signals(observed_at="2026-03-18T10:02:00Z"),
+            )
+
+            thread_upsert, _upsert_result, upsert_error = self._run_thread(
+                lambda: continuity_upsert_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=upsert_req,
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertTrue(entered_upsert.wait(timeout=5))
+            thread_revalidate, revalidate_result, revalidate_error = self._run_thread(
+                lambda: continuity_revalidate_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=revalidate_req,
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertFalse(entered_revalidate.wait(timeout=0.2))
+            release_upsert.set()
+            self.assertTrue(entered_revalidate.wait(timeout=5))
+            release_revalidate.set()
+            thread_upsert.join(timeout=5)
+            thread_revalidate.join(timeout=5)
+
+            self.assertIn("value", upsert_error)
+            self.assertNotIn("value", revalidate_error)
+            self.assertEqual(revalidate_result["value"]["outcome"], "confirm")
+            active = self._read_active(repo_root)
+            self.assertEqual(active["verification_state"]["status"], "system_confirmed")
+            self.assertEqual(active["capsule_health"]["status"], "healthy")
+
+    def test_failed_archive_cannot_rollback_over_later_upsert(self) -> None:
+        """A failed archive must not restore stale bytes after a later upsert succeeds."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            gm = _ControlledGitManager()
+            auth = AllowAllAuthStub()
+            base = self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:00:00Z")
+            self._write_active(repo_root, base)
+            entered_archive, release_archive = gm.control_path_commit(
+                "continuity: archive user stef", fail_with=RuntimeError("boom archive")
+            )
+            entered_upsert, release_upsert = gm.control_file_commit("continuity: after archive")
+
+            archive_req = ContinuityArchiveRequest(subject_kind="user", subject_id="stef", reason="cleanup")
+            upsert_req = ContinuityUpsertRequest(
+                subject_kind="user",
+                subject_id="stef",
+                capsule=self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:03:00Z"),
+                commit_message="continuity: after archive",
+            )
+
+            thread_archive, _archive_result, archive_error = self._run_thread(
+                lambda: continuity_archive_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=archive_req,
+                    now=datetime(2026, 3, 18, 10, 1, tzinfo=timezone.utc),
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertTrue(entered_archive.wait(timeout=5))
+            thread_upsert, upsert_result, upsert_error = self._run_thread(
+                lambda: continuity_upsert_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=upsert_req,
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertFalse(entered_upsert.wait(timeout=0.2))
+            release_archive.set()
+            self.assertTrue(entered_upsert.wait(timeout=5))
+            release_upsert.set()
+            thread_archive.join(timeout=5)
+            thread_upsert.join(timeout=5)
+
+            self.assertIn("value", archive_error)
+            self.assertNotIn("value", upsert_error)
+            self.assertTrue(upsert_result["value"]["ok"])
+            active = self._read_active(repo_root)
+            self.assertEqual(active["updated_at"], "2026-03-18T10:03:00Z")
+            archive_dir = repo_root / "memory" / "continuity" / "archive"
+            archived = list(archive_dir.glob("user-stef-*.json")) if archive_dir.exists() else []
+            self.assertEqual(archived, [])
+
+    def test_failed_delete_cannot_rollback_over_later_upsert(self) -> None:
+        """A failed delete must not restore stale bytes after a later upsert succeeds."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            gm = _ControlledGitManager()
+            auth = AllowAllAuthStub()
+            base = self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:00:00Z")
+            self._write_active(repo_root, base)
+            entered_delete, release_delete = gm.control_path_commit(
+                "continuity: delete user stef - cleanup", fail_with=RuntimeError("boom delete")
+            )
+            entered_upsert, release_upsert = gm.control_file_commit("continuity: after delete")
+
+            delete_req = ContinuityDeleteRequest(
+                subject_kind="user",
+                subject_id="stef",
+                delete_active=True,
+                reason="cleanup",
+            )
+            upsert_req = ContinuityUpsertRequest(
+                subject_kind="user",
+                subject_id="stef",
+                capsule=self._capsule_payload(subject_id="stef", updated_at="2026-03-18T10:04:00Z"),
+                commit_message="continuity: after delete",
+            )
+
+            thread_delete, _delete_result, delete_error = self._run_thread(
+                lambda: continuity_delete_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=delete_req,
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertTrue(entered_delete.wait(timeout=5))
+            thread_upsert, upsert_result, upsert_error = self._run_thread(
+                lambda: continuity_upsert_service(
+                    repo_root=repo_root,
+                    gm=gm,
+                    auth=auth,
+                    req=upsert_req,
+                    audit=lambda *_args: None,
+                )
+            )
+            self.assertFalse(entered_upsert.wait(timeout=0.2))
+            release_delete.set()
+            self.assertTrue(entered_upsert.wait(timeout=5))
+            release_upsert.set()
+            thread_delete.join(timeout=5)
+            thread_upsert.join(timeout=5)
+
+            self.assertIn("value", delete_error)
+            self.assertNotIn("value", upsert_error)
+            self.assertTrue(upsert_result["value"]["ok"])
+            active = self._read_active(repo_root)
+            self.assertEqual(active["updated_at"], "2026-03-18T10:04:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #97

## Summary
- serialize same-subject continuity mutations across upsert, revalidate, archive, and delete
- reuse the existing advisory lock primitive with a continuity subject lock id
- add concurrency regressions for stale rollback overwrite scenarios

## Verification
- ./.venv/bin/python -m ruff check app tests tools_hash_token.py
- ./.venv/bin/python -m unittest tests.test_continuity_97_locking -v
- ./.venv/bin/python -m unittest tests.test_continuity_v1 tests.test_continuity_v2_phase4 tests.test_continuity_v3_phase3 tests.test_continuity_phase4_phase1 tests.test_continuity_phase4_phase3 -v
- ./.venv/bin/python -m unittest discover -s tests -v
