### PR TITLE
Bound raw-scan fallback candidate selection

### DIFF
--- a/app/context/service.py
+++ b/app/context/service.py
@@ -7,6 +7,7 @@ import logging
 import re
 import subprocess
 from datetime import datetime, timezone
+from heapq import nsmallest
 from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
@@ -44,6 +45,7 @@ _PRIMARY_INDEX_ARTIFACTS = (
     "index/search.db",
     "index/index_state.json",
 )
+_RAW_SCAN_CANDIDATE_LIMIT = 200
 
 
 def _filter_search_results_for_auth(results: list[dict[str, Any]], auth: AuthContext) -> list[dict[str, Any]]:
@@ -295,9 +297,19 @@ def _task_terms(task: str) -> list[str]:
     return out
 
 
+def _select_top_raw_scan_candidates(
+    candidates: list[tuple[float, str, Any]],
+    limit: int = _RAW_SCAN_CANDIDATE_LIMIT,
+) -> list[tuple[float, str, Any]]:
+    """Keep a deterministic bounded recent slice without sorting the full population."""
+    if limit <= 0:
+        return []
+    return nsmallest(limit, candidates)
+
+
 def _raw_scan_candidate_paths(repo_root: Path) -> list[tuple[Path, float]]:
     """Enumerate deterministic raw-scan candidates using indexer eligibility rules."""
-    candidates: list[tuple[float, str, Path, float]] = []
+    candidates: list[tuple[float, str, tuple[Path, float]]] = []
     for path in repo_root.rglob("*"):
         if not path.is_file():
             continue
@@ -320,9 +332,9 @@ def _raw_scan_candidate_paths(repo_root: Path) -> list[tuple[Path, float]]:
             stat = path.stat()
         except Exception:
             continue
-        candidates.append((-stat.st_mtime, str(rel_path), path, stat.st_mtime))
-    candidates.sort()
-    return [(item[2], item[3]) for item in candidates[:200]]
+        candidates.append((-stat.st_mtime, str(rel_path), (path, stat.st_mtime)))
+    selected = _select_top_raw_scan_candidates(candidates)
+    return [item[2] for item in selected]
 
 
 def _raw_scan_recent_relevant(

--- a/tests/test_context_retrieval.py
+++ b/tests/test_context_retrieval.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from app.config import Settings
+from app.context.service import _select_top_raw_scan_candidates
 from app.indexer import rebuild_index
 from app.main import context_retrieve, recent_list, search
 from app.models import ContextRetrieveRequest, RecentRequest, SearchRequest
@@ -50,6 +51,26 @@ class TestContextRetrieval(unittest.TestCase):
             git_author_email="n/a",
             tokens={},
             audit_log_enabled=False,
+        )
+
+    def test_select_top_raw_scan_candidates_keeps_recent_paths_deterministically(self) -> None:
+        """Raw-scan candidate selection should keep only the most recent deterministic slice."""
+        candidates = [
+            (-10.0, "journal/2026/2026-03-10.md", "older"),
+            (-30.0, "messages/threads/thread-3.jsonl", "newest"),
+            (-20.0, "messages/threads/thread-2.jsonl", "middle"),
+            (-20.0, "journal/2026/2026-03-20.md", "middle-tiebreak"),
+        ]
+
+        selected = _select_top_raw_scan_candidates(candidates, limit=3)
+
+        self.assertEqual(
+            selected,
+            [
+                (-30.0, "messages/threads/thread-3.jsonl", "newest"),
+                (-20.0, "journal/2026/2026-03-20.md", "middle-tiebreak"),
+                (-20.0, "messages/threads/thread-2.jsonl", "middle"),
+            ],
         )
 
     def test_search_recent_orders_only_matching_results(self) -> None:


### PR DESCRIPTION
## Summary
- bound raw-scan candidate selection to the top deterministic 200 paths instead of sorting the full candidate population
- preserve existing fallback ordering and auth behavior while reducing degraded-mode selection work
- add regression coverage for deterministic bounded candidate selection

Closes #104

## Verification
- ./.venv/bin/python -m ruff check app tests tools_hash_token.py
- ./.venv/bin/python -m unittest discover -s tests -v