### PR TITLE
Fix review findings and add payload reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For the full cold-start endpoint sequence, see [System Overview: Agent Usage](do
 - [Reviewer Guide](docs/reviewer-guide.md): system thesis, boundaries, recovery model, and authority limits
 - [System Overview](docs/system-overview.md): implemented product shape and agent usage guidance
 - [API Surface](docs/api-surface.md): currently implemented HTTP behavior grouped by domain
+- [Payload Reference](docs/payload-reference.md): capsule structure, request/response schemas, and field constraints
 - [MCP Guide](docs/mcp.md): MCP bootstrap flow and tool mapping
 - [Go-live Runbook](deploy/GO_LIVE_RUNBOOK.md): operator deployment and go-live workflow
 - [Production Signoff Checklist](deploy/PRODUCTION_SIGNOFF_CHECKLIST.md): production verification and data-safety checks

--- a/app/models.py
+++ b/app/models.py
@@ -574,6 +574,8 @@ class OpsRunRequest(BaseModel):
         "continuity_retention_apply",
         "artifact_history_cold_store",
         "artifact_history_cold_rehydrate",
+        "registry_history_cold_store",
+        "registry_history_cold_rehydrate",
         "segment_history_maintenance",
         "segment_history_cold_store",
         "segment_history_cold_rehydrate",

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -4,7 +4,7 @@ This guide is for agents integrating with CogniRelay, whether starting cold or a
 
 ## What CogniRelay Offers You
 
-CogniRelay is a self-hosted service that preserves bounded orientation state across context-window resets, compaction boundaries, and handoffs to other agents. When you restart or lose context, it gives you back enough of what you were doing — constraints, drift signals, open questions, direction, and decisions you chose not to take — to resume usefully rather than starting blind.
+CogniRelay is a self-hosted service that preserves bounded orientation state across context-window resets, compaction boundaries, and handoffs to other agents. When you restart or lose context, it gives you back enough of what you were doing — constraints (`active_constraints`), drift signals (`drift_signals`), open loops (`open_loops`), stance (`stance_summary`), and decisions you chose not to take (`negative_decisions`) — to resume usefully rather than starting blind.
 
 It also provides:
 
@@ -26,11 +26,11 @@ If you are adding CogniRelay to an existing agent loop and want the smallest use
 1. `POST /v1/continuity/read` with your selector — returns your last persisted orientation capsule
 2. `POST /v1/context/retrieve` for your active task — returns a continuity-shaped context bundle including relevant memory, recent items, and any loaded capsule state
 
-Use the returned capsule to restore your constraints, drift signals, open questions, and direction before you begin working.
+Use the returned capsule to restore your constraints, drift signals, open loops, and stance before you begin working.
 
 **Before compaction or handoff (when you are about to lose context):**
 
-1. `POST /v1/continuity/upsert` with your current orientation — persists your active constraints, drift signals, open questions, current direction, and any negative decisions you want to survive the reset
+1. `POST /v1/continuity/upsert` with your current orientation — persists your active constraints, drift signals, open loops, stance summary, and any negative decisions you want to survive the reset
 
 This is enough for basic orientation recovery. Your next startup will retrieve what you persisted here.
 
@@ -90,5 +90,6 @@ Concretely:
 
 - [System Overview](system-overview.md) for the full product shape and endpoint guidance
 - [API Surface](api-surface.md) for the complete HTTP endpoint reference
+- [Payload Reference](payload-reference.md) for capsule structure, request/response schemas, and field constraints
 - [MCP Guide](mcp.md) if your runtime uses JSON-RPC tool protocols
 - [Reviewer Guide](reviewer-guide.md) for the system thesis, recovery model, and authority boundaries

--- a/docs/api-surface.md
+++ b/docs/api-surface.md
@@ -8,7 +8,7 @@ This document is the canonical human-facing summary of the currently implemented
 
 The sections below mirror that runtime shape and group endpoints by behavior rather than implementation order.
 
-For practical agent integration guidance, start with [Agent Onboarding](agent-onboarding.md). For the higher-level system thesis, recovery model, and authority boundaries, see [Reviewer Guide](reviewer-guide.md).
+For practical agent integration guidance, start with [Agent Onboarding](agent-onboarding.md). For capsule structure and request/response schemas, see [Payload Reference](payload-reference.md). For the higher-level system thesis, recovery model, and authority boundaries, see [Reviewer Guide](reviewer-guide.md).
 
 ## Discovery and contracts
 
@@ -131,7 +131,7 @@ Notable behavior:
 - direct delivery supports idempotency keys and acknowledgment tracking
 - relay forwarding writes immutable transport records plus inbox/thread artifacts
 - signed ingress can be enforced for direct and relayed message flows
-- messages and relay flows may carry stable handoff references via `attachments: ["handoff:{handoff_id}"]`; handoff ids become valid only after the referenced handoff artifact commits successfully
+- messages and relay flows may include handoff references in `attachments` using the convention `"handoff:{handoff_id}"`; the server stores these as opaque strings without validating the referenced artifact exists
 
 ## Shared work and code workflows
 
@@ -147,7 +147,7 @@ Notable behavior:
 Notable behavior:
 
 - task transitions are deterministic and constrained
-- tasks may carry a coordination handoff link through `metadata.handoff_id`; 5A treats this as a deterministic reference convention rather than automatic shared-state coupling
+- tasks may carry a handoff reference in `metadata.handoff_id` by convention; the server stores this as arbitrary task metadata without validating or acting on it
 - patch application validates working tree state and base reference compatibility
 - code merge decisions depend on persisted check evidence rather than implicit local state
 

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -1,0 +1,300 @@
+# Payload Reference
+
+This document describes the request and response payloads for key CogniRelay operations. The runtime source of truth for all input schemas is `GET /v1/discovery/tools`, which returns full JSON schemas for every endpoint.
+
+## Continuity Capsule Structure
+
+A continuity capsule is the core unit of orientation state. It is stored as a JSON file under `memory/continuity/`.
+
+### ContinuityCapsule
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schema_version` | `"1.0"` | no | default `"1.0"` |
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `updated_at` | ISO datetime string | yes | |
+| `verified_at` | ISO datetime string | yes | |
+| `source` | ContinuitySource | yes | |
+| `continuity` | ContinuityState | yes | |
+| `confidence` | ContinuityConfidence | yes | |
+| `verification_kind` | `"self_review"` \| `"external_observation"` \| `"user_confirmation"` \| `"peer_confirmation"` \| `"system_check"` | no | |
+| `attention_policy` | ContinuityAttentionPolicy | no | |
+| `freshness` | ContinuityFreshness | no | |
+| `canonical_sources` | list of strings | no | max 8 items, default `[]` |
+| `metadata` | object | no | default `{}` |
+| `verification_state` | ContinuityVerificationState | no | |
+| `capsule_health` | ContinuityCapsuleHealth | no | |
+
+### ContinuityState
+
+These are the core orientation fields that an agent writes to preserve working state across resets.
+
+| Field | Type | Required | Constraints | Purpose |
+|-------|------|----------|-------------|---------|
+| `top_priorities` | list of strings | yes | max 5 | What matters most right now |
+| `active_concerns` | list of strings | yes | max 5 | Active worries or risks |
+| `active_constraints` | list of strings | yes | max 5 | Hard boundaries on action |
+| `open_loops` | list of strings | yes | max 5 | Unresolved questions or pending items |
+| `stance_summary` | string | yes | max 240 chars | Current direction in one sentence |
+| `drift_signals` | list of strings | yes | max 5 | Signs that orientation may be shifting |
+| `working_hypotheses` | list of strings | no | max 5, default `[]` | Current best-guess assumptions |
+| `long_horizon_commitments` | list of strings | no | max 5, default `[]` | Commitments that outlast this session |
+| `session_trajectory` | list of strings | no | max 5, default `[]` | Key direction changes within this session |
+| `negative_decisions` | list of NegativeDecision | no | max 4, default `[]` | Decisions not to act |
+| `trailing_notes` | list of strings | no | max 3, default `[]` | Low-priority context worth preserving |
+| `curiosity_queue` | list of strings | no | max 5, default `[]` | Questions to revisit later |
+| `relationship_model` | ContinuityRelationshipModel | no | | Relationship-specific hints |
+| `retrieval_hints` | ContinuityRetrievalHints | no | | Preferences for what to load next |
+
+Optional fields have a deterministic trim order under token pressure. When the capsule must fit within a budget, the system trims from the bottom of the table upward — `retrieval_hints` first, then `relationship_model`, then `curiosity_queue`, and so on.
+
+### NegativeDecision
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `decision` | string | yes | 1–160 chars |
+| `rationale` | string | yes | 1–240 chars |
+
+### ContinuitySource
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `producer` | string | yes | 1–100 chars |
+| `update_reason` | `"startup_refresh"` \| `"pre_compaction"` \| `"interaction_boundary"` \| `"manual"` \| `"migration"` | yes | |
+| `inputs` | list of strings | no | max 12, default `[]` |
+
+When `update_reason` is `"interaction_boundary"`, the capsule must also include `metadata.interaction_boundary_kind` as a valid scalar value.
+
+### ContinuityConfidence
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `continuity` | float | yes | 0.0–1.0 |
+| `relationship_model` | float | yes | 0.0–1.0 |
+
+### ContinuityFreshness
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `freshness_class` | `"persistent"` \| `"durable"` \| `"situational"` \| `"ephemeral"` | no | |
+| `expires_at` | ISO datetime string | no | |
+| `stale_after_seconds` | integer | no | 300–31,536,000 |
+
+### ContinuityVerificationState
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `status` | `"unverified"` \| `"self_attested"` \| `"externally_supported"` \| `"user_confirmed"` \| `"peer_confirmed"` \| `"system_confirmed"` \| `"conflicted"` | yes | |
+| `last_revalidated_at` | ISO datetime string | yes | |
+| `strongest_signal` | `"self_review"` \| `"external_observation"` \| `"user_confirmation"` \| `"peer_confirmation"` \| `"system_check"` | yes | |
+| `evidence_refs` | list of strings | no | max 4, default `[]` |
+| `conflict_summary` | string | no | max 240 chars |
+
+## Continuity Requests
+
+### Upsert — `POST /v1/continuity/upsert`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `capsule` | ContinuityCapsule | yes | |
+| `commit_message` | string | no | max 240 chars |
+| `idempotency_key` | string | no | max 200 chars |
+
+Response includes `recovery_warnings` (list of strings) when the fallback snapshot refresh fails after the active write has already committed.
+
+### Read — `POST /v1/continuity/read`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `allow_fallback` | boolean | no | default `false` |
+
+Response:
+
+```json
+{
+  "ok": true,
+  "path": "memory/continuity/user-stef.json",
+  "capsule": { },
+  "archived": false,
+  "source_state": "active",
+  "recovery_warnings": []
+}
+```
+
+`source_state` is `"active"`, `"fallback"`, or `"missing"`. When `allow_fallback` is `false` (default) and the active capsule is missing, the response is an HTTP error. When `true`, the response degrades to fallback or missing state with appropriate `recovery_warnings`.
+
+### Compare — `POST /v1/continuity/compare`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `candidate_capsule` | ContinuityCapsule | yes | |
+| `signals` | list of ContinuityVerificationSignal | yes | 1–8 items |
+
+Returns deterministic changed fields, strongest signal, and a recommended verification outcome without mutating the active capsule.
+
+### Revalidate — `POST /v1/continuity/revalidate`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `outcome` | `"confirm"` \| `"correct"` \| `"degrade"` \| `"conflict"` | yes | |
+| `signals` | list of ContinuityVerificationSignal | yes | 1–8 items |
+| `candidate_capsule` | ContinuityCapsule | no | required when outcome is `"correct"` |
+| `reason` | string | no | 1–120 chars |
+
+Response includes `recovery_warnings` when the fallback snapshot refresh fails after the active write.
+
+### List — `POST /v1/continuity/list`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | no | filter by kind |
+| `limit` | integer | no | 1–200, default 50 |
+| `include_fallback` | boolean | no | default `false` |
+| `include_archived` | boolean | no | default `false` |
+| `include_cold` | boolean | no | default `false` |
+
+Response includes `artifact_state` and `retention_class` for each entry. Archive entries include `archive_stale` classification based on `COGNIRELAY_CONTINUITY_RETENTION_ARCHIVE_DAYS`.
+
+### Archive — `POST /v1/continuity/archive`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `reason` | string | yes | 3–240 chars |
+
+### Delete — `POST /v1/continuity/delete`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `delete_active` | boolean | no | default `false` |
+| `delete_archive` | boolean | no | default `false` |
+| `delete_fallback` | boolean | no | default `false` |
+| `reason` | string | yes | 3–240 chars |
+
+At least one delete flag must be `true`.
+
+## Context Retrieval
+
+### Retrieve — `POST /v1/context/retrieve`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `task` | string | yes | description of active task |
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | no | explicit capsule selector |
+| `subject_id` | string | no | max 200 chars |
+| `continuity_mode` | `"auto"` \| `"required"` \| `"off"` | no | default `"auto"` |
+| `continuity_verification_policy` | `"allow_degraded"` \| `"prefer_healthy"` \| `"require_healthy"` | no | default `"allow_degraded"` |
+| `continuity_resilience_policy` | `"allow_fallback"` \| `"prefer_active"` \| `"require_active"` | no | default `"allow_fallback"` |
+| `continuity_selectors` | list of ContinuitySelector | no | max 4 items |
+| `continuity_max_capsules` | integer | no | 1–4, default 1 |
+| `max_tokens_estimate` | integer | no | 256–100,000, default 4000 |
+| `include_types` | list of strings | no | default `[]` |
+| `time_window_days` | integer | no | 1–3650, default 30 |
+| `limit` | integer | no | 1–100, default 10 |
+
+Response:
+
+```json
+{
+  "ok": true,
+  "bundle": {
+    "task": "...",
+    "generated_at": "2024-01-01T00:00:00Z",
+    "core_memory": [{"path": "...", "snippet": "..."}],
+    "recent_relevant": [{"path": "...", "type": "...", "snippet": "...", "score": 1.0}],
+    "open_questions": ["..."],
+    "token_budget_hint": "4000",
+    "time_window_days": 30,
+    "notes": ["..."],
+    "continuity_state": {
+      "present": true,
+      "capsules": [{"source_state": "active", "...": "..."}],
+      "warnings": [],
+      "fallback_used": false,
+      "recovery_warnings": []
+    }
+  }
+}
+```
+
+When derived search indexes are stale, `continuity_state.warnings` includes `"continuity_index_stale"`. When indexes are missing, retrieval falls back to a bounded raw scan and adds `"continuity_index_missing"`.
+
+## Coordination Payloads
+
+### Handoff Create — `POST /v1/coordination/handoff/create`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `recipient_peer` | string | yes | 1–200 chars |
+| `subject_kind` | `"user"` \| `"peer"` \| `"thread"` \| `"task"` | yes | |
+| `subject_id` | string | yes | 1–200 chars |
+| `task_id` | string | no | max 200 chars |
+| `thread_id` | string | no | max 200 chars |
+| `note` | string | no | max 240 chars |
+| `commit_message` | string | no | |
+
+The handoff artifact projects only `active_constraints` and `drift_signals` from the referenced active continuity capsule. No other capsule fields cross the boundary.
+
+### Handoff Consume — `POST /v1/coordination/handoff/{handoff_id}/consume`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `status` | `"accepted_advisory"` \| `"deferred"` \| `"rejected"` | yes | |
+| `note` | string | no | max 240 chars |
+
+### Shared Coordination Create — `POST /v1/coordination/shared/create`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `participant_peers` | list of strings | no | max 8 items |
+| `task_id` | string | no | max 200 chars |
+| `thread_id` | string | no | max 200 chars |
+| `title` | string | yes | |
+| `summary` | string | no | |
+| `constraints` | list of strings | no | max 8 items |
+| `drift_signals` | list of strings | no | max 8 items |
+| `coordination_alerts` | list of strings | no | max 8 items |
+| `commit_message` | string | no | |
+
+### Reconciliation Open — `POST /v1/coordination/reconciliation/open`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `task_id` | string | no | max 200 chars |
+| `thread_id` | string | no | max 200 chars |
+| `title` | string | yes | |
+| `summary` | string | no | |
+| `classification` | `"contradictory"` \| `"stale_observation"` \| `"frame_conflict"` \| `"concurrent_race"` | yes | |
+| `trigger` | `"handoff_vs_handoff"` \| `"shared_vs_shared"` \| `"handoff_vs_shared"` \| `"concurrent_mutation_race"` | yes | |
+| `claims` | list of ReconciliationClaim | no | max 4 items |
+| `commit_message` | string | no | |
+
+### Reconciliation Resolve — `POST /v1/coordination/reconciliation/{reconciliation_id}/resolve`
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `expected_version` | integer | yes | first-write-wins concurrency check |
+| `resolution_outcome` | `"advisory_only"` \| `"conflicted"` \| `"rejected"` | yes | |
+| `resolution_summary` | string | no | max 240 chars |
+
+## Runtime Schema Discovery
+
+For the complete and always-current input schemas, use:
+
+- `GET /v1/discovery/tools` — returns full JSON schema for every endpoint's request model
+- `POST /v1/mcp` with `tools/list` — returns the same schemas in MCP tool format
+- `GET /v1/manifest` — returns the endpoint map with method and path metadata
+
+These runtime endpoints are the authoritative source. This document is a static reference for human readers and may lag behind the implementation.

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -47,7 +47,7 @@ CogniRelay is built from a small number of deliberately constrained building blo
 
 **Compaction as planning, not summarization.** The compaction service is an orchestrator that classifies candidates by age, size, memory class, and policy, then emits structured reports with action categories (summarize, archive, promote, keep, review). It does not generate summaries itself — the agent reads the plan and decides what to do. This keeps the system from making content decisions on the agent's behalf.
 
-**Four runtime dependencies.** The entire stack runs on FastAPI, uvicorn, Pydantic, and python-dotenv. No ORM, no external database, no cache or queue library. This keeps the operational surface minimal and the system easy to deploy, audit, and reason about.
+**Minimal runtime dependencies.** The entire stack runs on FastAPI, uvicorn, Pydantic, and python-dotenv. No ORM, no external database, no cache or queue library. This keeps the operational surface minimal and the system easy to deploy, audit, and reason about.
 
 ## The Core Model
 
@@ -57,12 +57,12 @@ CogniRelay treats continuity as a bounded orientation problem.
 
 Continuity capsules are meant to preserve enough of the agent's current direction to support a useful restart:
 
-- active constraints
-- drift signals
-- open questions and current direction
-- session trajectory
-- lower-commitment orientation fields such as trailing notes and curiosity queue
-- explicit negative decisions when the agent chooses to record them
+- active constraints (`active_constraints`)
+- drift signals (`drift_signals`)
+- open loops (`open_loops`) and stance summary (`stance_summary`)
+- session trajectory (`session_trajectory`)
+- lower-commitment orientation fields such as trailing notes (`trailing_notes`) and curiosity queue (`curiosity_queue`)
+- explicit negative decisions (`negative_decisions`) when the agent chooses to record them
 
 This is stronger than simple factual recall, but intentionally weaker than a full architecture for preserving every layer of texture or self-model.
 
@@ -203,9 +203,11 @@ Use the docs in this order:
    Use this for the implemented product shape, operational model, and agent usage guidance.
 5. `docs/api-surface.md`
    Use this for the currently implemented HTTP behavior and endpoint grouping.
-6. `docs/mcp.md`
+6. `docs/payload-reference.md`
+   Use this for capsule structure, request/response schemas, and field-level constraints.
+7. `docs/mcp.md`
    Use this if you care about MCP integration and tool exposure.
-7. `deploy/GO_LIVE_RUNBOOK.md` and `deploy/PRODUCTION_SIGNOFF_CHECKLIST.md`
+8. `deploy/GO_LIVE_RUNBOOK.md` and `deploy/PRODUCTION_SIGNOFF_CHECKLIST.md`
    Use these for operator-facing deployment and signoff concerns.
 
 ## What Reviewers Should Pressure-Test

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -70,7 +70,7 @@ CogniRelay combines a small number of building blocks:
 
 CogniRelay treats continuity as a bounded orientation-preservation problem, not as total-fidelity persistence.
 
-Continuity capsules preserve bounded working state across resets: active constraints, drift signals, open questions, current direction, session trajectory, and optional lower-commitment fields such as trailing notes, curiosity queue, and negative decisions. The model uses write-time curation rather than unlimited retention — payloads are bounded, optional fields have a deterministic trim order under token pressure, and what is present, omitted, or archived is always explicit.
+Continuity capsules preserve bounded working state across resets: active constraints (`active_constraints`), drift signals (`drift_signals`), open loops (`open_loops`), stance summary (`stance_summary`), session trajectory (`session_trajectory`), and optional lower-commitment fields such as trailing notes (`trailing_notes`), curiosity queue (`curiosity_queue`), and negative decisions (`negative_decisions`). The model uses write-time curation rather than unlimited retention — payloads are bounded, optional fields have a deterministic trim order under token pressure, and what is present, omitted, or archived is always explicit.
 
 Continuity artifacts move through four tiers:
 
@@ -254,3 +254,4 @@ If automated, run these through a local scheduler such as `systemd` or `cron` an
 - Use [Reviewer Guide](reviewer-guide.md) first when you want the system thesis, non-goals, recovery model, and inter-agent authority boundaries
 - Start here for product shape and system boundaries
 - Use [API Surface](api-surface.md) for the currently implemented HTTP surface
+- Use [Payload Reference](payload-reference.md) for capsule structure, request/response schemas, and field constraints


### PR DESCRIPTION
## Summary

Fixes #92 (Stage E)

Addresses all 6 review findings from the full documentation accuracy review, plus adds a new payload reference doc.

### Code fix

**Finding 1** (Important): `registry_history_cold_store` and `registry_history_cold_rehydrate` were in `OPS_JOBS` and fully handled by the dispatcher, but missing from the `OpsRunRequest.job_id` Literal. Pydantic rejected these job IDs before the handler could run, making the jobs unreachable via HTTP. The underlying handlers already implement full crash safety (source-path locking, git mutation lock, crash recovery on entry, rollback on failure, durable flag reporting). Fix: add both strings to the Literal.

### Doc fixes

**Finding 2** (Important): `api-surface.md` described `attachments: ["handoff:{handoff_id}"]` with temporal validity implying server-side enforcement. Reworded to clarify server stores these as opaque strings without validation.

**Finding 3** (Important): `api-surface.md` called `metadata.handoff_id` a "deterministic reference convention." Reworded to clarify server stores this as arbitrary metadata without validating or acting on it.

**Finding 4** (Informational): Prose in system-overview, reviewer-guide, and agent-onboarding used "open questions" and "current direction" but actual model fields are `open_loops` and `stance_summary`. Added actual field names in parentheses.

**Finding 5** (Informational): "Four runtime dependencies" in reviewer-guide changed to "Minimal runtime dependencies" so it doesn't silently go stale.

**Finding 6** (Informational): No change needed — README lists discovery surfaces (not ordering), system-overview lists a recommended sequence. Different purposes.

### New documentation

Added `docs/payload-reference.md` — static human-readable reference for:
- Continuity capsule structure (ContinuityCapsule, ContinuityState, all nested types)
- Field-level constraints (max lengths, max items, required vs optional)
- Key request schemas (upsert, read, compare, revalidate, list, archive, delete)
- Key response shapes (continuity read, context retrieve)
- Coordination payloads (handoff create/consume, shared create, reconciliation open/resolve)
- Runtime schema discovery guidance

Cross-referenced from README, reviewer-guide, system-overview, api-surface, and agent-onboarding.

## Test plan

- [x] 1103 tests pass
- [x] Ruff clean
- [x] Both registry_history jobs pass Pydantic validation
- [x] No remaining DESIGN_DOC references
- [ ] Read each modified doc end-to-end for accuracy
- [ ] Verify all links in payload-reference.md