### PR TITLE
Move capsule budget section to top of payload reference

### DIFF
--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -2,6 +2,109 @@
 
 This document describes the request and response payloads for key CogniRelay operations. The runtime source of truth for all input schemas is `GET /v1/discovery/tools`, which returns full JSON schemas for every endpoint.
 
+## Capsule Size and Token Budget
+
+A fully-populated capsule with realistic content in every field is approximately **~10 KB of JSON** and **~2,400–2,800 tokens**. Read this section first to understand the budget envelope before diving into individual field tables.
+
+### Field count by object
+
+ContinuityCapsule (top-level): 15 fields
+
+Nested objects when all optional fields are populated:
+
+- ContinuitySource: 3 fields
+- ContinuityState: 14 fields
+  - NegativeDecision (×4): 2 fields each = 8 fields
+  - ContinuityRelationshipModel: 3 fields
+  - ContinuityRetrievalHints: 3 fields
+- ContinuityConfidence: 2 fields
+- ContinuityAttentionPolicy: 2 fields
+- ContinuityFreshness: 3 fields
+- ContinuityVerificationState: 5 fields
+- ContinuityCapsuleHealth: 3 fields
+
+Total: **~58 distinct fields** across all nested objects.
+
+### Maximum list items at full population
+
+| Area | Items | Max chars per item |
+|------|-------|--------------------|
+| ContinuityState lists (6 required) | 5 each = 30 strings | no per-item limit |
+| ContinuityState optional lists (5) | 3–5 each = 23 strings | no per-item limit |
+| `negative_decisions` | 4 × (160 + 240) = 1,600 chars | structured |
+| `stance_summary` | 1 string | 240 chars |
+| `relationship_model` lists (2) | 5 each = 10 strings | no per-item limit |
+| `retrieval_hints` lists (3) | 8 each = 24 strings | no per-item limit |
+| `attention_policy` lists (2) | 5 + 8 = 13 strings | no per-item limit |
+| `canonical_sources` | 8 strings | no per-item limit |
+| `source.inputs` | 12 strings | no per-item limit |
+| `evidence_refs` | 4 strings | no per-item limit |
+| `capsule_health.reasons` | 5 strings | no per-item limit |
+| `conflict_summary` | 1 string | 240 chars |
+| `subject_id` | 1 string | 200 chars |
+| `producer` | 1 string | 100 chars |
+
+Total: **~130 strings + 4 negative decision objects + ~10 scalar fields**.
+
+### Estimated JSON size
+
+The string list items don't have per-item length limits in the model (only `stance_summary`, `conflict_summary`, `decision`, `rationale`, `producer`, `subject_id` are bounded). In practice, if each unbounded string averages 80–120 chars:
+
+- **Typical full capsule**: ~4–8 KB JSON
+- **Maximum realistic capsule** (all lists full, verbose strings): ~12–18 KB JSON
+- **Theoretical extreme** (very long strings in every slot): could approach the `COGNIRELAY_MAX_PAYLOAD_BYTES` limit (default 262 KB), but this would be pathological
+
+The system is designed so that a fully-populated capsule with practical content fits comfortably in a few KB — well within context-window budgets and storage constraints.
+
+### Token estimates by section
+
+| Section | ~Tokens | Fields | Notes |
+|---------|---------|--------|-------|
+| Core orientation (6 required lists + `stance_summary`) | ~670 | 31 strings + 1 scalar | Always present — the essential orientation |
+| Optional lists (`working_hypotheses`, `long_horizon_commitments`, `session_trajectory`, `negative_decisions`, `trailing_notes`, `curiosity_queue`) | ~840 | 27 strings + 4 objects | Trimmed first under token pressure |
+| `retrieval_hints` (`must_include`, `avoid`, `load_next`) | ~270 | up to 24 strings | Dropped early in trim order |
+| `relationship_model` (`trust_level`, `preferred_style`, `sensitivity_notes`) | ~200 | up to 11 fields | Dropped early in trim order |
+| `attention_policy` (`early_load`, `presence_bias_overrides`) | ~175 | up to 13 strings | |
+| `source` + `canonical_sources` + `metadata` | ~280 | variable | |
+| `verification_state` + `capsule_health` + `confidence` | ~185 | ~10 fields | |
+| Top-level metadata (`subject_kind`, `subject_id`, timestamps, etc.) | ~60 | ~6 fields | |
+| **Total (fully populated)** | **~2,400–2,800** | **~58 fields** | **~10 KB JSON** |
+
+### Context window impact
+
+| Context window | % used by one full capsule |
+|----------------|---------------------------|
+| 8K | ~35% |
+| 32K | ~9% |
+| 128K | ~2% |
+| 200K | ~1.4% |
+| 1M | ~0.3% |
+
+### Practical guidance
+
+**Minimum viable capsule** — populate only the 6 required `ContinuityState` lists, `stance_summary`, `source`, and `confidence`. This costs approximately **~900–1,000 tokens** and provides enough orientation for basic restart recovery.
+
+**Full capsule** — populate every field including `relationship_model`, `retrieval_hints`, `attention_policy`, `negative_decisions`, `session_trajectory`, `verification_state`, and `capsule_health`. This costs approximately **~2,400–2,800 tokens** and provides the richest possible orientation.
+
+**Under token pressure** — the system trims optional fields in deterministic order starting from the bottom of the `ContinuityState` table: `retrieval_hints` first, then `relationship_model`, `curiosity_queue`, `trailing_notes`, `negative_decisions`, `session_trajectory`, `long_horizon_commitments`, and `working_hypotheses`. The 6 required core lists and `stance_summary` are never trimmed.
+
+**Multi-capsule retrieval** — `POST /v1/context/retrieve` supports loading up to 4 capsules via `continuity_selectors` and `continuity_max_capsules`. At full population, 4 capsules would cost ~10,000–11,000 tokens. The `max_tokens_estimate` parameter (default 4,000) controls the total continuity token budget, and the system trims each capsule to fit.
+
+### Per-item string constraints
+
+Most list item strings in `ContinuityState` do not have a per-item character limit enforced in the model — the system relies on list count limits (max 3–5 items per field) and the deterministic trim mechanism to control total size. The exceptions with explicit character limits are:
+
+| Field | Max length |
+|-------|-----------|
+| `stance_summary` | 240 chars |
+| `negative_decisions[].decision` | 160 chars |
+| `negative_decisions[].rationale` | 240 chars |
+| `conflict_summary` (in `verification_state`) | 240 chars |
+| `subject_id` | 200 chars |
+| `source.producer` | 100 chars |
+
+Agents should keep individual list item strings concise (roughly 80–120 chars) to stay within practical token budgets. Very long strings in many fields simultaneously would be legal but would consume disproportionate token budget for diminishing orientation value.
+
 ## Continuity Capsule Structure
 
 A continuity capsule is the core unit of orientation state. It is stored as a JSON file under `memory/continuity/`.
@@ -288,109 +391,6 @@ The handoff artifact projects only `active_constraints` and `drift_signals` from
 | `expected_version` | integer | yes | first-write-wins concurrency check |
 | `resolution_outcome` | `"advisory_only"` \| `"conflicted"` \| `"rejected"` | yes | |
 | `resolution_summary` | string | no | max 240 chars |
-
-## Capsule Size and Token Budget
-
-A fully-populated capsule with realistic content in every field is approximately **~10 KB of JSON** and **~2,400–2,800 tokens**. This section breaks down the budget by section so agents and operators can make informed decisions about what to populate.
-
-### Field count by object
-
-ContinuityCapsule (top-level): 15 fields
-
-Nested objects when all optional fields are populated:
-
-- ContinuitySource: 3 fields
-- ContinuityState: 14 fields
-  - NegativeDecision (×4): 2 fields each = 8 fields
-  - ContinuityRelationshipModel: 3 fields
-  - ContinuityRetrievalHints: 3 fields
-- ContinuityConfidence: 2 fields
-- ContinuityAttentionPolicy: 2 fields
-- ContinuityFreshness: 3 fields
-- ContinuityVerificationState: 5 fields
-- ContinuityCapsuleHealth: 3 fields
-
-Total: **~58 distinct fields** across all nested objects.
-
-### Maximum list items at full population
-
-| Area | Items | Max chars per item |
-|------|-------|--------------------|
-| ContinuityState lists (6 required) | 5 each = 30 strings | no per-item limit |
-| ContinuityState optional lists (5) | 3–5 each = 23 strings | no per-item limit |
-| `negative_decisions` | 4 × (160 + 240) = 1,600 chars | structured |
-| `stance_summary` | 1 string | 240 chars |
-| `relationship_model` lists (2) | 5 each = 10 strings | no per-item limit |
-| `retrieval_hints` lists (3) | 8 each = 24 strings | no per-item limit |
-| `attention_policy` lists (2) | 5 + 8 = 13 strings | no per-item limit |
-| `canonical_sources` | 8 strings | no per-item limit |
-| `source.inputs` | 12 strings | no per-item limit |
-| `evidence_refs` | 4 strings | no per-item limit |
-| `capsule_health.reasons` | 5 strings | no per-item limit |
-| `conflict_summary` | 1 string | 240 chars |
-| `subject_id` | 1 string | 200 chars |
-| `producer` | 1 string | 100 chars |
-
-Total: **~130 strings + 4 negative decision objects + ~10 scalar fields**.
-
-### Estimated JSON size
-
-The string list items don't have per-item length limits in the model (only `stance_summary`, `conflict_summary`, `decision`, `rationale`, `producer`, `subject_id` are bounded). In practice, if each unbounded string averages 80–120 chars:
-
-- **Typical full capsule**: ~4–8 KB JSON
-- **Maximum realistic capsule** (all lists full, verbose strings): ~12–18 KB JSON
-- **Theoretical extreme** (very long strings in every slot): could approach the `COGNIRELAY_MAX_PAYLOAD_BYTES` limit (default 262 KB), but this would be pathological
-
-The system is designed so that a fully-populated capsule with practical content fits comfortably in a few KB — well within context-window budgets and storage constraints.
-
-### Size by section (token estimates)
-
-| Section | ~Tokens | Fields | Notes |
-|---------|---------|--------|-------|
-| Core orientation (6 required lists + `stance_summary`) | ~670 | 31 strings + 1 scalar | Always present — the essential orientation |
-| Optional lists (`working_hypotheses`, `long_horizon_commitments`, `session_trajectory`, `negative_decisions`, `trailing_notes`, `curiosity_queue`) | ~840 | 27 strings + 4 objects | Trimmed first under token pressure |
-| `retrieval_hints` (`must_include`, `avoid`, `load_next`) | ~270 | up to 24 strings | Dropped early in trim order |
-| `relationship_model` (`trust_level`, `preferred_style`, `sensitivity_notes`) | ~200 | up to 11 fields | Dropped early in trim order |
-| `attention_policy` (`early_load`, `presence_bias_overrides`) | ~175 | up to 13 strings | |
-| `source` + `canonical_sources` + `metadata` | ~280 | variable | |
-| `verification_state` + `capsule_health` + `confidence` | ~185 | ~10 fields | |
-| Top-level metadata (`subject_kind`, `subject_id`, timestamps, etc.) | ~60 | ~6 fields | |
-| **Total (fully populated)** | **~2,400–2,800** | **~58 fields** | **~10 KB JSON** |
-
-### Context window impact
-
-| Context window | % used by one full capsule |
-|----------------|---------------------------|
-| 8K | ~35% |
-| 32K | ~9% |
-| 128K | ~2% |
-| 200K | ~1.4% |
-| 1M | ~0.3% |
-
-### Practical guidance
-
-**Minimum viable capsule** — populate only the 6 required `ContinuityState` lists, `stance_summary`, `source`, and `confidence`. This costs approximately **~900–1,000 tokens** and provides enough orientation for basic restart recovery.
-
-**Full capsule** — populate every field including `relationship_model`, `retrieval_hints`, `attention_policy`, `negative_decisions`, `session_trajectory`, `verification_state`, and `capsule_health`. This costs approximately **~2,400–2,800 tokens** and provides the richest possible orientation.
-
-**Under token pressure** — the system trims optional fields in deterministic order starting from the bottom of the `ContinuityState` table: `retrieval_hints` first, then `relationship_model`, `curiosity_queue`, `trailing_notes`, `negative_decisions`, `session_trajectory`, `long_horizon_commitments`, and `working_hypotheses`. The 6 required core lists and `stance_summary` are never trimmed.
-
-**Multi-capsule retrieval** — `POST /v1/context/retrieve` supports loading up to 4 capsules via `continuity_selectors` and `continuity_max_capsules`. At full population, 4 capsules would cost ~10,000–11,000 tokens. The `max_tokens_estimate` parameter (default 4,000) controls the total continuity token budget, and the system trims each capsule to fit.
-
-### Per-item string constraints
-
-Most list item strings in `ContinuityState` do not have a per-item character limit enforced in the model — the system relies on list count limits (max 3–5 items per field) and the deterministic trim mechanism to control total size. The exceptions with explicit character limits are:
-
-| Field | Max length |
-|-------|-----------|
-| `stance_summary` | 240 chars |
-| `negative_decisions[].decision` | 160 chars |
-| `negative_decisions[].rationale` | 240 chars |
-| `conflict_summary` (in `verification_state`) | 240 chars |
-| `subject_id` | 200 chars |
-| `source.producer` | 100 chars |
-
-Agents should keep individual list item strings concise (roughly 80–120 chars) to stay within practical token budgets. Very long strings in many fields simultaneously would be legal but would consume disproportionate token budget for diminishing orientation value.
 
 ## Runtime Schema Discovery
 


### PR DESCRIPTION
## Summary

Refs #92

Moves the "Capsule Size and Token Budget" section from the end of
`docs/payload-reference.md` to right after the intro, before the
field tables. Readers benefit from understanding the budget envelope
(~2,400–2,800 tokens, ~10 KB, ~58 fields) before diving into
individual field definitions.

No content changes — pure reorder.

## Test plan

- [ ] Verify doc reads top-to-bottom in logical order