### PR TITLE
Fix Stage D cross-namespace lifecycle concurrency findings (F1-F9)

### DIFF
--- a/app/artifact_lifecycle/service.py
+++ b/app/artifact_lifecycle/service.py
@@ -27,6 +27,11 @@ from fastapi import HTTPException
 from app.auth import AuthContext
 from app.coordination.locking import artifact_lock
 from app.git_safety import try_commit_paths
+from app.segment_history.locking import (
+    LockInfrastructureError,
+    SegmentHistoryLockTimeout,
+    segment_history_source_lock,
+)
 from app.storage import safe_path, write_bytes_file, write_text_file
 
 _logger = logging.getLogger(__name__)
@@ -922,24 +927,29 @@ def _externalize_selected_family(
                     warnings.append(f"{family}_hot_changed:{artifact_id}")
                     return
 
-                _, payload_rel, stub_rel, payload, stub = _externalize_single_artifact(
-                    repo_root=repo_root,
-                    family=family,
-                    schema_type=schema_type,
-                    artifact_id=artifact_id,
-                    source_rel=row["source_rel"],
-                    artifact=row["artifact"],
-                    summary=row["summary"],
-                    history_dir_rel=history_dir_rel,
-                    cut_at=row["cut_at"],
-                    reserved_ids=reserved_ids,
-                )
-                if not _write_pair_exclusive(
-                    safe_path(repo_root, payload_rel), payload,
-                    safe_path(repo_root, stub_rel), stub,
-                ):
-                    warnings.append(f"{collision_warning_prefix}:{artifact_id}")
-                    return
+                # Retry on O_EXCL collision (concurrent ID allocation)
+                _max_ext_retries = 3
+                for _ext_attempt in range(_max_ext_retries):
+                    _, payload_rel, stub_rel, payload, stub = _externalize_single_artifact(
+                        repo_root=repo_root,
+                        family=family,
+                        schema_type=schema_type,
+                        artifact_id=artifact_id,
+                        source_rel=row["source_rel"],
+                        artifact=row["artifact"],
+                        summary=row["summary"],
+                        history_dir_rel=history_dir_rel,
+                        cut_at=row["cut_at"],
+                        reserved_ids=reserved_ids,
+                    )
+                    if _write_pair_exclusive(
+                        safe_path(repo_root, payload_rel), payload,
+                        safe_path(repo_root, stub_rel), stub,
+                    ):
+                        break
+                    if _ext_attempt == _max_ext_retries - 1:
+                        warnings.append(f"{collision_warning_prefix}:{artifact_id}")
+                        return
                 if current_path.resolve() not in rollback_seen:
                     rollback_seen.add(current_path.resolve())
                     rollback_plan.append((current_path, current_bytes))
@@ -1174,42 +1184,53 @@ def artifact_history_cold_store_service(
     auth.require_write_path(stub_rel)
     auth.require_write_path(cold_storage_path)
 
-    payload = _load_artifact_history_payload(repo_root, source_payload_path)
-    stub = _load_artifact_history_stub(repo_root, stub_rel)
-    if stub.get("payload_path") != source_payload_path:
-        raise HTTPException(status_code=409, detail="Artifact-history stub does not point at the hot payload")
-    if stub.get("summary") != payload.get("summary") or stub.get("source_path") != payload.get("source_path"):
-        raise HTTPException(status_code=400, detail="Artifact-history stub does not match payload")
-    source_bytes = hot_payload_path.read_bytes()
-    if cold_payload_path.exists():
-        raise HTTPException(status_code=409, detail="Artifact-history cold payload already exists")
-
+    # Serialize concurrent cold-store/rehydrate operations on the same payload
+    lock_key = f"artifact_history_cold:{source_payload_path}"
+    lock_dir = repo_root / ".locks"
     try:
-        gzip_bytes = gzip.compress(source_bytes, mtime=0)
-        write_bytes_file(cold_payload_path, gzip_bytes)
-        updated_stub = dict(stub)
-        updated_stub["payload_path"] = cold_storage_path
-        _write_json(safe_path(repo_root, stub_rel), updated_stub)
-        hot_payload_path.unlink()
-        committed = bool(gm and try_commit_paths(
-            paths=[cold_payload_path, safe_path(repo_root, stub_rel), hot_payload_path],
-            gm=gm,
-            commit_message=f"artifact-history: cold-store {family} {payload['history_id']}",
-        ))
-        if gm is not None and not committed:
-            raise RuntimeError("Artifact-history cold-store commit produced no changes")
-    except Exception as exc:
-        cleanup_errors = _restore_failed_artifact_history_cold_store(
-            source_payload_path=hot_payload_path,
-            source_payload_bytes=source_bytes,
-            cold_payload_path=cold_payload_path,
-            stub_path=safe_path(repo_root, stub_rel),
-            original_stub=stub,
-        )
-        detail = f"Artifact-history cold-store failed: {exc}"
-        if cleanup_errors:
-            detail += f"; rollback failed for {', '.join(cleanup_errors)}"
-        raise HTTPException(status_code=500, detail=detail) from exc
+        lock_ctx = segment_history_source_lock(lock_key, lock_dir=lock_dir)
+    except LockInfrastructureError as exc:
+        raise HTTPException(status_code=503, detail="Artifact-history cold-store lock unavailable; retry") from exc
+    try:
+        with lock_ctx:
+            payload = _load_artifact_history_payload(repo_root, source_payload_path)
+            stub = _load_artifact_history_stub(repo_root, stub_rel)
+            if stub.get("payload_path") != source_payload_path:
+                raise HTTPException(status_code=409, detail="Artifact-history stub does not point at the hot payload")
+            if stub.get("summary") != payload.get("summary") or stub.get("source_path") != payload.get("source_path"):
+                raise HTTPException(status_code=400, detail="Artifact-history stub does not match payload")
+            source_bytes = hot_payload_path.read_bytes()
+            if cold_payload_path.exists():
+                raise HTTPException(status_code=409, detail="Artifact-history cold payload already exists")
+
+            try:
+                gzip_bytes = gzip.compress(source_bytes, mtime=0)
+                write_bytes_file(cold_payload_path, gzip_bytes)
+                updated_stub = dict(stub)
+                updated_stub["payload_path"] = cold_storage_path
+                _write_json(safe_path(repo_root, stub_rel), updated_stub)
+                hot_payload_path.unlink()
+                committed = bool(gm and try_commit_paths(
+                    paths=[cold_payload_path, safe_path(repo_root, stub_rel), hot_payload_path],
+                    gm=gm,
+                    commit_message=f"artifact-history: cold-store {family} {payload['history_id']}",
+                ))
+                if gm is not None and not committed:
+                    raise RuntimeError("Artifact-history cold-store commit produced no changes")
+            except Exception as exc:
+                cleanup_errors = _restore_failed_artifact_history_cold_store(
+                    source_payload_path=hot_payload_path,
+                    source_payload_bytes=source_bytes,
+                    cold_payload_path=cold_payload_path,
+                    stub_path=safe_path(repo_root, stub_rel),
+                    original_stub=stub,
+                )
+                detail = f"Artifact-history cold-store failed: {exc}"
+                if cleanup_errors:
+                    detail += f"; rollback failed for {', '.join(cleanup_errors)}"
+                raise HTTPException(status_code=500, detail=detail) from exc
+    except SegmentHistoryLockTimeout as exc:
+        raise HTTPException(status_code=503, detail="Artifact-history cold-store lock timed out; retry") from exc
 
     audit(
         auth,
@@ -1263,58 +1284,70 @@ def artifact_history_cold_rehydrate_service(
     stub_path = safe_path(repo_root, cold_stub_path)
     hot_payload_path = safe_path(repo_root, source_payload_path)
     cold_payload_path = safe_path(repo_root, cold_storage_path)
-    if hot_payload_path.exists():
-        raise HTTPException(status_code=409, detail="Artifact-history payload already exists")
-    if not cold_payload_path.exists() or not cold_payload_path.is_file():
-        raise HTTPException(status_code=404, detail="Artifact-history cold payload not found")
-    try:
-        cold_payload_bytes = cold_payload_path.read_bytes()
-        cold_stub_bytes = stub_path.read_bytes()
-        payload_bytes = gzip.decompress(cold_payload_bytes)
-        payload = json.loads(payload_bytes.decode("utf-8"))
-        if not isinstance(payload, dict):
-            raise ValueError("payload is not an object")
-        if payload.get("history_id") != Path(source_payload_path).stem:
-            raise ValueError("history_id mismatch")
-        if payload.get("summary") != stub.get("summary") or payload.get("source_path") != stub.get("source_path"):
-            raise ValueError("stub/payload mismatch")
-        _load_artifact_history_payload_from_dict(payload=payload, payload_rel=source_payload_path)
-    except HTTPException:
-        raise
-    except Exception as exc:
-        raise HTTPException(status_code=400, detail=f"Invalid artifact-history cold payload: {exc}") from exc
 
-    updated_stub = dict(stub)
-    updated_stub["payload_path"] = source_payload_path
+    # Serialize concurrent cold-store/rehydrate operations on the same payload
+    lock_key = f"artifact_history_cold:{source_payload_path}"
+    lock_dir = repo_root / ".locks"
     try:
-        write_bytes_file(hot_payload_path, payload_bytes)
-        _write_json(stub_path, updated_stub)
-        cold_payload_path.unlink()
-        committed = bool(gm and try_commit_paths(
-            paths=[hot_payload_path, stub_path, cold_payload_path],
-            gm=gm,
-            commit_message=f"artifact-history: cold-rehydrate {payload['family']} {payload['history_id']}",
-        ))
-        if gm is not None and not committed:
-            raise RuntimeError("Artifact-history cold rehydrate commit produced no changes")
-    except Exception as exc:
-        rollback_errors: list[str] = []
-        try:
-            hot_payload_path.unlink(missing_ok=True)
-        except Exception as rollback_exc:
-            rollback_errors.append(f"remove restored payload: {rollback_exc}")
-        try:
-            write_bytes_file(cold_payload_path, cold_payload_bytes)
-        except Exception as rollback_exc:
-            rollback_errors.append(f"restore cold payload: {rollback_exc}")
-        try:
-            write_bytes_file(stub_path, cold_stub_bytes)
-        except Exception as rollback_exc:
-            rollback_errors.append(f"restore cold stub: {rollback_exc}")
-        detail = f"Artifact-history cold rehydrate failed: {exc}"
-        if rollback_errors:
-            detail += f"; rollback failed for {', '.join(rollback_errors)}"
-        raise HTTPException(status_code=500, detail=detail) from exc
+        lock_ctx = segment_history_source_lock(lock_key, lock_dir=lock_dir)
+    except LockInfrastructureError as exc:
+        raise HTTPException(status_code=503, detail="Artifact-history cold-rehydrate lock unavailable; retry") from exc
+    try:
+        with lock_ctx:
+            if hot_payload_path.exists():
+                raise HTTPException(status_code=409, detail="Artifact-history payload already exists")
+            if not cold_payload_path.exists() or not cold_payload_path.is_file():
+                raise HTTPException(status_code=404, detail="Artifact-history cold payload not found")
+            try:
+                cold_payload_bytes = cold_payload_path.read_bytes()
+                cold_stub_bytes = stub_path.read_bytes()
+                payload_bytes = gzip.decompress(cold_payload_bytes)
+                payload = json.loads(payload_bytes.decode("utf-8"))
+                if not isinstance(payload, dict):
+                    raise ValueError("payload is not an object")
+                if payload.get("history_id") != Path(source_payload_path).stem:
+                    raise ValueError("history_id mismatch")
+                if payload.get("summary") != stub.get("summary") or payload.get("source_path") != stub.get("source_path"):
+                    raise ValueError("stub/payload mismatch")
+                _load_artifact_history_payload_from_dict(payload=payload, payload_rel=source_payload_path)
+            except HTTPException:
+                raise
+            except Exception as exc:
+                raise HTTPException(status_code=400, detail=f"Invalid artifact-history cold payload: {exc}") from exc
+
+            updated_stub = dict(stub)
+            updated_stub["payload_path"] = source_payload_path
+            try:
+                write_bytes_file(hot_payload_path, payload_bytes)
+                _write_json(stub_path, updated_stub)
+                cold_payload_path.unlink()
+                committed = bool(gm and try_commit_paths(
+                    paths=[hot_payload_path, stub_path, cold_payload_path],
+                    gm=gm,
+                    commit_message=f"artifact-history: cold-rehydrate {payload['family']} {payload['history_id']}",
+                ))
+                if gm is not None and not committed:
+                    raise RuntimeError("Artifact-history cold rehydrate commit produced no changes")
+            except Exception as exc:
+                rollback_errors: list[str] = []
+                try:
+                    hot_payload_path.unlink(missing_ok=True)
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"remove restored payload: {rollback_exc}")
+                try:
+                    write_bytes_file(cold_payload_path, cold_payload_bytes)
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"restore cold payload: {rollback_exc}")
+                try:
+                    write_bytes_file(stub_path, cold_stub_bytes)
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"restore cold stub: {rollback_exc}")
+                detail = f"Artifact-history cold rehydrate failed: {exc}"
+                if rollback_errors:
+                    detail += f"; rollback failed for {', '.join(rollback_errors)}"
+                raise HTTPException(status_code=500, detail=detail) from exc
+    except SegmentHistoryLockTimeout as exc:
+        raise HTTPException(status_code=503, detail="Artifact-history cold-rehydrate lock timed out; retry") from exc
 
     audit(
         auth,

--- a/app/continuity/service.py
+++ b/app/continuity/service.py
@@ -751,7 +751,10 @@ def _persist_fallback_snapshot(
         if old_bytes == new_bytes:
             return fallback_rel, "unchanged", None
         write_text_file(path, canonical)
-        with repository_mutation_lock(repo_root):
+        # Fallback snapshots are defense-in-depth; use a shorter git
+        # lock timeout (15 s) to reduce thread-pool exhaustion risk when
+        # the primary capsule write already consumed the full 60 s budget.
+        with repository_mutation_lock(repo_root, timeout=15.0):
             committed = gm.commit_file(path, f"continuity: update fallback {subject_kind} {subject_id}")
             if not committed:
                 raise RuntimeError("git commit produced no changes")
@@ -2567,12 +2570,12 @@ def continuity_archive_service(
         active_path = safe_path(repo_root, rel)
         active_bytes = active_path.read_bytes()
         write_text_file(archive_path, canonical_json(archive_payload))
-        # The active-path deletion must be staged before the git commit can atomically
-        # record the archive write plus active-file removal. If the commit step fails,
-        # restore the active capsule and discard the archive envelope immediately.
-        active_path.unlink()
+        # Both the archive write and the active-file deletion are performed
+        # inside the git lock so that a process crash before commit cannot
+        # leave the active capsule deleted without a durable archive.
         with repository_mutation_lock(repo_root):
             try:
+                active_path.unlink()
                 committed = gm.commit_paths(
                     [archive_path, active_path],
                     f"continuity: archive {req.subject_kind} {req.subject_id}",
@@ -2688,8 +2691,11 @@ def continuity_cold_store_service(
             )
             write_bytes_file(cold_payload_file, gzip_bytes)
             write_text_file(cold_stub_file, stub_text)
-            archive_path.unlink()
+            # Archive deletion and commit are inside the git lock so that a
+            # process crash before commit cannot leave the archive deleted
+            # without durable cold files.
             with repository_mutation_lock(repo_root):
+                archive_path.unlink()
                 committed = gm.commit_paths(
                     [cold_payload_file, cold_stub_file, archive_path],
                     f"continuity: cold-store {envelope['capsule']['subject_kind']} {envelope['capsule']['subject_id']}",
@@ -2802,9 +2808,12 @@ def continuity_cold_rehydrate_service(
         rehydrated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
         try:
             write_bytes_file(archive_path, archive_bytes)
-            cold_payload_file.unlink()
-            cold_stub_file.unlink()
+            # Cold file deletions and commit are inside the git lock so
+            # that a process crash before commit cannot leave cold files
+            # deleted without a durable rehydrated archive.
             with repository_mutation_lock(repo_root):
+                cold_payload_file.unlink()
+                cold_stub_file.unlink()
                 committed = gm.commit_paths(
                     [archive_path, cold_payload_file, cold_stub_file],
                     f"continuity: cold-rehydrate {capsule['subject_kind']} {capsule['subject_id']}",

--- a/app/coordination/locking.py
+++ b/app/coordination/locking.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import fcntl
 import logging
 import re
+import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -19,6 +20,7 @@ _SAFE_ID = re.compile(r"^[a-z0-9_]+$")
 LOCK_TIMEOUT_SECONDS: float = 30.0
 _LOCK_POLL_INTERVAL: float = 0.05
 
+_lock_dir_ready_guard = threading.Lock()
 _lock_dir_ready: set[str] = set()
 
 
@@ -44,16 +46,21 @@ def purge_stale_lockfiles(lock_dir: Path) -> int:
 
 
 def _ensure_lock_dir(lock_dir: Path) -> None:
-    """Create the lock directory once per unique path, per process lifetime."""
+    """Create the lock directory once per unique path, per process lifetime.
+
+    The check and mkdir are performed under the same guard to prevent
+    two threads from both attempting mkdir on the same path.
+    """
     key = str(lock_dir)
-    if key in _lock_dir_ready:
-        return
-    try:
-        lock_dir.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        _log.error("Cannot create lock directory %s: %s", lock_dir, exc)
-        raise HTTPException(status_code=503, detail="Coordination lock infrastructure unavailable") from exc
-    _lock_dir_ready.add(key)
+    with _lock_dir_ready_guard:
+        if key in _lock_dir_ready:
+            return
+        try:
+            lock_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            _log.error("Cannot create lock directory %s: %s", lock_dir, exc)
+            raise HTTPException(status_code=503, detail="Coordination lock infrastructure unavailable") from exc
+        _lock_dir_ready.add(key)
 
 
 @contextmanager

--- a/app/git_locking.py
+++ b/app/git_locking.py
@@ -63,7 +63,7 @@ def _ensure_lock_dir(lock_dir: Path) -> None:
 
 
 @contextmanager
-def _repo_file_lock(repo_root: Path) -> Generator[None, None, None]:
+def _repo_file_lock(repo_root: Path, *, timeout: float = _GIT_LOCK_TIMEOUT) -> Generator[None, None, None]:
     """Acquire the per-repository advisory file lock."""
     lock_dir = repo_root / ".locks"
     _ensure_lock_dir(lock_dir)
@@ -81,7 +81,7 @@ def _repo_file_lock(repo_root: Path) -> Generator[None, None, None]:
             _log.error("Cannot open git lock file %s after retry: %s", lock_path, exc)
             raise GitLockInfrastructureError(f"Cannot open git lock file {lock_path}: {exc}") from exc
     try:
-        deadline = time.monotonic() + _GIT_LOCK_TIMEOUT
+        deadline = time.monotonic() + timeout
         while True:
             try:
                 fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -90,7 +90,7 @@ def _repo_file_lock(repo_root: Path) -> Generator[None, None, None]:
                 if time.monotonic() >= deadline:
                     lock_file.close()
                     raise GitLockTimeout(
-                        f"Repository mutation lock timed out after {_GIT_LOCK_TIMEOUT}s"
+                        f"Repository mutation lock timed out after {timeout}s"
                     ) from None
                 time.sleep(_GIT_LOCK_POLL)
             except OSError as exc:
@@ -106,8 +106,13 @@ def _repo_file_lock(repo_root: Path) -> Generator[None, None, None]:
 
 
 @contextmanager
-def repository_mutation_lock(repo_root: Path) -> Generator[None, None, None]:
-    """Serialize git-backed mutations for one repository, including nested calls."""
+def repository_mutation_lock(repo_root: Path, *, timeout: float = _GIT_LOCK_TIMEOUT) -> Generator[None, None, None]:
+    """Serialize git-backed mutations for one repository, including nested calls.
+
+    *timeout* controls how long to wait for the underlying file lock.
+    Callers that are defense-in-depth (e.g. fallback snapshot writes) can
+    pass a shorter timeout to avoid thread-pool exhaustion under contention.
+    """
     resolved = repo_root.resolve()
     key = str(resolved)
     depths = getattr(_thread_state, "depths", None)
@@ -128,7 +133,7 @@ def repository_mutation_lock(repo_root: Path) -> Generator[None, None, None]:
                 depths.pop(key, None)
         return
 
-    with _repo_file_lock(resolved):
+    with _repo_file_lock(resolved, timeout=timeout):
         depths[key] = 1
         try:
             yield

--- a/app/maintenance/service.py
+++ b/app/maintenance/service.py
@@ -44,6 +44,7 @@ from app.continuity.service import (
     continuity_rel_path,
 )
 from app.git_safety import safe_commit_paths, try_commit_file, try_commit_paths
+from app.segment_history.locking import acquire_sorted_source_locks, segment_history_source_lock, SegmentHistoryLockTimeout, LockInfrastructureError
 from app.models import BackupCreateRequest, BackupRestoreTestRequest, CompactRequest, ContinuityCapsule, ReplicationPullRequest, ReplicationPushRequest
 from app.registry_lifecycle.service import externalize_superseded_pull, externalize_superseded_push
 from app.storage import canonical_json, read_text_file, safe_path, write_bytes_file, write_text_file
@@ -910,200 +911,208 @@ def replication_pull_service(
     enforce_payload_limit(settings, req.model_dump(), "replication_pull")
     auth.require("admin:peers")
 
-    state = load_replication_state(settings.repo_root)
-    idempotency_key = (req.idempotency_key or "").strip() or None
-    idem_ref = f"{req.source_peer}|{idempotency_key}" if idempotency_key else None
-    if idem_ref:
-        previous = state.get("pull_idempotency", {}).get(idem_ref)
-        if isinstance(previous, dict):
-            return {
-                "ok": True,
-                "idempotent_replay": True,
-                "source_peer": req.source_peer,
-                "received_count": int(previous.get("received_count") or 0),
-                "changed_count": int(previous.get("changed_count") or 0),
-                "deleted_count": int(previous.get("deleted_count") or 0),
-                "conflict_count": int(previous.get("conflict_count") or 0),
-                "skipped_count": int(previous.get("skipped_count") or 0),
-                "committed_files": [],
-                "latest_commit": gm.latest_commit(),
-            }
-
-    committed_files: list[str] = []
-    rollback_plan: list[tuple[Path, bytes | None]] = []
-    seen_paths: set[Path] = set()
-    changed_paths: list[Path] = []
-    changed_rels: list[str] = []
-    changed = 0
-    deleted = 0
-    skipped = 0
-    conflicts = 0
-    tombstones = _load_replication_tombstones(settings.repo_root)
-    tomb_entries = tombstones.setdefault("entries", {})
-    if not isinstance(tomb_entries, dict):
-        tomb_entries = {}
-        tombstones["entries"] = tomb_entries
-
-    def track_change(path: Path, rel: str) -> None:
-        _capture_path_state(path, rollback_plan, seen_paths)
-        if path not in changed_paths:
-            changed_paths.append(path)
-            changed_rels.append(rel)
-
-    now = datetime.now(timezone.utc)
+    _lock_dir = settings.repo_root / ".locks"
     try:
-        for file_row in req.files:
-            top = Path(file_row.path).parts[0] if Path(file_row.path).parts else ""
-            if top not in REPLICATION_ALLOWED_PREFIXES:
-                raise HTTPException(status_code=400, detail=f"Replication path namespace not allowed: {file_row.path}")
-            auth.require_write_path(file_row.path)
+        with acquire_sorted_source_locks(
+            ["registry:replication_state", "registry:replication_tombstones"],
+            lock_dir=_lock_dir,
+        ):
+            state = load_replication_state(settings.repo_root)
+            idempotency_key = (req.idempotency_key or "").strip() or None
+            idem_ref = f"{req.source_peer}|{idempotency_key}" if idempotency_key else None
+            if idem_ref:
+                previous = state.get("pull_idempotency", {}).get(idem_ref)
+                if isinstance(previous, dict):
+                    return {
+                        "ok": True,
+                        "idempotent_replay": True,
+                        "source_peer": req.source_peer,
+                        "received_count": int(previous.get("received_count") or 0),
+                        "changed_count": int(previous.get("changed_count") or 0),
+                        "deleted_count": int(previous.get("deleted_count") or 0),
+                        "conflict_count": int(previous.get("conflict_count") or 0),
+                        "skipped_count": int(previous.get("skipped_count") or 0),
+                        "committed_files": [],
+                        "latest_commit": gm.latest_commit(),
+                    }
 
-            path = safe_path(settings.repo_root, file_row.path)
-            local_exists = path.exists() and path.is_file()
-            local_content = read_text_file(path) if local_exists else None
-            local_epoch = path.stat().st_mtime if local_exists else 0.0
-            remote_epoch = _parse_dt_or_epoch(file_row.modified_at, now.timestamp(), parse_iso=parse_iso)
+            committed_files: list[str] = []
+            rollback_plan: list[tuple[Path, bytes | None]] = []
+            seen_paths: set[Path] = set()
+            changed_paths: list[Path] = []
+            changed_rels: list[str] = []
+            changed = 0
+            deleted = 0
+            skipped = 0
+            conflicts = 0
+            tombstones = _load_replication_tombstones(settings.repo_root)
+            tomb_entries = tombstones.setdefault("entries", {})
+            if not isinstance(tomb_entries, dict):
+                tomb_entries = {}
+                tombstones["entries"] = tomb_entries
 
-            if file_row.deleted:
-                if req.conflict_policy == "target_wins" and local_exists:
-                    conflicts += 1
-                    skipped += 1
-                    continue
-                if req.conflict_policy == "error" and local_exists:
-                    raise HTTPException(status_code=409, detail=f"Replication conflict on delete: {file_row.path}")
+            def track_change(path: Path, rel: str) -> None:
+                _capture_path_state(path, rollback_plan, seen_paths)
+                if path not in changed_paths:
+                    changed_paths.append(path)
+                    changed_rels.append(rel)
 
-                if local_exists:
+            now = datetime.now(timezone.utc)
+            try:
+                for file_row in req.files:
+                    top = Path(file_row.path).parts[0] if Path(file_row.path).parts else ""
+                    if top not in REPLICATION_ALLOWED_PREFIXES:
+                        raise HTTPException(status_code=400, detail=f"Replication path namespace not allowed: {file_row.path}")
+                    auth.require_write_path(file_row.path)
+
+                    path = safe_path(settings.repo_root, file_row.path)
+                    local_exists = path.exists() and path.is_file()
+                    local_content = read_text_file(path) if local_exists else None
+                    local_epoch = path.stat().st_mtime if local_exists else 0.0
+                    remote_epoch = _parse_dt_or_epoch(file_row.modified_at, now.timestamp(), parse_iso=parse_iso)
+
+                    if file_row.deleted:
+                        if req.conflict_policy == "target_wins" and local_exists:
+                            conflicts += 1
+                            skipped += 1
+                            continue
+                        if req.conflict_policy == "error" and local_exists:
+                            raise HTTPException(status_code=409, detail=f"Replication conflict on delete: {file_row.path}")
+
+                        if local_exists:
+                            track_change(path, file_row.path)
+                            try:
+                                path.unlink()
+                                deleted += 1
+                                changed += 1
+                            except Exception as e:
+                                raise HTTPException(status_code=500, detail=f"Failed to delete replicated path {file_row.path}: {e}") from e
+                        else:
+                            skipped += 1
+
+                        tomb_entries[file_row.path] = {
+                            "tombstone_at": file_row.tombstone_at or now.isoformat(),
+                            "source_peer": req.source_peer,
+                            "idempotency_key": idempotency_key,
+                        }
+                        continue
+
+                    if file_row.content is None or file_row.sha256 is None:
+                        raise HTTPException(status_code=400, detail=f"Replication file payload requires content+sha256 for upsert: {file_row.path}")
+                    if _sha256_text(file_row.content) != file_row.sha256:
+                        raise HTTPException(status_code=400, detail=f"Replication sha256 mismatch for {file_row.path}")
+
+                    if req.mode == "upsert" and local_exists and local_content == file_row.content:
+                        skipped += 1
+                        continue
+
+                    should_write = True
+                    if local_exists and local_content != file_row.content:
+                        if req.conflict_policy == "target_wins":
+                            should_write = False
+                            conflicts += 1
+                        elif req.conflict_policy == "error":
+                            raise HTTPException(status_code=409, detail=f"Replication conflict on path: {file_row.path}")
+                        elif req.conflict_policy == "last_write_wins" and remote_epoch < local_epoch:
+                            should_write = False
+                            conflicts += 1
+
+                    if not should_write:
+                        skipped += 1
+                        continue
+
                     track_change(path, file_row.path)
-                    try:
-                        path.unlink()
-                        deleted += 1
-                        changed += 1
-                    except Exception as e:
-                        raise HTTPException(status_code=500, detail=f"Failed to delete replicated path {file_row.path}: {e}") from e
-                else:
-                    skipped += 1
+                    write_text_file(path, file_row.content)
+                    changed += 1
+                    tomb_entries.pop(file_row.path, None)
 
-                tomb_entries[file_row.path] = {
-                    "tombstone_at": file_row.tombstone_at or now.isoformat(),
-                    "source_peer": req.source_peer,
+                # Synchronous pre-write capture per #112: externalize superseded pull row
+                _pull_history_extra: list[str] = []
+                pull_by_source = state.setdefault("last_pull_by_source", {})
+                previous_pull = pull_by_source.get(req.source_peer)
+                if isinstance(previous_pull, dict) and previous_pull:
+                    try:
+                        ext_result = externalize_superseded_pull(
+                            repo_root=settings.repo_root,
+                            now=now,
+                            source_peer=req.source_peer,
+                            previous_row=previous_pull,
+                            hot_retention_days=int(getattr(settings, "replication_history_hot_retention_days", 14)),
+                        )
+                        if ext_result:
+                            _pull_history_extra.extend([ext_result["shard_path"], ext_result["stub_path"]])
+                            # Update history_meta per #112
+                            hm = state.setdefault("history_meta", {})
+                            if not isinstance(hm, dict):
+                                hm = {}
+                                state["history_meta"] = hm
+                            rs = hm.setdefault("replication_state", {})
+                            if not isinstance(rs, dict):
+                                rs = {}
+                                hm["replication_state"] = rs
+                            rs["last_cut_at"] = now.isoformat()
+                            rs["last_cut_pull_count"] = rs.get("last_cut_pull_count", 0) + 1 if isinstance(rs.get("last_cut_pull_count"), int) else 1
+                    except Exception:
+                        _logger.error(
+                            "Failed to externalize superseded pull row for %s; row data will be lost on overwrite: %s",
+                            req.source_peer,
+                            json.dumps(previous_pull, ensure_ascii=False, default=str),
+                            exc_info=True,
+                        )
+
+                pull_by_source[req.source_peer] = {
+                    "pulled_at": now.isoformat(),
+                    "received_count": len(req.files),
+                    "changed_count": changed,
+                    "deleted_count": deleted,
+                    "conflict_count": conflicts,
+                    "mode": req.mode,
+                    "conflict_policy": req.conflict_policy,
                     "idempotency_key": idempotency_key,
                 }
-                continue
+                if idem_ref:
+                    pull_map = state.setdefault("pull_idempotency", {})
+                    if not isinstance(pull_map, dict):
+                        pull_map = {}
+                        state["pull_idempotency"] = pull_map
+                    pull_map[idem_ref] = {
+                        "at": now.isoformat(),
+                        "received_count": len(req.files),
+                        "changed_count": changed,
+                        "deleted_count": deleted,
+                        "conflict_count": conflicts,
+                        "skipped_count": skipped,
+                    }
 
-            if file_row.content is None or file_row.sha256 is None:
-                raise HTTPException(status_code=400, detail=f"Replication file payload requires content+sha256 for upsert: {file_row.path}")
-            if _sha256_text(file_row.content) != file_row.sha256:
-                raise HTTPException(status_code=400, detail=f"Replication sha256 mismatch for {file_row.path}")
+                tomb_path = safe_path(settings.repo_root, REPLICATION_TOMBSTONES_REL)
+                track_change(tomb_path, REPLICATION_TOMBSTONES_REL)
+                _write_replication_tombstones(settings.repo_root, tombstones)
 
-            if req.mode == "upsert" and local_exists and local_content == file_row.content:
-                skipped += 1
-                continue
+                # Track history shard/stub paths for rollback if head write fails.
+                # These files were just created by externalize_superseded_pull, so we
+                # record them with prior bytes=None so rollback *deletes* them rather
+                # than restoring the new content (which would orphan shards the head
+                # no longer references).
+                for extra_rel in _pull_history_extra:
+                    extra_path = safe_path(settings.repo_root, extra_rel)
+                    resolved = extra_path.resolve()
+                    if resolved not in seen_paths:
+                        seen_paths.add(resolved)
+                        rollback_plan.append((extra_path, None))
+                    if extra_path not in changed_paths:
+                        changed_paths.append(extra_path)
+                        changed_rels.append(extra_rel)
 
-            should_write = True
-            if local_exists and local_content != file_row.content:
-                if req.conflict_policy == "target_wins":
-                    should_write = False
-                    conflicts += 1
-                elif req.conflict_policy == "error":
-                    raise HTTPException(status_code=409, detail=f"Replication conflict on path: {file_row.path}")
-                elif req.conflict_policy == "last_write_wins" and remote_epoch < local_epoch:
-                    should_write = False
-                    conflicts += 1
-
-            if not should_write:
-                skipped += 1
-                continue
-
-            track_change(path, file_row.path)
-            write_text_file(path, file_row.content)
-            changed += 1
-            tomb_entries.pop(file_row.path, None)
-
-        # Synchronous pre-write capture per #112: externalize superseded pull row
-        _pull_history_extra: list[str] = []
-        pull_by_source = state.setdefault("last_pull_by_source", {})
-        previous_pull = pull_by_source.get(req.source_peer)
-        if isinstance(previous_pull, dict) and previous_pull:
-            try:
-                ext_result = externalize_superseded_pull(
-                    repo_root=settings.repo_root,
-                    now=now,
-                    source_peer=req.source_peer,
-                    previous_row=previous_pull,
-                    hot_retention_days=int(getattr(settings, "replication_history_hot_retention_days", 14)),
-                )
-                if ext_result:
-                    _pull_history_extra.extend([ext_result["shard_path"], ext_result["stub_path"]])
-                    # Update history_meta per #112
-                    hm = state.setdefault("history_meta", {})
-                    if not isinstance(hm, dict):
-                        hm = {}
-                        state["history_meta"] = hm
-                    rs = hm.setdefault("replication_state", {})
-                    if not isinstance(rs, dict):
-                        rs = {}
-                        hm["replication_state"] = rs
-                    rs["last_cut_at"] = now.isoformat()
-                    rs["last_cut_pull_count"] = rs.get("last_cut_pull_count", 0) + 1 if isinstance(rs.get("last_cut_pull_count"), int) else 1
-            except Exception:
-                _logger.error(
-                    "Failed to externalize superseded pull row for %s; row data will be lost on overwrite: %s",
-                    req.source_peer,
-                    json.dumps(previous_pull, ensure_ascii=False, default=str),
-                    exc_info=True,
-                )
-
-        pull_by_source[req.source_peer] = {
-            "pulled_at": now.isoformat(),
-            "received_count": len(req.files),
-            "changed_count": changed,
-            "deleted_count": deleted,
-            "conflict_count": conflicts,
-            "mode": req.mode,
-            "conflict_policy": req.conflict_policy,
-            "idempotency_key": idempotency_key,
-        }
-        if idem_ref:
-            pull_map = state.setdefault("pull_idempotency", {})
-            if not isinstance(pull_map, dict):
-                pull_map = {}
-                state["pull_idempotency"] = pull_map
-            pull_map[idem_ref] = {
-                "at": now.isoformat(),
-                "received_count": len(req.files),
-                "changed_count": changed,
-                "deleted_count": deleted,
-                "conflict_count": conflicts,
-                "skipped_count": skipped,
-            }
-
-        tomb_path = safe_path(settings.repo_root, REPLICATION_TOMBSTONES_REL)
-        track_change(tomb_path, REPLICATION_TOMBSTONES_REL)
-        _write_replication_tombstones(settings.repo_root, tombstones)
-
-        # Track history shard/stub paths for rollback if head write fails.
-        # These files were just created by externalize_superseded_pull, so we
-        # record them with prior bytes=None so rollback *deletes* them rather
-        # than restoring the new content (which would orphan shards the head
-        # no longer references).
-        for extra_rel in _pull_history_extra:
-            extra_path = safe_path(settings.repo_root, extra_rel)
-            resolved = extra_path.resolve()
-            if resolved not in seen_paths:
-                seen_paths.add(resolved)
-                rollback_plan.append((extra_path, None))
-            if extra_path not in changed_paths:
-                changed_paths.append(extra_path)
-                changed_rels.append(extra_rel)
-
-        state_path = safe_path(settings.repo_root, REPLICATION_STATE_REL)
-        track_change(state_path, REPLICATION_STATE_REL)
-        _write_replication_state(settings.repo_root, state)
-    except Exception as exc:
-        _restore_rollback_plan(rollback_plan)
-        if isinstance(exc, HTTPException):
-            raise
-        raise HTTPException(status_code=500, detail=f"Failed replication pull write for {req.source_peer}: {exc}") from exc
+                state_path = safe_path(settings.repo_root, REPLICATION_STATE_REL)
+                track_change(state_path, REPLICATION_STATE_REL)
+                _write_replication_state(settings.repo_root, state)
+            except Exception as exc:
+                _restore_rollback_plan(rollback_plan)
+                if isinstance(exc, HTTPException):
+                    raise
+                raise HTTPException(status_code=500, detail=f"Failed replication pull write for {req.source_peer}: {exc}") from exc
+    except (SegmentHistoryLockTimeout, LockInfrastructureError) as lock_exc:
+        raise HTTPException(status_code=503, detail="Replication state lock unavailable; retry") from lock_exc
 
     if safe_commit_paths(
         rollback_plan=rollback_plan,
@@ -1228,58 +1237,63 @@ def replication_push_service(
         raise HTTPException(status_code=502, detail=f"Failed replication push: {e}") from e
 
     auth.require_write_path(REPLICATION_STATE_REL)
-    state = load_replication_state(settings.repo_root)
-
-    # Synchronous pre-write capture per #112: externalize superseded push row
-    push_now = datetime.now(timezone.utc)  # single timestamp for shard cut_at and state pushed_at
-    _history_extra_paths: list[str] = []
-    previous_push = state.get("last_push")
-    if isinstance(previous_push, dict) and previous_push:
-        try:
-            ext_result = externalize_superseded_push(
-                repo_root=settings.repo_root,
-                now=push_now,
-                previous_row=previous_push,
-                hot_retention_days=int(getattr(settings, "replication_history_hot_retention_days", 14)),
-            )
-            if ext_result:
-                _history_extra_paths.extend([ext_result["shard_path"], ext_result["stub_path"]])
-                # Update history_meta per #112
-                hm = state.setdefault("history_meta", {})
-                if not isinstance(hm, dict):
-                    hm = {}
-                    state["history_meta"] = hm
-                rs = hm.setdefault("replication_state", {})
-                if not isinstance(rs, dict):
-                    rs = {}
-                    hm["replication_state"] = rs
-                rs["last_cut_at"] = push_now.isoformat()
-                rs["last_cut_push_count"] = rs.get("last_cut_push_count", 0) + 1 if isinstance(rs.get("last_cut_push_count"), int) else 1
-        except Exception:
-            _logger.error(
-                "Failed to externalize superseded push row; row data will be lost on overwrite: %s",
-                json.dumps(previous_push, ensure_ascii=False, default=str),
-                exc_info=True,
-            )
-
-    state["last_push"] = {
-        "pushed_at": push_now.isoformat(),
-        "target_url": target_url,
-        "file_count": len(files),
-        "by_prefix": by_prefix,
-        "idempotency_key": push_id,
-        "conflict_policy": req.conflict_policy,
-        "include_deleted": req.include_deleted,
-    }
-    committed_files = []
+    _push_lock_dir = settings.repo_root / ".locks"
     try:
-        state_path = _write_replication_state(settings.repo_root, state)
-    except Exception:
-        # Clean up shard/stub files created by externalize_superseded_push
-        # to avoid orphaned shards the head doesn't reference.
-        for p in _history_extra_paths:
-            safe_path(settings.repo_root, p).unlink(missing_ok=True)
-        raise
+        with segment_history_source_lock("registry:replication_state", lock_dir=_push_lock_dir):
+            state = load_replication_state(settings.repo_root)
+
+            # Synchronous pre-write capture per #112: externalize superseded push row
+            push_now = datetime.now(timezone.utc)  # single timestamp for shard cut_at and state pushed_at
+            _history_extra_paths: list[str] = []
+            previous_push = state.get("last_push")
+            if isinstance(previous_push, dict) and previous_push:
+                try:
+                    ext_result = externalize_superseded_push(
+                        repo_root=settings.repo_root,
+                        now=push_now,
+                        previous_row=previous_push,
+                        hot_retention_days=int(getattr(settings, "replication_history_hot_retention_days", 14)),
+                    )
+                    if ext_result:
+                        _history_extra_paths.extend([ext_result["shard_path"], ext_result["stub_path"]])
+                        # Update history_meta per #112
+                        hm = state.setdefault("history_meta", {})
+                        if not isinstance(hm, dict):
+                            hm = {}
+                            state["history_meta"] = hm
+                        rs = hm.setdefault("replication_state", {})
+                        if not isinstance(rs, dict):
+                            rs = {}
+                            hm["replication_state"] = rs
+                        rs["last_cut_at"] = push_now.isoformat()
+                        rs["last_cut_push_count"] = rs.get("last_cut_push_count", 0) + 1 if isinstance(rs.get("last_cut_push_count"), int) else 1
+                except Exception:
+                    _logger.error(
+                        "Failed to externalize superseded push row; row data will be lost on overwrite: %s",
+                        json.dumps(previous_push, ensure_ascii=False, default=str),
+                        exc_info=True,
+                    )
+
+            state["last_push"] = {
+                "pushed_at": push_now.isoformat(),
+                "target_url": target_url,
+                "file_count": len(files),
+                "by_prefix": by_prefix,
+                "idempotency_key": push_id,
+                "conflict_policy": req.conflict_policy,
+                "include_deleted": req.include_deleted,
+            }
+            committed_files = []
+            try:
+                state_path = _write_replication_state(settings.repo_root, state)
+            except Exception:
+                # Clean up shard/stub files created by externalize_superseded_push
+                # to avoid orphaned shards the head doesn't reference.
+                for p in _history_extra_paths:
+                    safe_path(settings.repo_root, p).unlink(missing_ok=True)
+                raise
+    except (SegmentHistoryLockTimeout, LockInfrastructureError) as lock_exc:
+        raise HTTPException(status_code=503, detail="Replication state lock unavailable; retry") from lock_exc
     warnings: list[str] = []
     if _history_extra_paths:
         push_commit_paths = [state_path] + [safe_path(settings.repo_root, p) for p in _history_extra_paths]

--- a/app/messages/service.py
+++ b/app/messages/service.py
@@ -17,6 +17,7 @@ from app.config import DEFAULT_MAX_JSONL_READ_BYTES
 from app.git_safety import try_commit_paths
 from app.models import MessageAckRequest, MessageReplayRequest, MessageSendRequest, RelayForwardRequest
 from app.segment_history.append import SegmentHistoryAppendError, locked_append_jsonl, locked_append_jsonl_multi
+from app.segment_history.locking import LockInfrastructureError, SegmentHistoryLockTimeout, segment_history_source_lock
 from app.storage import safe_path, write_bytes_file, write_text_file
 
 DELIVERY_STATE_REL = "messages/state/delivery_index.json"
@@ -198,162 +199,166 @@ def messages_send_service(
     if settings.require_signed_ingress and req.signed_envelope is None:
         raise HTTPException(status_code=400, detail="signed_envelope is required when strict signed ingress is enabled")
 
-    state = load_delivery_state(settings.repo_root)
-    if req.idempotency_key:
-        idem_key = _idempotency_scope_key(req.sender, req.recipient, req.idempotency_key)
-        existing_id = state.get("idempotency", {}).get(idem_key)
-        if existing_id:
-            existing = state.get("records", {}).get(existing_id)
-            if isinstance(existing, dict):
-                verification = None
-                if req.signed_envelope is not None:
-                    signed_payload = {
-                        "thread_id": req.thread_id,
-                        "sender": req.sender,
-                        "recipient": req.recipient,
-                        "subject": req.subject,
-                        "body_md": req.body_md,
-                        "priority": req.priority,
-                        "attachments": req.attachments,
-                        "idempotency_key": req.idempotency_key,
-                        "delivery": req.delivery.model_dump(),
-                    }
-                    verification = verify_signed_payload(
-                        settings=settings,
-                        gm=gm,
-                        auth=auth,
-                        payload=signed_payload,
-                        key_id=req.signed_envelope.key_id,
-                        nonce=req.signed_envelope.nonce,
-                        expires_at=req.signed_envelope.expires_at,
-                        signature=req.signed_envelope.signature,
-                        algorithm=req.signed_envelope.algorithm,
-                        consume_nonce=False,
-                        audit_event="messages_send_signature",
-                        verification_failure_count=verification_failure_count,
-                        record_verification_failure=record_verification_failure,
-                        audit=audit,
-                    )
-                    if not verification["valid"]:
-                        raise HTTPException(status_code=401, detail=f"Invalid signed envelope: {verification['reason']}")
-
-                now = datetime.now(timezone.utc)
-                audit(auth, "message_send_idempotent_replay", {"idempotency_key": req.idempotency_key, "message_id": existing_id})
-                early_result: dict[str, Any] = {
-                    "ok": True,
-                    "idempotent_replay": True,
-                    "message": existing.get("message"),
-                    "delivery_state": delivery_record_view(existing, now, parse_iso=parse_iso),
-                    "signature_verification": verification,
-                    "committed_files": [],
-                    "latest_commit": gm.latest_commit(),
-                }
-                if state.get("warnings"):
-                    early_result["warnings"] = state["warnings"]
-                return early_result
-
-    signature_verification = None
-    committed_files: list[str] = []
-    if req.signed_envelope is not None:
-        signed_payload = {
-            "thread_id": req.thread_id,
-            "sender": req.sender,
-            "recipient": req.recipient,
-            "subject": req.subject,
-            "body_md": req.body_md,
-            "priority": req.priority,
-            "attachments": req.attachments,
-            "idempotency_key": req.idempotency_key,
-            "delivery": req.delivery.model_dump(),
-        }
-        signature_verification = verify_signed_payload(
-            settings=settings,
-            gm=gm,
-            auth=auth,
-            payload=signed_payload,
-            key_id=req.signed_envelope.key_id,
-            nonce=req.signed_envelope.nonce,
-            expires_at=req.signed_envelope.expires_at,
-            signature=req.signed_envelope.signature,
-            algorithm=req.signed_envelope.algorithm,
-            consume_nonce=req.signed_envelope.consume_nonce,
-            audit_event="messages_send_signature",
-            verification_failure_count=verification_failure_count,
-            record_verification_failure=record_verification_failure,
-            audit=audit,
-        )
-        if not signature_verification["valid"]:
-            raise HTTPException(status_code=401, detail=f"Invalid signed envelope: {signature_verification['reason']}")
-        committed_files.extend(signature_verification.get("committed_files", []))
-
-    now = datetime.now(timezone.utc)
-    msg = {
-        "id": f"msg_{uuid4().hex[:12]}",
-        "thread_id": req.thread_id,
-        "from": req.sender,
-        "to": req.recipient,
-        "sent_at": now.isoformat(),
-        "subject": req.subject,
-        "body_md": req.body_md,
-        "priority": req.priority,
-        "attachments": req.attachments,
-        "idempotency_key": req.idempotency_key,
-        "delivery": req.delivery.model_dump(),
-    }
-
-    inbox_path_rel = f"messages/inbox/{req.recipient}.jsonl"
-    outbox_path_rel = f"messages/outbox/{req.sender}.jsonl"
-    thread_path_rel = f"messages/threads/{req.thread_id}.jsonl"
-
-    rels = [inbox_path_rel, outbox_path_rel, thread_path_rel]
-    paths = [safe_path(settings.repo_root, r) for r in rels]
-
-    should_track_delivery = bool(req.idempotency_key or req.delivery.requires_ack)
-    delivery_state = None
-    warnings: list[str] = list(state.get("warnings") or [])
-    if should_track_delivery:
-        ack_deadline = None
-        if req.delivery.requires_ack:
-            ack_deadline = (now + timedelta(seconds=req.delivery.ack_timeout_seconds)).isoformat()
-        status = "pending_ack" if req.delivery.requires_ack else "delivered"
-        record = {
-            "message_id": msg["id"],
-            "thread_id": req.thread_id,
-            "from": req.sender,
-            "to": req.recipient,
-            "subject": req.subject,
-            "idempotency_key": req.idempotency_key,
-            "status": status,
-            "requires_ack": req.delivery.requires_ack,
-            "ack_timeout_seconds": req.delivery.ack_timeout_seconds,
-            "max_retries": req.delivery.max_retries,
-            "retry_count": 0,
-            "sent_at": now.isoformat(),
-            "ack_deadline": ack_deadline,
-            "acks": [],
-            "last_error": None,
-            "message": msg,
-        }
-        state.setdefault("records", {})[msg["id"]] = record
-        if req.idempotency_key:
-            key = _idempotency_scope_key(req.sender, req.recipient, req.idempotency_key)
-            state.setdefault("idempotency", {})[key] = msg["id"]
-        delivery_state = delivery_record_view(record, now, parse_iso=parse_iso)
-
-    commit_paths = list(paths)
-    commit_rels = list(rels)
-    append_targets = _capture_append_targets(paths)
-    state_rollback_plan = _capture_rollback_plan([_delivery_state_path(settings.repo_root)]) if should_track_delivery else []
     try:
-        locked_append_jsonl_multi(paths, msg, repo_root=settings.repo_root, gm=gm, settings=settings)
-        if should_track_delivery:
-            state_path = _write_delivery_state(settings.repo_root, state)
-            commit_paths.append(state_path)
-            commit_rels.append(DELIVERY_STATE_REL)
-    except Exception:
-        _restore_rollback_plan(state_rollback_plan)
-        _restore_appends(append_targets)
-        raise
+        with segment_history_source_lock("registry:delivery_index", lock_dir=settings.repo_root / ".locks"):
+            state = load_delivery_state(settings.repo_root)
+            if req.idempotency_key:
+                idem_key = _idempotency_scope_key(req.sender, req.recipient, req.idempotency_key)
+                existing_id = state.get("idempotency", {}).get(idem_key)
+                if existing_id:
+                    existing = state.get("records", {}).get(existing_id)
+                    if isinstance(existing, dict):
+                        verification = None
+                        if req.signed_envelope is not None:
+                            signed_payload = {
+                                "thread_id": req.thread_id,
+                                "sender": req.sender,
+                                "recipient": req.recipient,
+                                "subject": req.subject,
+                                "body_md": req.body_md,
+                                "priority": req.priority,
+                                "attachments": req.attachments,
+                                "idempotency_key": req.idempotency_key,
+                                "delivery": req.delivery.model_dump(),
+                            }
+                            verification = verify_signed_payload(
+                                settings=settings,
+                                gm=gm,
+                                auth=auth,
+                                payload=signed_payload,
+                                key_id=req.signed_envelope.key_id,
+                                nonce=req.signed_envelope.nonce,
+                                expires_at=req.signed_envelope.expires_at,
+                                signature=req.signed_envelope.signature,
+                                algorithm=req.signed_envelope.algorithm,
+                                consume_nonce=False,
+                                audit_event="messages_send_signature",
+                                verification_failure_count=verification_failure_count,
+                                record_verification_failure=record_verification_failure,
+                                audit=audit,
+                            )
+                            if not verification["valid"]:
+                                raise HTTPException(status_code=401, detail=f"Invalid signed envelope: {verification['reason']}")
+
+                        now = datetime.now(timezone.utc)
+                        audit(auth, "message_send_idempotent_replay", {"idempotency_key": req.idempotency_key, "message_id": existing_id})
+                        early_result: dict[str, Any] = {
+                            "ok": True,
+                            "idempotent_replay": True,
+                            "message": existing.get("message"),
+                            "delivery_state": delivery_record_view(existing, now, parse_iso=parse_iso),
+                            "signature_verification": verification,
+                            "committed_files": [],
+                            "latest_commit": gm.latest_commit(),
+                        }
+                        if state.get("warnings"):
+                            early_result["warnings"] = state["warnings"]
+                        return early_result
+
+            signature_verification = None
+            committed_files: list[str] = []
+            if req.signed_envelope is not None:
+                signed_payload = {
+                    "thread_id": req.thread_id,
+                    "sender": req.sender,
+                    "recipient": req.recipient,
+                    "subject": req.subject,
+                    "body_md": req.body_md,
+                    "priority": req.priority,
+                    "attachments": req.attachments,
+                    "idempotency_key": req.idempotency_key,
+                    "delivery": req.delivery.model_dump(),
+                }
+                signature_verification = verify_signed_payload(
+                    settings=settings,
+                    gm=gm,
+                    auth=auth,
+                    payload=signed_payload,
+                    key_id=req.signed_envelope.key_id,
+                    nonce=req.signed_envelope.nonce,
+                    expires_at=req.signed_envelope.expires_at,
+                    signature=req.signed_envelope.signature,
+                    algorithm=req.signed_envelope.algorithm,
+                    consume_nonce=req.signed_envelope.consume_nonce,
+                    audit_event="messages_send_signature",
+                    verification_failure_count=verification_failure_count,
+                    record_verification_failure=record_verification_failure,
+                    audit=audit,
+                )
+                if not signature_verification["valid"]:
+                    raise HTTPException(status_code=401, detail=f"Invalid signed envelope: {signature_verification['reason']}")
+                committed_files.extend(signature_verification.get("committed_files", []))
+
+            now = datetime.now(timezone.utc)
+            msg = {
+                "id": f"msg_{uuid4().hex[:12]}",
+                "thread_id": req.thread_id,
+                "from": req.sender,
+                "to": req.recipient,
+                "sent_at": now.isoformat(),
+                "subject": req.subject,
+                "body_md": req.body_md,
+                "priority": req.priority,
+                "attachments": req.attachments,
+                "idempotency_key": req.idempotency_key,
+                "delivery": req.delivery.model_dump(),
+            }
+
+            inbox_path_rel = f"messages/inbox/{req.recipient}.jsonl"
+            outbox_path_rel = f"messages/outbox/{req.sender}.jsonl"
+            thread_path_rel = f"messages/threads/{req.thread_id}.jsonl"
+
+            rels = [inbox_path_rel, outbox_path_rel, thread_path_rel]
+            paths = [safe_path(settings.repo_root, r) for r in rels]
+
+            should_track_delivery = bool(req.idempotency_key or req.delivery.requires_ack)
+            delivery_state = None
+            warnings: list[str] = list(state.get("warnings") or [])
+            if should_track_delivery:
+                ack_deadline = None
+                if req.delivery.requires_ack:
+                    ack_deadline = (now + timedelta(seconds=req.delivery.ack_timeout_seconds)).isoformat()
+                status = "pending_ack" if req.delivery.requires_ack else "delivered"
+                record = {
+                    "message_id": msg["id"],
+                    "thread_id": req.thread_id,
+                    "from": req.sender,
+                    "to": req.recipient,
+                    "subject": req.subject,
+                    "idempotency_key": req.idempotency_key,
+                    "status": status,
+                    "requires_ack": req.delivery.requires_ack,
+                    "ack_timeout_seconds": req.delivery.ack_timeout_seconds,
+                    "max_retries": req.delivery.max_retries,
+                    "retry_count": 0,
+                    "sent_at": now.isoformat(),
+                    "ack_deadline": ack_deadline,
+                    "acks": [],
+                    "last_error": None,
+                    "message": msg,
+                }
+                state.setdefault("records", {})[msg["id"]] = record
+                if req.idempotency_key:
+                    key = _idempotency_scope_key(req.sender, req.recipient, req.idempotency_key)
+                    state.setdefault("idempotency", {})[key] = msg["id"]
+                delivery_state = delivery_record_view(record, now, parse_iso=parse_iso)
+
+            commit_paths = list(paths)
+            commit_rels = list(rels)
+            append_targets = _capture_append_targets(paths)
+            state_rollback_plan = _capture_rollback_plan([_delivery_state_path(settings.repo_root)]) if should_track_delivery else []
+            try:
+                locked_append_jsonl_multi(paths, msg, repo_root=settings.repo_root, gm=gm, settings=settings)
+                if should_track_delivery:
+                    state_path = _write_delivery_state(settings.repo_root, state)
+                    commit_paths.append(state_path)
+                    commit_rels.append(DELIVERY_STATE_REL)
+            except Exception:
+                _restore_rollback_plan(state_rollback_plan)
+                _restore_appends(append_targets)
+                raise
+    except (SegmentHistoryLockTimeout, LockInfrastructureError):
+        raise HTTPException(status_code=503, detail="Delivery state lock unavailable; retry")
 
     if try_commit_paths(paths=commit_paths, gm=gm, commit_message=f"messages: send {msg['id']}"):
         committed_files.extend(commit_rels)
@@ -388,45 +393,49 @@ def messages_ack_service(
     auth.require("write:messages")
     auth.require_write_path(DELIVERY_STATE_REL)
 
-    state = load_delivery_state(repo_root)
-    record = state.get("records", {}).get(req.message_id)
-    if not isinstance(record, dict):
-        raise HTTPException(status_code=404, detail="Tracked message not found")
-
-    now = datetime.now(timezone.utc)
-    ack_row = {
-        "ack_id": req.ack_id or f"ack_{uuid4().hex[:12]}",
-        "message_id": req.message_id,
-        "status": req.status,
-        "reason": req.reason,
-        "ack_at": now.isoformat(),
-        "by": auth.peer_id,
-    }
-    record.setdefault("acks", []).append(ack_row)
-
-    if req.status == "accepted":
-        record["status"] = "acked"
-    elif req.status == "rejected":
-        record["status"] = "dead_letter"
-        record["last_error"] = req.reason or "rejected"
-    else:
-        record["status"] = "pending_ack"
-        timeout = int(record.get("ack_timeout_seconds") or 300)
-        record["ack_deadline"] = (now + timedelta(seconds=timeout)).isoformat()
-
-    committed_files = []
-    ack_rel = f"messages/acks/{req.message_id}.jsonl"
-    state_path = _delivery_state_path(repo_root)
-    ack_path = safe_path(repo_root, ack_rel)
-    state_rollback_plan = _capture_rollback_plan([state_path])
-    ack_append_targets = _capture_append_targets([ack_path])
     try:
-        _write_delivery_state(repo_root, state)
-        locked_append_jsonl(ack_path, ack_row, repo_root=repo_root, gm=gm, settings=None, family="message_stream")
-    except Exception:
-        _restore_appends(ack_append_targets)
-        _restore_rollback_plan(state_rollback_plan)
-        raise
+        with segment_history_source_lock("registry:delivery_index", lock_dir=repo_root / ".locks"):
+            state = load_delivery_state(repo_root)
+            record = state.get("records", {}).get(req.message_id)
+            if not isinstance(record, dict):
+                raise HTTPException(status_code=404, detail="Tracked message not found")
+
+            now = datetime.now(timezone.utc)
+            ack_row = {
+                "ack_id": req.ack_id or f"ack_{uuid4().hex[:12]}",
+                "message_id": req.message_id,
+                "status": req.status,
+                "reason": req.reason,
+                "ack_at": now.isoformat(),
+                "by": auth.peer_id,
+            }
+            record.setdefault("acks", []).append(ack_row)
+
+            if req.status == "accepted":
+                record["status"] = "acked"
+            elif req.status == "rejected":
+                record["status"] = "dead_letter"
+                record["last_error"] = req.reason or "rejected"
+            else:
+                record["status"] = "pending_ack"
+                timeout = int(record.get("ack_timeout_seconds") or 300)
+                record["ack_deadline"] = (now + timedelta(seconds=timeout)).isoformat()
+
+            committed_files = []
+            ack_rel = f"messages/acks/{req.message_id}.jsonl"
+            state_path = _delivery_state_path(repo_root)
+            ack_path = safe_path(repo_root, ack_rel)
+            state_rollback_plan = _capture_rollback_plan([state_path])
+            ack_append_targets = _capture_append_targets([ack_path])
+            try:
+                _write_delivery_state(repo_root, state)
+                locked_append_jsonl(ack_path, ack_row, repo_root=repo_root, gm=gm, settings=None, family="message_stream")
+            except Exception:
+                _restore_appends(ack_append_targets)
+                _restore_rollback_plan(state_rollback_plan)
+                raise
+    except (SegmentHistoryLockTimeout, LockInfrastructureError):
+        raise HTTPException(status_code=503, detail="Delivery state lock unavailable; retry")
     warnings: list[str] = list(state.get("warnings") or [])
     if try_commit_paths(paths=[state_path, ack_path], gm=gm, commit_message=f"messages: ack {req.message_id}"):
         committed_files.extend([DELIVERY_STATE_REL, ack_rel])
@@ -798,99 +807,103 @@ def replay_messages_service(
     auth.require("write:messages")
     auth.require_write_path("messages/inbox/x.jsonl")
     auth.require_write_path(DELIVERY_STATE_REL)
-    state = load_delivery_state(settings.repo_root)
-    record = state.get("records", {}).get(req.message_id)
-    if not isinstance(record, dict):
-        raise HTTPException(status_code=404, detail="Tracked message not found")
-
-    now = datetime.now(timezone.utc)
-    effective = effective_delivery_status(record, now, parse_iso=parse_iso)
-    if not req.force and effective != "dead_letter":
-        raise HTTPException(status_code=409, detail=f"Replay requires dead_letter status; got {effective}")
-    retry_count = int(record.get("retry_count") or 0)
-    max_retries = int(record.get("max_retries") or 0)
-    if not req.force and retry_count >= max_retries:
-        raise HTTPException(status_code=409, detail=f"Replay retry limit reached ({retry_count}/{max_retries})")
-
-    original = record.get("message")
-    if not isinstance(original, dict):
-        original = {
-            "id": req.message_id,
-            "thread_id": record.get("thread_id"),
-            "from": record.get("from"),
-            "to": record.get("to"),
-            "subject": record.get("subject"),
-            "body_md": "",
-            "attachments": [],
-            "priority": "normal",
-            "delivery": {
-                "requires_ack": bool(record.get("requires_ack")),
-                "ack_timeout_seconds": int(record.get("ack_timeout_seconds") or req.ack_timeout_seconds),
-                "max_retries": max_retries,
-            },
-        }
-
-    new_message_id = f"msg_{uuid4().hex[:12]}"
-    replay_msg = dict(original)
-    replay_msg["id"] = new_message_id
-    replay_msg["replay_of"] = req.message_id
-    replay_msg["sent_at"] = now.isoformat()
-
-    sender = str(replay_msg.get("from") or record.get("from") or "unknown")
-    recipient = str(replay_msg.get("to") or record.get("to") or "unknown")
-    thread_id = str(replay_msg.get("thread_id") or record.get("thread_id") or "thread_unknown")
-    inbox_rel = f"messages/inbox/{recipient}.jsonl"
-    outbox_rel = f"messages/outbox/{sender}.jsonl"
-    thread_rel = f"messages/threads/{thread_id}.jsonl"
-    rels = [inbox_rel, outbox_rel, thread_rel]
-    for rel in rels:
-        auth.require_write_path(rel)
-    paths = [safe_path(settings.repo_root, r) for r in rels]
-    committed_files = []
-
-    if req.requires_ack:
-        ack_deadline = (now + timedelta(seconds=req.ack_timeout_seconds)).isoformat()
-        new_status = "pending_ack"
-    else:
-        ack_deadline = None
-        new_status = "delivered"
-
-    new_record = dict(record)
-    new_record.update(
-        {
-            "message_id": new_message_id,
-            "thread_id": thread_id,
-            "from": sender,
-            "to": recipient,
-            "status": new_status,
-            "requires_ack": req.requires_ack,
-            "ack_timeout_seconds": req.ack_timeout_seconds,
-            "retry_count": retry_count + 1,
-            "sent_at": now.isoformat(),
-            "ack_deadline": ack_deadline,
-            "acks": [],
-            "last_error": None,
-            "replay_of": req.message_id,
-            "message": replay_msg,
-        }
-    )
-    state.setdefault("records", {})[new_message_id] = new_record
-    record["status"] = "replayed"
-    record["replayed_to"] = new_message_id
-    record["updated_at"] = now.isoformat()
-    if req.reason:
-        record["replay_reason"] = req.reason
-
-    state_path = _delivery_state_path(settings.repo_root)
-    append_targets = _capture_append_targets(paths)
-    state_rollback_plan = _capture_rollback_plan([state_path])
     try:
-        locked_append_jsonl_multi(paths, replay_msg, repo_root=settings.repo_root, gm=gm, settings=settings)
-        _write_delivery_state(settings.repo_root, state)
-    except Exception:
-        _restore_rollback_plan(state_rollback_plan)
-        _restore_appends(append_targets)
-        raise
+        with segment_history_source_lock("registry:delivery_index", lock_dir=settings.repo_root / ".locks"):
+            state = load_delivery_state(settings.repo_root)
+            record = state.get("records", {}).get(req.message_id)
+            if not isinstance(record, dict):
+                raise HTTPException(status_code=404, detail="Tracked message not found")
+
+            now = datetime.now(timezone.utc)
+            effective = effective_delivery_status(record, now, parse_iso=parse_iso)
+            if not req.force and effective != "dead_letter":
+                raise HTTPException(status_code=409, detail=f"Replay requires dead_letter status; got {effective}")
+            retry_count = int(record.get("retry_count") or 0)
+            max_retries = int(record.get("max_retries") or 0)
+            if not req.force and retry_count >= max_retries:
+                raise HTTPException(status_code=409, detail=f"Replay retry limit reached ({retry_count}/{max_retries})")
+
+            original = record.get("message")
+            if not isinstance(original, dict):
+                original = {
+                    "id": req.message_id,
+                    "thread_id": record.get("thread_id"),
+                    "from": record.get("from"),
+                    "to": record.get("to"),
+                    "subject": record.get("subject"),
+                    "body_md": "",
+                    "attachments": [],
+                    "priority": "normal",
+                    "delivery": {
+                        "requires_ack": bool(record.get("requires_ack")),
+                        "ack_timeout_seconds": int(record.get("ack_timeout_seconds") or req.ack_timeout_seconds),
+                        "max_retries": max_retries,
+                    },
+                }
+
+            new_message_id = f"msg_{uuid4().hex[:12]}"
+            replay_msg = dict(original)
+            replay_msg["id"] = new_message_id
+            replay_msg["replay_of"] = req.message_id
+            replay_msg["sent_at"] = now.isoformat()
+
+            sender = str(replay_msg.get("from") or record.get("from") or "unknown")
+            recipient = str(replay_msg.get("to") or record.get("to") or "unknown")
+            thread_id = str(replay_msg.get("thread_id") or record.get("thread_id") or "thread_unknown")
+            inbox_rel = f"messages/inbox/{recipient}.jsonl"
+            outbox_rel = f"messages/outbox/{sender}.jsonl"
+            thread_rel = f"messages/threads/{thread_id}.jsonl"
+            rels = [inbox_rel, outbox_rel, thread_rel]
+            for rel in rels:
+                auth.require_write_path(rel)
+            paths = [safe_path(settings.repo_root, r) for r in rels]
+            committed_files = []
+
+            if req.requires_ack:
+                ack_deadline = (now + timedelta(seconds=req.ack_timeout_seconds)).isoformat()
+                new_status = "pending_ack"
+            else:
+                ack_deadline = None
+                new_status = "delivered"
+
+            new_record = dict(record)
+            new_record.update(
+                {
+                    "message_id": new_message_id,
+                    "thread_id": thread_id,
+                    "from": sender,
+                    "to": recipient,
+                    "status": new_status,
+                    "requires_ack": req.requires_ack,
+                    "ack_timeout_seconds": req.ack_timeout_seconds,
+                    "retry_count": retry_count + 1,
+                    "sent_at": now.isoformat(),
+                    "ack_deadline": ack_deadline,
+                    "acks": [],
+                    "last_error": None,
+                    "replay_of": req.message_id,
+                    "message": replay_msg,
+                }
+            )
+            state.setdefault("records", {})[new_message_id] = new_record
+            record["status"] = "replayed"
+            record["replayed_to"] = new_message_id
+            record["updated_at"] = now.isoformat()
+            if req.reason:
+                record["replay_reason"] = req.reason
+
+            state_path = _delivery_state_path(settings.repo_root)
+            append_targets = _capture_append_targets(paths)
+            state_rollback_plan = _capture_rollback_plan([state_path])
+            try:
+                locked_append_jsonl_multi(paths, replay_msg, repo_root=settings.repo_root, gm=gm, settings=settings)
+                _write_delivery_state(settings.repo_root, state)
+            except Exception:
+                _restore_rollback_plan(state_rollback_plan)
+                _restore_appends(append_targets)
+                raise
+    except (SegmentHistoryLockTimeout, LockInfrastructureError):
+        raise HTTPException(status_code=503, detail="Delivery state lock unavailable; retry")
     warnings: list[str] = list(state.get("warnings") or [])
     commit_paths = paths + [state_path]
     commit_rels = rels + [DELIVERY_STATE_REL]

--- a/app/peers/service.py
+++ b/app/peers/service.py
@@ -13,6 +13,7 @@ from urllib.request import Request as UrlRequest, urlopen
 from fastapi import HTTPException
 
 from app.auth import AuthContext
+from app.segment_history.locking import segment_history_source_lock, SegmentHistoryLockTimeout, LockInfrastructureError
 from app.git_safety import safe_commit_paths, safe_commit_updated_file
 from app.models import PeerRegisterRequest, PeerTrustTransitionRequest
 from app.storage import safe_path, write_bytes_file, write_text_file
@@ -157,79 +158,83 @@ def peers_register_service(
     auth.require("admin:peers")
     auth.require_write_path(PEERS_REGISTRY_REL)
 
-    registry = load_peers_registry(repo_root)
-    peers = registry.setdefault("peers", {})
-    now = datetime.now(timezone.utc).isoformat()
-    prev = peers.get(req.peer_id) if isinstance(peers, dict) else None
-
-    policies = _load_trust_policies(repo_root, trust_policies_rel)
-    current_trust = str(prev.get("trust_level") or "untrusted") if isinstance(prev, dict) else "untrusted"
-    target_trust = req.trust_level
-
-    provided_fp = _public_key_fingerprint(req.public_key) if req.public_key else None
-    expected_fp = _normalize_fingerprint(req.expected_public_key_fingerprint)
-    prev_fp = str(prev.get("public_key_fingerprint") or "") if isinstance(prev, dict) else ""
-
-    if expected_fp and provided_fp and expected_fp != provided_fp:
-        raise HTTPException(status_code=400, detail="public_key fingerprint mismatch")
-    if expected_fp and not provided_fp and prev_fp and expected_fp != prev_fp:
-        raise HTTPException(status_code=400, detail="existing peer fingerprint does not match expected fingerprint")
-
-    if isinstance(prev, dict):
-        _assert_trust_transition_allowed(policies, current_trust, target_trust, req.transition_reason)
-
-    if bool(policies.get("require_fingerprint_for_trusted", True)) and target_trust == "trusted":
-        fingerprint_for_trusted = provided_fp or (prev_fp if prev_fp else None)
-        if not fingerprint_for_trusted:
-            raise HTTPException(status_code=400, detail="public_key fingerprint is required for trusted peers")
-
-    created_at = prev.get("created_at") if isinstance(prev, dict) and prev.get("created_at") else now
-    history = []
-    if isinstance(prev, dict) and isinstance(prev.get("trust_history"), list):
-        history = list(prev.get("trust_history"))
-    if current_trust != target_trust:
-        history.append(
-            {
-                "at": now,
-                "from": current_trust,
-                "to": target_trust,
-                "reason": req.transition_reason or "register_update",
-                "by": auth.peer_id,
-            }
-        )
-
-    record = {
-        "base_url": req.base_url,
-        "public_key": req.public_key,
-        "public_key_fingerprint": provided_fp or (prev_fp if prev_fp else None),
-        "capabilities_url": req.capabilities_url,
-        "trust_level": target_trust,
-        "allowed_scopes": req.allowed_scopes,
-        "created_at": created_at,
-        "updated_at": now,
-        "trust_history": history,
-    }
-    peers[req.peer_id] = record
-    registry["updated_at"] = now
-    path = safe_path(repo_root, PEERS_REGISTRY_REL)
-    policy_path = safe_path(repo_root, trust_policies_rel)
-    rollback_plan = [
-        (path, path.read_bytes() if path.exists() else None),
-        (policy_path, policy_path.read_bytes() if policy_path.exists() else None),
-    ]
     try:
-        _write_peers_registry(repo_root, registry)
-        _write_trust_policies(repo_root, trust_policies_rel, policies)
-    except Exception as exc:
-        _restore_paths(rollback_plan)
-        raise HTTPException(status_code=500, detail=f"Failed to write peer registration for {req.peer_id}: {exc}") from exc
+        with segment_history_source_lock("registry:peers_registry", lock_dir=repo_root / ".locks"):
+            registry = load_peers_registry(repo_root)
+            peers = registry.setdefault("peers", {})
+            now = datetime.now(timezone.utc).isoformat()
+            prev = peers.get(req.peer_id) if isinstance(peers, dict) else None
 
-    committed = safe_commit_paths(
-        rollback_plan=rollback_plan,
-        gm=gm,
-        commit_message=f"peers: register {req.peer_id}",
-        error_detail=f"Failed to durably commit peer registration for {req.peer_id}",
-    )
+            policies = _load_trust_policies(repo_root, trust_policies_rel)
+            current_trust = str(prev.get("trust_level") or "untrusted") if isinstance(prev, dict) else "untrusted"
+            target_trust = req.trust_level
+
+            provided_fp = _public_key_fingerprint(req.public_key) if req.public_key else None
+            expected_fp = _normalize_fingerprint(req.expected_public_key_fingerprint)
+            prev_fp = str(prev.get("public_key_fingerprint") or "") if isinstance(prev, dict) else ""
+
+            if expected_fp and provided_fp and expected_fp != provided_fp:
+                raise HTTPException(status_code=400, detail="public_key fingerprint mismatch")
+            if expected_fp and not provided_fp and prev_fp and expected_fp != prev_fp:
+                raise HTTPException(status_code=400, detail="existing peer fingerprint does not match expected fingerprint")
+
+            if isinstance(prev, dict):
+                _assert_trust_transition_allowed(policies, current_trust, target_trust, req.transition_reason)
+
+            if bool(policies.get("require_fingerprint_for_trusted", True)) and target_trust == "trusted":
+                fingerprint_for_trusted = provided_fp or (prev_fp if prev_fp else None)
+                if not fingerprint_for_trusted:
+                    raise HTTPException(status_code=400, detail="public_key fingerprint is required for trusted peers")
+
+            created_at = prev.get("created_at") if isinstance(prev, dict) and prev.get("created_at") else now
+            history = []
+            if isinstance(prev, dict) and isinstance(prev.get("trust_history"), list):
+                history = list(prev.get("trust_history"))
+            if current_trust != target_trust:
+                history.append(
+                    {
+                        "at": now,
+                        "from": current_trust,
+                        "to": target_trust,
+                        "reason": req.transition_reason or "register_update",
+                        "by": auth.peer_id,
+                    }
+                )
+
+            record = {
+                "base_url": req.base_url,
+                "public_key": req.public_key,
+                "public_key_fingerprint": provided_fp or (prev_fp if prev_fp else None),
+                "capabilities_url": req.capabilities_url,
+                "trust_level": target_trust,
+                "allowed_scopes": req.allowed_scopes,
+                "created_at": created_at,
+                "updated_at": now,
+                "trust_history": history,
+            }
+            peers[req.peer_id] = record
+            registry["updated_at"] = now
+            path = safe_path(repo_root, PEERS_REGISTRY_REL)
+            policy_path = safe_path(repo_root, trust_policies_rel)
+            rollback_plan = [
+                (path, path.read_bytes() if path.exists() else None),
+                (policy_path, policy_path.read_bytes() if policy_path.exists() else None),
+            ]
+            try:
+                _write_peers_registry(repo_root, registry)
+                _write_trust_policies(repo_root, trust_policies_rel, policies)
+            except Exception as exc:
+                _restore_paths(rollback_plan)
+                raise HTTPException(status_code=500, detail=f"Failed to write peer registration for {req.peer_id}: {exc}") from exc
+
+            committed = safe_commit_paths(
+                rollback_plan=rollback_plan,
+                gm=gm,
+                commit_message=f"peers: register {req.peer_id}",
+                error_detail=f"Failed to durably commit peer registration for {req.peer_id}",
+            )
+    except (SegmentHistoryLockTimeout, LockInfrastructureError):
+        raise HTTPException(status_code=503, detail="Peers registry lock unavailable; retry")
 
     audit(
         auth,
@@ -264,46 +269,50 @@ def peers_trust_transition_service(
     auth.require("admin:peers")
     auth.require_write_path(PEERS_REGISTRY_REL)
 
-    registry = load_peers_registry(repo_root)
-    peers = registry.setdefault("peers", {})
-    row = peers.get(peer_id) if isinstance(peers, dict) else None
-    if not isinstance(row, dict):
-        raise HTTPException(status_code=404, detail=f"Peer not found: {peer_id}")
-
-    policies = _load_trust_policies(repo_root, trust_policies_rel)
-    current = str(row.get("trust_level") or "untrusted")
-    target = req.trust_level
-    _assert_trust_transition_allowed(policies, current, target, req.reason)
-
-    expected_fp = _normalize_fingerprint(req.expected_public_key_fingerprint)
-    current_fp = _normalize_fingerprint(str(row.get("public_key_fingerprint") or ""))
-    if expected_fp and expected_fp != current_fp:
-        raise HTTPException(status_code=409, detail="Peer fingerprint mismatch for trust transition")
-
-    now = datetime.now(timezone.utc).isoformat()
-    history = row.get("trust_history")
-    if not isinstance(history, list):
-        history = []
-    history.append({"at": now, "from": current, "to": target, "reason": req.reason, "by": auth.peer_id})
-    row["trust_level"] = target
-    row["updated_at"] = now
-    row["trust_history"] = history
-    peers[peer_id] = row
-    registry["updated_at"] = now
-
-    path = safe_path(repo_root, PEERS_REGISTRY_REL)
-    old_bytes = path.read_bytes() if path.exists() else None
     try:
-        _write_peers_registry(repo_root, registry)
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Failed to write peer trust transition for {peer_id}: {exc}") from exc
-    committed = safe_commit_updated_file(
-        path=path,
-        gm=gm,
-        commit_message=f"peers: trust transition {peer_id} {current}->{target}",
-        error_detail=f"Failed to durably commit peer trust transition for {peer_id}",
-        old_bytes=old_bytes,
-    )
+        with segment_history_source_lock("registry:peers_registry", lock_dir=repo_root / ".locks"):
+            registry = load_peers_registry(repo_root)
+            peers = registry.setdefault("peers", {})
+            row = peers.get(peer_id) if isinstance(peers, dict) else None
+            if not isinstance(row, dict):
+                raise HTTPException(status_code=404, detail=f"Peer not found: {peer_id}")
+
+            policies = _load_trust_policies(repo_root, trust_policies_rel)
+            current = str(row.get("trust_level") or "untrusted")
+            target = req.trust_level
+            _assert_trust_transition_allowed(policies, current, target, req.reason)
+
+            expected_fp = _normalize_fingerprint(req.expected_public_key_fingerprint)
+            current_fp = _normalize_fingerprint(str(row.get("public_key_fingerprint") or ""))
+            if expected_fp and expected_fp != current_fp:
+                raise HTTPException(status_code=409, detail="Peer fingerprint mismatch for trust transition")
+
+            now = datetime.now(timezone.utc).isoformat()
+            history = row.get("trust_history")
+            if not isinstance(history, list):
+                history = []
+            history.append({"at": now, "from": current, "to": target, "reason": req.reason, "by": auth.peer_id})
+            row["trust_level"] = target
+            row["updated_at"] = now
+            row["trust_history"] = history
+            peers[peer_id] = row
+            registry["updated_at"] = now
+
+            path = safe_path(repo_root, PEERS_REGISTRY_REL)
+            old_bytes = path.read_bytes() if path.exists() else None
+            try:
+                _write_peers_registry(repo_root, registry)
+            except Exception as exc:
+                raise HTTPException(status_code=500, detail=f"Failed to write peer trust transition for {peer_id}: {exc}") from exc
+            committed = safe_commit_updated_file(
+                path=path,
+                gm=gm,
+                commit_message=f"peers: trust transition {peer_id} {current}->{target}",
+                error_detail=f"Failed to durably commit peer trust transition for {peer_id}",
+                old_bytes=old_bytes,
+            )
+    except (SegmentHistoryLockTimeout, LockInfrastructureError):
+        raise HTTPException(status_code=503, detail="Peers registry lock unavailable; retry")
     audit(auth, "peers_trust_transition", {"peer_id": peer_id, "from": current, "to": target, "reason": req.reason})
     return {"ok": True, "peer": {"peer_id": peer_id, **row}, "committed": committed, "latest_commit": gm.latest_commit()}
 

--- a/app/registry_lifecycle/service.py
+++ b/app/registry_lifecycle/service.py
@@ -10,11 +10,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
 from app.git_safety import try_commit_paths
+from app.segment_history.locking import (
+    LockInfrastructureError,
+    segment_history_source_lock,
+)
 from app.storage import safe_path, write_bytes_file, write_text_file
 
 _logger = logging.getLogger(__name__)
@@ -179,6 +184,83 @@ def _write_json(path: Path, data: dict[str, Any]) -> None:
     write_text_file(path, json.dumps(data, ensure_ascii=False, indent=2))
 
 
+def _write_json_exclusive(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON data to path, failing if the file already exists.
+
+    Uses ``O_CREAT | O_EXCL`` to claim the filename atomically, then
+    delegates to ``write_text_file`` for durable content (temp+fsync+rename).
+    If the durable write fails, the empty sentinel is removed so a future
+    retry can reclaim the sequence.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    os.close(fd)
+    try:
+        write_text_file(path, json.dumps(data, ensure_ascii=False, indent=2))
+    except Exception:
+        path.unlink(missing_ok=True)
+        raise
+
+
+_SHARD_WRITE_MAX_RETRIES = 3
+
+
+def _write_shard_pair_exclusive(
+    *,
+    family: str,
+    cut_at: datetime,
+    shard_dir: Path,
+    stub_dir: Path,
+    shard_dir_rel: str,
+    stub_dir_rel: str,
+    shard_payload: dict[str, Any],
+    stub_payload: dict[str, Any],
+) -> tuple[str, str, str]:
+    """Allocate a shard ID and write shard+stub atomically with retry on collision.
+
+    Returns ``(shard_id, shard_rel, stub_rel)`` on success.
+    Raises ``RuntimeError`` if all retries are exhausted.
+    """
+    shard_dir.mkdir(parents=True, exist_ok=True)
+    stub_dir.mkdir(parents=True, exist_ok=True)
+
+    for attempt in range(_SHARD_WRITE_MAX_RETRIES):
+        shard_id = _next_shard_id(family, cut_at, shard_dir)
+        shard_rel = f"{shard_dir_rel}/{shard_id}.json"
+        stub_rel = f"{stub_dir_rel}/{shard_id}.json"
+        shard_path = shard_dir / f"{shard_id}.json"
+        stub_path = stub_dir / f"{shard_id}.json"
+
+        # Update shard_id in payloads (they reference their own ID)
+        shard_payload["shard_id"] = shard_id
+        stub_payload["shard_id"] = shard_id
+        stub_payload["payload_path"] = shard_rel
+
+        try:
+            _write_json_exclusive(shard_path, shard_payload)
+        except FileExistsError:
+            if attempt == _SHARD_WRITE_MAX_RETRIES - 1:
+                raise RuntimeError(f"Shard ID collision exhausted {_SHARD_WRITE_MAX_RETRIES} retries for {family}")
+            _logger.debug("Shard ID collision on %s (attempt %d), retrying", shard_id, attempt + 1)
+            continue
+
+        try:
+            _write_json_exclusive(stub_path, stub_payload)
+        except FileExistsError:
+            shard_path.unlink(missing_ok=True)
+            if attempt == _SHARD_WRITE_MAX_RETRIES - 1:
+                raise RuntimeError(f"Stub ID collision exhausted {_SHARD_WRITE_MAX_RETRIES} retries for {family}")
+            _logger.debug("Stub ID collision on %s (attempt %d), retrying", shard_id, attempt + 1)
+            continue
+        except Exception:
+            shard_path.unlink(missing_ok=True)
+            raise
+
+        return shard_id, shard_rel, stub_rel
+
+    raise RuntimeError(f"Shard write exhausted {_SHARD_WRITE_MAX_RETRIES} retries for {family}")
+
+
 # ---------------------------------------------------------------------------
 # Effective delivery status (mirrors messages/service.py logic)
 # ---------------------------------------------------------------------------
@@ -269,6 +351,29 @@ def delivery_maintenance_pass(
 
     Returns a result dict with ok, warnings, shard_id (if created), and counts.
     """
+    lock_dir = repo_root / ".locks"
+    try:
+        lock_ctx = segment_history_source_lock("registry:delivery_index", lock_dir=lock_dir)
+    except LockInfrastructureError:
+        return {"ok": False, "family": "delivery", "warning": "registry_head_lock_unavailable:delivery_index"}
+    with lock_ctx:
+        return _delivery_maintenance_pass_locked(
+            repo_root=repo_root, now=now,
+            terminal_retention_days=terminal_retention_days,
+            idempotency_retention_days=idempotency_retention_days,
+            batch_limit=batch_limit,
+        )
+
+
+def _delivery_maintenance_pass_locked(
+    *,
+    repo_root: Path,
+    now: datetime,
+    terminal_retention_days: int,
+    idempotency_retention_days: int,
+    batch_limit: int,
+) -> dict[str, Any]:
+    """Inner implementation of delivery_maintenance_pass, called under head-file lock."""
     warnings: list[str] = []
     head_path = safe_path(repo_root, DELIVERY_STATE_REL)
     head, load_warnings = _load_json_head(
@@ -353,10 +458,6 @@ def delivery_maintenance_pass(
     cut_idempotency: dict[str, str] = {}
 
     if eligible_records:
-        shard_dir = safe_path(repo_root, DELIVERY_HISTORY_DIR_REL)
-        shard_dir.mkdir(parents=True, exist_ok=True)
-        shard_id = _next_shard_id("delivery", now, shard_dir)
-
         for msg_id, row, _ in eligible_records:
             cut_records[msg_id] = row
         cut_idempotency = dict(idem_to_externalize)
@@ -381,7 +482,7 @@ def delivery_maintenance_pass(
         shard_payload = {
             "schema_type": "delivery_history_shard",
             "schema_version": "1.0",
-            "shard_id": shard_id,
+            "shard_id": "",
             "source_head_path": DELIVERY_STATE_REL,
             "cut_at": now.isoformat(),
             "records": cut_records,
@@ -389,16 +490,24 @@ def delivery_maintenance_pass(
             "summary": summary,
         }
 
-        shard_rel = f"{DELIVERY_HISTORY_DIR_REL}/{shard_id}.json"
-        stub_rel = f"{DELIVERY_STUB_DIR_REL}/{shard_id}.json"
-
         stub_payload = _create_stub(
             family="delivery",
-            shard_id=shard_id,
-            payload_path=shard_rel,
+            shard_id="",
+            payload_path="",
             created_at=now,
             source_head_path=DELIVERY_STATE_REL,
             summary=summary,
+        )
+
+        shard_id, shard_rel, stub_rel = _write_shard_pair_exclusive(
+            family="delivery",
+            cut_at=now,
+            shard_dir=safe_path(repo_root, DELIVERY_HISTORY_DIR_REL),
+            stub_dir=safe_path(repo_root, DELIVERY_STUB_DIR_REL),
+            shard_dir_rel=DELIVERY_HISTORY_DIR_REL,
+            stub_dir_rel=DELIVERY_STUB_DIR_REL,
+            shard_payload=shard_payload,
+            stub_payload=stub_payload,
         )
 
     # --- Apply changes to head ---
@@ -431,23 +540,22 @@ def delivery_maintenance_pass(
     head["records"] = records
     head["idempotency"] = idempotency
 
-    # --- Write files with rollback (shard→stub→head so partial rollback
-    # failure leaves an orphaned shard, not a mutilated head) ---
-    paths_to_write: list[tuple[Path, str, dict[str, Any]]] = []
+    # --- Write head with rollback; shard+stub already written exclusively ---
+    written_rels: list[str] = []
+    rollback_plan: list[tuple[Path, bytes | None]] = []
     if shard_rel:
-        shard_path = safe_path(repo_root, shard_rel)
-        paths_to_write.append((shard_path, shard_rel, shard_payload))  # type: ignore[possibly-undefined]
+        rollback_plan.append((safe_path(repo_root, shard_rel), None))
+        written_rels.append(shard_rel)
     if stub_rel:
-        stub_path = safe_path(repo_root, stub_rel)
-        paths_to_write.append((stub_path, stub_rel, stub_payload))  # type: ignore[possibly-undefined]
-    paths_to_write.append((head_path, DELIVERY_STATE_REL, head))
+        rollback_plan.append((safe_path(repo_root, stub_rel), None))
+        written_rels.append(stub_rel)
+    rollback_plan.extend(_capture_rollback([head_path]))
+    written_rels.append(DELIVERY_STATE_REL)
 
-    rollback = _capture_rollback([p for p, _, _ in paths_to_write])
     try:
-        for path, _, data in paths_to_write:
-            _write_json(path, data)
+        _write_json(head_path, head)
     except Exception:
-        _restore_rollback(rollback)
+        _restore_rollback(rollback_plan)
         raise
 
     return {
@@ -459,7 +567,7 @@ def delivery_maintenance_pass(
         "shard_id": shard_id,
         "shard_path": shard_rel,
         "stub_path": stub_rel,
-        "written_paths": [rel for _, rel, _ in paths_to_write],
+        "written_paths": written_rels,
         "warnings": warnings,
     }
 
@@ -476,6 +584,26 @@ def nonce_maintenance_pass(
     batch_limit: int,
 ) -> dict[str, Any]:
     """Run one maintenance pass for nonce_index.json (prune-only)."""
+    lock_dir = repo_root / ".locks"
+    try:
+        lock_ctx = segment_history_source_lock("registry:nonce_index", lock_dir=lock_dir)
+    except LockInfrastructureError:
+        return {"ok": False, "family": "nonce", "warning": "registry_head_lock_unavailable:nonce_index"}
+    with lock_ctx:
+        return _nonce_maintenance_pass_locked(
+            repo_root=repo_root, now=now,
+            nonce_retention_days=nonce_retention_days, batch_limit=batch_limit,
+        )
+
+
+def _nonce_maintenance_pass_locked(
+    *,
+    repo_root: Path,
+    now: datetime,
+    nonce_retention_days: int,
+    batch_limit: int,
+) -> dict[str, Any]:
+    """Inner implementation of nonce_maintenance_pass, called under head-file lock."""
     warnings: list[str] = []
     head_path = safe_path(repo_root, NONCE_INDEX_REL)
     head, load_warnings = _load_json_head(
@@ -572,6 +700,28 @@ def peer_trust_maintenance_pass(
     batch_limit: int,
 ) -> dict[str, Any]:
     """Run one maintenance pass for peers/registry.json trust history."""
+    lock_dir = repo_root / ".locks"
+    try:
+        lock_ctx = segment_history_source_lock("registry:peers_registry", lock_dir=lock_dir)
+    except LockInfrastructureError:
+        return {"ok": False, "family": "peer_trust", "warning": "registry_head_lock_unavailable:peers_registry"}
+    with lock_ctx:
+        return _peer_trust_maintenance_pass_locked(
+            repo_root=repo_root, now=now,
+            max_hot_entries=max_hot_entries, hot_retention_days=hot_retention_days,
+            batch_limit=batch_limit,
+        )
+
+
+def _peer_trust_maintenance_pass_locked(
+    *,
+    repo_root: Path,
+    now: datetime,
+    max_hot_entries: int,
+    hot_retention_days: int,
+    batch_limit: int,
+) -> dict[str, Any]:
+    """Inner implementation of peer_trust_maintenance_pass, called under head-file lock."""
     warnings: list[str] = []
     head_path = safe_path(repo_root, PEERS_REGISTRY_REL)
     head, load_warnings = _load_json_head(
@@ -620,10 +770,6 @@ def peer_trust_maintenance_pass(
             continue
 
         # Build shard
-        shard_dir = safe_path(repo_root, PEER_TRUST_HISTORY_DIR_REL)
-        shard_dir.mkdir(parents=True, exist_ok=True)
-        shard_id = _next_shard_id("peer_trust", now, shard_dir)
-
         transition_timestamps: list[datetime] = [dt for t in eligible if (dt := _parse_iso(t.get("at"))) is not None]
         final_trust_after = str(row.get("trust_level") or "untrusted")
 
@@ -637,7 +783,7 @@ def peer_trust_maintenance_pass(
         shard_payload = {
             "schema_type": "peer_trust_history_shard",
             "schema_version": "1.0",
-            "shard_id": shard_id,
+            "shard_id": "",
             "source_head_path": PEERS_REGISTRY_REL,
             "peer_id": peer_id,
             "cut_at": now.isoformat(),
@@ -645,19 +791,27 @@ def peer_trust_maintenance_pass(
             "summary": summary,
         }
 
-        shard_rel = f"{PEER_TRUST_HISTORY_DIR_REL}/{shard_id}.json"
-        stub_rel = f"{PEER_TRUST_STUB_DIR_REL}/{shard_id}.json"
-
         stub_summary = dict(summary)
         stub_summary["peer_id"] = peer_id
 
         stub_payload = _create_stub(
             family="peer_trust",
-            shard_id=shard_id,
-            payload_path=shard_rel,
+            shard_id="",
+            payload_path="",
             created_at=now,
             source_head_path=PEERS_REGISTRY_REL,
             summary=stub_summary,
+        )
+
+        shard_id, shard_rel, stub_rel = _write_shard_pair_exclusive(
+            family="peer_trust",
+            cut_at=now,
+            shard_dir=safe_path(repo_root, PEER_TRUST_HISTORY_DIR_REL),
+            stub_dir=safe_path(repo_root, PEER_TRUST_STUB_DIR_REL),
+            shard_dir_rel=PEER_TRUST_HISTORY_DIR_REL,
+            stub_dir_rel=PEER_TRUST_STUB_DIR_REL,
+            shard_payload=shard_payload,
+            stub_payload=stub_payload,
         )
 
         # Update peer row: remaining prefix + keep tail
@@ -670,8 +824,6 @@ def peer_trust_maintenance_pass(
             "shard_rel": shard_rel,
             "stub_rel": stub_rel,
             "transition_count": len(eligible),
-            "shard_payload": shard_payload,
-            "stub_payload": stub_payload,
         })
 
     if not shard_results:
@@ -728,22 +880,20 @@ def peer_trust_maintenance_pass(
 
     head["peers"] = peers
 
-    # --- Write all files with rollback (shards→stubs→head so partial rollback
-    # failure leaves orphaned shards, not a mutilated head) ---
-    paths_to_write: list[tuple[Path, str, dict[str, Any]]] = []
+    # --- Write head with rollback; shards+stubs already written exclusively ---
+    written_rels: list[str] = []
+    rollback_plan: list[tuple[Path, bytes | None]] = []
     for sr in shard_results:
-        shard_path = safe_path(repo_root, sr["shard_rel"])
-        paths_to_write.append((shard_path, sr["shard_rel"], sr["shard_payload"]))
-        stub_path = safe_path(repo_root, sr["stub_rel"])
-        paths_to_write.append((stub_path, sr["stub_rel"], sr["stub_payload"]))
-    paths_to_write.append((head_path, PEERS_REGISTRY_REL, head))
+        rollback_plan.append((safe_path(repo_root, sr["shard_rel"]), None))
+        rollback_plan.append((safe_path(repo_root, sr["stub_rel"]), None))
+        written_rels.extend([sr["shard_rel"], sr["stub_rel"]])
+    rollback_plan.extend(_capture_rollback([head_path]))
+    written_rels.append(PEERS_REGISTRY_REL)
 
-    rollback = _capture_rollback([p for p, _, _ in paths_to_write])
     try:
-        for path, _, data in paths_to_write:
-            _write_json(path, data)
+        _write_json(head_path, head)
     except Exception:
-        _restore_rollback(rollback)
+        _restore_rollback(rollback_plan)
         raise
 
     return {
@@ -752,7 +902,7 @@ def peer_trust_maintenance_pass(
         "transitions_externalized": total_externalized,
         "shards_created": len(shard_results),
         "shards": [{"peer_id": sr["peer_id"], "shard_id": sr["shard_id"], "transition_count": sr["transition_count"]} for sr in shard_results],
-        "written_paths": [rel for _, rel, _ in paths_to_write],
+        "written_paths": written_rels,
         "warnings": warnings,
     }
 
@@ -781,10 +931,6 @@ def externalize_superseded_push(
     if pushed_at > cutoff:
         return None  # Still within hot window
 
-    shard_dir = safe_path(repo_root, REPLICATION_STATE_HISTORY_DIR_REL)
-    shard_dir.mkdir(parents=True, exist_ok=True)
-    shard_id = _next_shard_id("replication_state", now, shard_dir)
-
     summary = {
         "push_event_count": 1,
         "pull_event_count": 0,
@@ -795,7 +941,7 @@ def externalize_superseded_push(
     shard_payload = {
         "schema_type": "replication_state_history_shard",
         "schema_version": "1.0",
-        "shard_id": shard_id,
+        "shard_id": "",
         "source_head_path": REPLICATION_STATE_REL,
         "cut_at": now.isoformat(),
         "push_events": [{"superseded_at": now.isoformat(), "row": previous_row}],
@@ -803,27 +949,25 @@ def externalize_superseded_push(
         "summary": summary,
     }
 
-    shard_rel = f"{REPLICATION_STATE_HISTORY_DIR_REL}/{shard_id}.json"
-    stub_rel = f"{REPLICATION_STATE_STUB_DIR_REL}/{shard_id}.json"
-
     stub_payload = _create_stub(
         family="replication_state",
-        shard_id=shard_id,
-        payload_path=shard_rel,
+        shard_id="",
+        payload_path="",
         created_at=now,
         source_head_path=REPLICATION_STATE_REL,
         summary=summary,
     )
 
-    shard_path = safe_path(repo_root, shard_rel)
-    stub_path = safe_path(repo_root, stub_rel)
-    rollback = _capture_rollback([shard_path, stub_path])
-    try:
-        _write_json(shard_path, shard_payload)
-        _write_json(stub_path, stub_payload)
-    except Exception:
-        _restore_rollback(rollback)
-        raise
+    shard_id, shard_rel, stub_rel = _write_shard_pair_exclusive(
+        family="replication_state",
+        cut_at=now,
+        shard_dir=safe_path(repo_root, REPLICATION_STATE_HISTORY_DIR_REL),
+        stub_dir=safe_path(repo_root, REPLICATION_STATE_STUB_DIR_REL),
+        shard_dir_rel=REPLICATION_STATE_HISTORY_DIR_REL,
+        stub_dir_rel=REPLICATION_STATE_STUB_DIR_REL,
+        shard_payload=shard_payload,
+        stub_payload=stub_payload,
+    )
 
     return {
         "shard_id": shard_id,
@@ -849,10 +993,6 @@ def externalize_superseded_pull(
     if pulled_at > cutoff:
         return None
 
-    shard_dir = safe_path(repo_root, REPLICATION_STATE_HISTORY_DIR_REL)
-    shard_dir.mkdir(parents=True, exist_ok=True)
-    shard_id = _next_shard_id("replication_state", now, shard_dir)
-
     summary = {
         "push_event_count": 0,
         "pull_event_count": 1,
@@ -863,7 +1003,7 @@ def externalize_superseded_pull(
     shard_payload = {
         "schema_type": "replication_state_history_shard",
         "schema_version": "1.0",
-        "shard_id": shard_id,
+        "shard_id": "",
         "source_head_path": REPLICATION_STATE_REL,
         "cut_at": now.isoformat(),
         "push_events": [],
@@ -871,27 +1011,25 @@ def externalize_superseded_pull(
         "summary": summary,
     }
 
-    shard_rel = f"{REPLICATION_STATE_HISTORY_DIR_REL}/{shard_id}.json"
-    stub_rel = f"{REPLICATION_STATE_STUB_DIR_REL}/{shard_id}.json"
-
     stub_payload = _create_stub(
         family="replication_state",
-        shard_id=shard_id,
-        payload_path=shard_rel,
+        shard_id="",
+        payload_path="",
         created_at=now,
         source_head_path=REPLICATION_STATE_REL,
         summary=summary,
     )
 
-    shard_path = safe_path(repo_root, shard_rel)
-    stub_path = safe_path(repo_root, stub_rel)
-    rollback = _capture_rollback([shard_path, stub_path])
-    try:
-        _write_json(shard_path, shard_payload)
-        _write_json(stub_path, stub_payload)
-    except Exception:
-        _restore_rollback(rollback)
-        raise
+    shard_id, shard_rel, stub_rel = _write_shard_pair_exclusive(
+        family="replication_state",
+        cut_at=now,
+        shard_dir=safe_path(repo_root, REPLICATION_STATE_HISTORY_DIR_REL),
+        stub_dir=safe_path(repo_root, REPLICATION_STATE_STUB_DIR_REL),
+        shard_dir_rel=REPLICATION_STATE_HISTORY_DIR_REL,
+        stub_dir_rel=REPLICATION_STATE_STUB_DIR_REL,
+        shard_payload=shard_payload,
+        stub_payload=stub_payload,
+    )
 
     return {
         "shard_id": shard_id,
@@ -908,6 +1046,27 @@ def replication_state_prune_idempotency(
     batch_limit: int,
 ) -> dict[str, Any]:
     """Prune expired pull_idempotency entries from replication_state.json."""
+    lock_dir = repo_root / ".locks"
+    try:
+        lock_ctx = segment_history_source_lock("registry:replication_state", lock_dir=lock_dir)
+    except LockInfrastructureError:
+        return {"ok": False, "family": "replication_state", "warning": "registry_head_lock_unavailable:replication_state"}
+    with lock_ctx:
+        return _replication_state_prune_idempotency_locked(
+            repo_root=repo_root, now=now,
+            pull_idempotency_retention_days=pull_idempotency_retention_days,
+            batch_limit=batch_limit,
+        )
+
+
+def _replication_state_prune_idempotency_locked(
+    *,
+    repo_root: Path,
+    now: datetime,
+    pull_idempotency_retention_days: int,
+    batch_limit: int,
+) -> dict[str, Any]:
+    """Inner implementation, called under head-file lock."""
     warnings: list[str] = []
     head_path = safe_path(repo_root, REPLICATION_STATE_REL)
     head, load_warnings = _load_json_head(
@@ -988,6 +1147,25 @@ def tombstone_maintenance_pass(
     batch_limit: int,
 ) -> dict[str, Any]:
     """Run one maintenance pass for replication_tombstones.json."""
+    lock_dir = repo_root / ".locks"
+    try:
+        lock_ctx = segment_history_source_lock("registry:replication_tombstones", lock_dir=lock_dir)
+    except LockInfrastructureError:
+        return {"ok": False, "family": "replication_tombstones", "warning": "registry_head_lock_unavailable:replication_tombstones"}
+    with lock_ctx:
+        return _tombstone_maintenance_pass_locked(
+            repo_root=repo_root, now=now, grace_days=grace_days, batch_limit=batch_limit,
+        )
+
+
+def _tombstone_maintenance_pass_locked(
+    *,
+    repo_root: Path,
+    now: datetime,
+    grace_days: int,
+    batch_limit: int,
+) -> dict[str, Any]:
+    """Inner implementation, called under head-file lock."""
     warnings: list[str] = []
     head_path = safe_path(repo_root, REPLICATION_TOMBSTONES_REL)
     head, load_warnings = _load_json_head(
@@ -1026,10 +1204,6 @@ def tombstone_maintenance_pass(
         }
 
     # Build shard
-    shard_dir = safe_path(repo_root, REPLICATION_TOMBSTONE_HISTORY_DIR_REL)
-    shard_dir.mkdir(parents=True, exist_ok=True)
-    shard_id = _next_shard_id("replication_tombstone", now, shard_dir)
-
     cut_entries: dict[str, Any] = {}
     tombstone_timestamps: list[datetime] = []
     for path_key, row, ts in eligible:
@@ -1045,23 +1219,31 @@ def tombstone_maintenance_pass(
     shard_payload = {
         "schema_type": "replication_tombstone_shard",
         "schema_version": "1.0",
-        "shard_id": shard_id,
+        "shard_id": "",
         "source_head_path": REPLICATION_TOMBSTONES_REL,
         "cut_at": now.isoformat(),
         "entries": cut_entries,
         "summary": summary,
     }
 
-    shard_rel = f"{REPLICATION_TOMBSTONE_HISTORY_DIR_REL}/{shard_id}.json"
-    stub_rel = f"{REPLICATION_TOMBSTONE_STUB_DIR_REL}/{shard_id}.json"
-
     stub_payload = _create_stub(
         family="replication_tombstone",
-        shard_id=shard_id,
-        payload_path=shard_rel,
+        shard_id="",
+        payload_path="",
         created_at=now,
         source_head_path=REPLICATION_TOMBSTONES_REL,
         summary=summary,
+    )
+
+    shard_id, shard_rel, stub_rel = _write_shard_pair_exclusive(
+        family="replication_tombstone",
+        cut_at=now,
+        shard_dir=safe_path(repo_root, REPLICATION_TOMBSTONE_HISTORY_DIR_REL),
+        stub_dir=safe_path(repo_root, REPLICATION_TOMBSTONE_STUB_DIR_REL),
+        shard_dir_rel=REPLICATION_TOMBSTONE_HISTORY_DIR_REL,
+        stub_dir_rel=REPLICATION_TOMBSTONE_STUB_DIR_REL,
+        shard_payload=shard_payload,
+        stub_payload=stub_payload,
     )
 
     # Remove from head
@@ -1092,20 +1274,17 @@ def tombstone_maintenance_pass(
 
     head["entries"] = entries
 
-    # Write with rollback (shard→stub→head so partial rollback failure
-    # leaves an orphaned shard, not a mutilated head)
-    paths_to_write: list[tuple[Path, str, dict[str, Any]]] = [
-        (safe_path(repo_root, shard_rel), shard_rel, shard_payload),
-        (safe_path(repo_root, stub_rel), stub_rel, stub_payload),
-        (head_path, REPLICATION_TOMBSTONES_REL, head),
+    # --- Write head with rollback; shard+stub already written exclusively ---
+    rollback_plan: list[tuple[Path, bytes | None]] = [
+        (safe_path(repo_root, shard_rel), None),
+        (safe_path(repo_root, stub_rel), None),
     ]
+    rollback_plan.extend(_capture_rollback([head_path]))
 
-    rollback = _capture_rollback([p for p, _, _ in paths_to_write])
     try:
-        for path, _, data in paths_to_write:
-            _write_json(path, data)
+        _write_json(head_path, head)
     except Exception:
-        _restore_rollback(rollback)
+        _restore_rollback(rollback_plan)
         raise
 
     return {
@@ -1115,7 +1294,7 @@ def tombstone_maintenance_pass(
         "shard_id": shard_id,
         "shard_path": shard_rel,
         "stub_path": stub_rel,
-        "written_paths": [rel for _, rel, _ in paths_to_write],
+        "written_paths": [shard_rel, stub_rel, REPLICATION_TOMBSTONES_REL],
         "warnings": warnings,
     }
 

--- a/app/security/service.py
+++ b/app/security/service.py
@@ -23,6 +23,7 @@ from app.models import (
     SecurityTokenRotateRequest,
 )
 from app.git_safety import safe_commit_updated_file, try_commit_file
+from app.segment_history.locking import segment_history_source_lock, SegmentHistoryLockTimeout, LockInfrastructureError
 from app.storage import safe_path, write_text_file
 
 TOKEN_CONFIG_REL = "config/peer_tokens.json"
@@ -801,25 +802,29 @@ def verify_signed_payload_service(
     elif not signature_valid:
         reason = "invalid_signature"
     elif consume_nonce:
-        nonce_payload = _load_nonce_index(settings.repo_root)
-        _prune_nonce_entries(nonce_payload, now)
-        entries = nonce_payload.setdefault("entries", {})
-        key = f"{key_id}|{nonce}"
-        if key in entries:
-            replay_detected = True
-            reason = "replay_detected"
-        else:
-            entries[key] = {"key_id": key_id, "nonce": nonce, "first_seen_at": now.isoformat(), "expires_at": expires_at}
-            nonce_path = _write_nonce_index(settings.repo_root, nonce_payload)
-            nonce_committed = try_commit_file(
-                path=nonce_path, gm=gm,
-                commit_message=f"messages: consume nonce {key_id}:{nonce}",
-            )
-            if nonce_committed:
-                committed_files.append(NONCE_INDEX_REL)
-            else:
-                warnings.append("nonce_commit_failed: nonce consumed on disk but not committed to git")
-            nonce_consumed = True
+        try:
+            with segment_history_source_lock("registry:nonce_index", lock_dir=settings.repo_root / ".locks"):
+                nonce_payload = _load_nonce_index(settings.repo_root)
+                _prune_nonce_entries(nonce_payload, now)
+                entries = nonce_payload.setdefault("entries", {})
+                key = f"{key_id}|{nonce}"
+                if key in entries:
+                    replay_detected = True
+                    reason = "replay_detected"
+                else:
+                    entries[key] = {"key_id": key_id, "nonce": nonce, "first_seen_at": now.isoformat(), "expires_at": expires_at}
+                    nonce_path = _write_nonce_index(settings.repo_root, nonce_payload)
+                    nonce_committed = try_commit_file(
+                        path=nonce_path, gm=gm,
+                        commit_message=f"messages: consume nonce {key_id}:{nonce}",
+                    )
+                    if nonce_committed:
+                        committed_files.append(NONCE_INDEX_REL)
+                    else:
+                        warnings.append("nonce_commit_failed: nonce consumed on disk but not committed to git")
+                    nonce_consumed = True
+        except (SegmentHistoryLockTimeout, LockInfrastructureError):
+            raise HTTPException(status_code=503, detail="Nonce index lock unavailable; retry")
 
     valid = reason == "ok"
     if not valid:

--- a/app/segment_history/manifest.py
+++ b/app/segment_history/manifest.py
@@ -7,8 +7,10 @@ import fcntl
 import json
 import logging
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Generator
 
 from app.storage import write_text_file
 
@@ -198,6 +200,73 @@ def read_manifest(repo_root: Path, family: str = "") -> dict | None:
         return data
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
         raise ValueError(f"Corrupt manifest at {path}: {exc}") from exc
+
+
+@contextmanager
+def manifest_lock(repo_root: Path, family: str) -> Generator[None, None, None]:
+    """Acquire the per-family manifest advisory lock.
+
+    Callers that need to read and then conditionally remove a manifest
+    under a single lock should use this context manager with
+    :func:`read_manifest` and :func:`remove_manifest_unlocked` instead
+    of calling :func:`remove_manifest` (which acquires its own lock).
+    """
+    lock_path = _manifest_lock_path(repo_root, family)
+    try:
+        lock_file = lock_path.open("a")
+    except OSError as exc:
+        _log.warning("Could not open manifest lock %s: %s", lock_path, exc)
+        raise
+    try:
+        deadline = time.monotonic() + _MANIFEST_LOCK_TIMEOUT
+        while True:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    lock_file.close()
+                    _log.warning("Manifest lock timeout for family %s", family)
+                    raise TimeoutError(f"Manifest lock timeout for family '{family}'")
+                time.sleep(_MANIFEST_LOCK_POLL)
+            except OSError as exc:
+                if exc.errno == errno.EINTR:
+                    continue
+                lock_file.close()
+                raise
+        yield
+    finally:
+        lock_file.close()
+
+
+def remove_manifest_unlocked(
+    repo_root: Path,
+    family: str = "",
+    *,
+    expected_operation: str | None = None,
+) -> bool:
+    """Remove the manifest file without acquiring the advisory lock.
+
+    The caller must already hold the per-family manifest lock (e.g. via
+    :func:`manifest_lock`).  This prevents double-lock issues when the
+    caller needs to read and remove under a single lock hold.
+    """
+    path = manifest_path(repo_root, family)
+    if not path.is_file():
+        return False
+    if expected_operation is not None:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if data.get("operation") != expected_operation:
+                return False
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+            _log.debug("Corrupt manifest during removal check for %s; safe to remove", path)
+    try:
+        path.unlink()
+        return True
+    except OSError as exc:
+        _log.warning("Could not remove manifest %s: %s", path, exc)
+    return False
 
 
 def remove_manifest(

--- a/app/segment_history/service.py
+++ b/app/segment_history/service.py
@@ -9,6 +9,7 @@ import logging
 import re
 import subprocess
 import threading
+import time
 import zlib
 from datetime import datetime, timezone
 from pathlib import Path
@@ -762,6 +763,21 @@ def _cleanup_family_orphans(repo_root: Path, family: str) -> int:
                         _log.debug("Skipping in-flight manifest target: %s", f_rel)
                         continue
                     if f_rel not in tracked:
+                        # Grace period: skip files newer than 5 minutes
+                        # to avoid deleting in-flight payloads from
+                        # concurrent operations that have not yet
+                        # written their crash-recovery manifest.
+                        try:
+                            age_seconds = time.time() - f.stat().st_mtime
+                            if age_seconds < 300:
+                                _log.debug(
+                                    "Skipping recent orphan (%.0fs old): %s",
+                                    age_seconds,
+                                    f_rel,
+                                )
+                                continue
+                        except OSError:
+                            continue  # Cannot stat — skip safely
                         try:
                             f.unlink()
                             removed += 1
@@ -834,13 +850,42 @@ def _reconcile_manifest_residue(
     Returns None if no manifest exists, or a dict with ``warning`` and
     ``reconciled_source_paths`` keys describing the reconciliation action.
     """
-    from app.segment_history.manifest import read_manifest, remove_manifest
+    from app.segment_history.manifest import manifest_lock
+
+    # Acquire the manifest lock before reading so that a concurrent
+    # write_manifest cannot replace the manifest between our read and
+    # a subsequent remove, which would delete the fresh manifest and
+    # destroy the concurrent operation's crash-recovery pointer.
+    try:
+        lock_ctx = manifest_lock(repo_root, caller_family)
+    except (OSError, TimeoutError):
+        _log.warning("Could not acquire manifest lock for %s reconciliation; deferring", caller_family)
+        return None
+    with lock_ctx:
+        return _reconcile_manifest_residue_locked(
+            repo_root=repo_root,
+            caller_family=caller_family,
+            caller_op=caller_op,
+            gm=gm,
+            locked_source_paths=locked_source_paths,
+        )
+
+
+def _reconcile_manifest_residue_locked(
+    repo_root: Path,
+    caller_family: str,
+    caller_op: str,
+    gm: Any,
+    locked_source_paths: set[str] | None,
+) -> dict[str, Any] | None:
+    """Inner implementation, called under manifest lock."""
+    from app.segment_history.manifest import read_manifest, remove_manifest_unlocked
 
     try:
         manifest = read_manifest(repo_root, caller_family)
     except ValueError:
         # Corrupt manifest -- clean up and scan for orphans
-        remove_manifest(repo_root, caller_family)
+        remove_manifest_unlocked(repo_root, caller_family)
         orphan_count = _cleanup_family_orphans(repo_root, caller_family)
         detail = "segment_history_manifest_unreadable_cleanup"
         if orphan_count:
@@ -873,7 +918,7 @@ def _reconcile_manifest_residue(
             "Corrupt manifest for %s: missing required fields %s; removing and cleaning orphans",
             caller_family, _missing_fields,
         )
-        remove_manifest(repo_root, caller_family)
+        remove_manifest_unlocked(repo_root, caller_family)
         orphan_count = _cleanup_family_orphans(repo_root, caller_family)
         detail = f"segment_history_manifest_schema_invalid: missing {_missing_fields}"
         if orphan_count:
@@ -903,7 +948,7 @@ def _reconcile_manifest_residue(
         except Exception:
             all_in_head = False  # git check failed — conservative path
         if all_in_head:
-            remove_manifest(repo_root, caller_family, expected_operation=recorded_op)
+            remove_manifest_unlocked(repo_root, caller_family, expected_operation=recorded_op)
             # Truncate sources to remove already-committed rolled data
             if recorded_op in ("maintenance", "write_time_rollover"):
                 source_paths_list = manifest.get("source_paths", [])
@@ -1082,7 +1127,7 @@ def _reconcile_manifest_residue(
     # the next reconciliation pass retry, matching the maintenance and
     # cold-store pattern (F5).
     if recovered or not existing_targets:
-        remove_manifest(repo_root, caller_family, expected_operation=recorded_op)
+        remove_manifest_unlocked(repo_root, caller_family, expected_operation=recorded_op)
 
     action = "recovered" if recovered else f"preserved={len(existing_targets)}"
     detail = f"segment_history_manifest_residue:{recorded_op}:{family}:{len(segment_ids)}:{action}"

--- a/tests/test_registry_lifecycle_112.py
+++ b/tests/test_registry_lifecycle_112.py
@@ -956,17 +956,19 @@ class TestRegistryMaintenanceOrchestrator(unittest.TestCase):
             "file_count": 10,
         }
 
-        # Patch _write_json to fail on the second call (stub write)
+        # Patch _write_json_exclusive to fail (stub write)
+        original_write_json_exclusive = __import__("app.registry_lifecycle.service", fromlist=["_write_json_exclusive"])._write_json_exclusive
+
         call_count = 0
 
-        def failing_write_json(path, data):
+        def failing_write_json_exclusive(path, data):
             nonlocal call_count
             call_count += 1
             if call_count == 2:
                 raise OSError("disk full")
-            write_text_file(path, json.dumps(data, ensure_ascii=False, indent=2))
+            original_write_json_exclusive(path, data)
 
-        with patch("app.registry_lifecycle.service._write_json", side_effect=failing_write_json):
+        with patch("app.registry_lifecycle.service._write_json_exclusive", side_effect=failing_write_json_exclusive):
             with self.assertRaises(OSError):
                 externalize_superseded_push(
                     repo_root=self.repo, now=self.now,
@@ -998,18 +1000,20 @@ class TestRegistryMaintenanceOrchestrator(unittest.TestCase):
         }
         _write_head(self.repo, DELIVERY_STATE_REL, state)
 
+        original_write_json_exclusive = __import__("app.registry_lifecycle.service", fromlist=["_write_json_exclusive"])._write_json_exclusive
+
         call_count = 0
 
-        def failing_write(path, data):
+        def failing_write_exclusive(path, data):
             nonlocal call_count
             call_count += 1
-            if call_count == 2:  # shard write
+            if call_count == 1:  # shard write (first exclusive write)
                 raise OSError("disk full")
-            write_text_file(path, json.dumps(data, ensure_ascii=False, indent=2))
+            original_write_json_exclusive(path, data)
 
         from unittest.mock import patch
-        with patch("app.registry_lifecycle.service._write_json", side_effect=failing_write):
-            with self.assertRaises(OSError):
+        with patch("app.registry_lifecycle.service._write_json_exclusive", side_effect=failing_write_exclusive):
+            with self.assertRaises((OSError, RuntimeError)):
                 delivery_maintenance_pass(
                     repo_root=self.repo, now=self.now,
                     terminal_retention_days=30, idempotency_retention_days=30,


### PR DESCRIPTION
## Summary

Fixes all 9 concurrency/TOCTOU/race-condition findings from the Stage D lifecycle safety review (#92 checklist, final cross-namespace item) across #107-#114 code paths.

- **F1 (HIGH):** Move `unlink()` inside `repository_mutation_lock` in continuity archive/cold-store/rehydrate — prevents crash-window data loss where source file is deleted before git commit
- **F2 (HIGH):** Add per-head-file advisory locks to all registry head-file read-modify-write sequences across 5 modules — prevents concurrent last-writer-wins data loss
- **F3 (HIGH):** Add `O_EXCL` shard writes with retry to registry_lifecycle — prevents TOCTOU on shard ID allocation causing silent overwrites
- **F4 (HIGH):** Add `segment_history_source_lock` to artifact_lifecycle cold-store/rehydrate — serializes concurrent mutations on the same payload
- **F5 (MEDIUM-HIGH):** Add 5-minute mtime grace period to `_cleanup_family_orphans` — protects in-flight payloads from concurrent operations
- **F6 (MEDIUM-HIGH):** Add `manifest_lock` context manager; wrap reconciliation read+remove under single lock — prevents stale manifest deletion
- **F7 (MEDIUM):** Add optional `timeout` parameter to `repository_mutation_lock`; use 15s for fallback snapshots — reduces worst-case timeout stacking from 150s to 105s
- **F8 (MEDIUM):** Add `threading.Lock` guard to `coordination/locking.py` `_ensure_lock_dir` — matches pattern in other locking modules
- **F9 (MEDIUM):** Add retry loop to `_externalize_selected_family` on O_EXCL collision — matches `externalize_superseded_shared` pattern

Fixes #92 (Stage D final cross-namespace lifecycle safety review checklist item)

## Test plan

- [x] All 977 tests pass: `./.venv/bin/python -m unittest discover -s tests -v`
- [x] Ruff clean: `./.venv/bin/python -m ruff check app tests`
- [x] Lock ordering verified: source/artifact lock → registry head-file lock → manifest lock → git lock (never inverted)
- [x] All `unlink()` calls in continuity mutation paths now inside `repository_mutation_lock` scope
- [x] All registry head-file read-modify-write cycles now under per-head-file advisory lock
- [x] All shard writes use O_EXCL with retry
- [x] Rollback paths are best-effort (log, don't raise)
- [x] On timeout/lock-failure, response is graceful degradation (warning or 503)