### PR TITLE
Clarify trust model, token-scoped isolation, and admin:peers authority in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Self-hosted continuity and collaboration substrate for autonomous agents with bo
 
 CogniRelay uses a local git repository as durable state, exposes a machine-first FastAPI interface, stores content as Markdown and JSON/JSONL, and keeps dependencies minimal. It is not a Git forge — it is infrastructure for memory, retrieval, messaging, coordination, and continuity preservation across context-window resets.
 
-The default deployment model is one owner-agent per CogniRelay instance. The owner-agent is also the local operator of that instance. An agent that wants its own continuity substrate should run its own instance rather than sharing one. Collaboration with other agents is a delegated secondary surface — the owner-agent issues narrower API tokens to collaborating peers, and those peers interact through the coordination surfaces without access to the owner's continuity capsules.
+The default deployment model is one owner-agent per CogniRelay instance. The owner-agent is also the local operator of that instance. An agent that wants its own continuity substrate should run its own instance rather than sharing one. Collaboration with other agents is a delegated secondary surface — the owner-agent issues narrower API tokens to collaborating peers, and those peers interact through the coordination surfaces without access to the owner's continuity capsules. Access isolation between agents is enforced by token scopes and namespace restrictions, not by built-in per-agent tenant isolation.
 
 ## When CogniRelay Is Useful
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -2,7 +2,7 @@
 
 This guide is for agents integrating with CogniRelay, whether starting cold or adding deeper integration to an already-running setup.
 
-CogniRelay is designed so that each agent wanting its own continuity runs its own instance. This guide assumes you are the owner-agent of your CogniRelay instance — meaning you are also the local operator and the principal that controls token issuance, trust transitions, and system maintenance. If you are integrating as a collaborator peer on someone else's instance, your access is narrower and limited to the coordination surfaces they have delegated to you.
+CogniRelay is designed so that each agent wanting its own continuity runs its own instance. This guide assumes you are the owner-agent of your CogniRelay instance — meaning you are also the local operator and the principal that controls token issuance, trust transitions, and system maintenance. If you are integrating as a collaborator peer on someone else's instance, your access is determined by the scopes and namespace restrictions on the token issued to you — the system does not enforce per-agent identity-bound isolation, so your access boundaries are the token's configured policy. By default, collaborator tokens are scoped to coordination surfaces and do not include access to the owner's continuity capsules or core memory.
 
 ## What CogniRelay Offers You
 

--- a/docs/api-surface.md
+++ b/docs/api-surface.md
@@ -184,6 +184,7 @@ Most mutating endpoints require bearer-token scopes plus namespace restrictions.
 
 Implementation notes that matter for operators and client authors:
 
+- tokens carrying `admin:peers` bypass all scope and namespace checks — see the [Reviewer Guide](reviewer-guide.md#operator-and-host-local-boundary) for the full authority model
 - split namespace controls use `read_namespaces` and `write_namespaces`
 - legacy `namespaces` is still supported as a shorthand applying to both read and write
 - signed message verification includes nonce replay protection

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -133,6 +133,16 @@ When reviewing the system, treat these as key design claims:
 
 The inter-agent model is deliberately conservative.
 
+### Access isolation model
+
+Access isolation between agents is enforced entirely by token scopes and namespace/path restrictions configured by the operator. The system does not provide a separate intrinsic identity-bound ownership or tenant isolation layer beyond that configured access model.
+
+Continuity capsules are namespace-gated, not agent-gated. Any token with read access to `memory/continuity` can read any capsule stored there, regardless of which agent created it. In the default `collaboration_peer` governance template, collaborator tokens cannot access `memory/continuity` — this is a configured policy boundary enforced by sub-directory namespace restrictions, not a built-in per-agent tenant isolation mechanism.
+
+The strengthened collaborator model (sub-namespace hardening) means the default template protects owner-private continuity by excluding it from collaborator namespace grants. This is materially stronger than broad top-level `memory` access, but remains token/namespace policy, not ownership enforcement. Readers should not infer a built-in multi-tenant per-agent isolation model from the current system.
+
+The collaborator token policy described above is only meaningful when `admin:peers` is withheld from collaborator tokens, as the default templates do. Any token carrying `admin:peers` bypasses both scope and namespace checks entirely — see the [Operator and Host-Local Boundary](#operator-and-host-local-boundary) section for details.
+
 ### What crosses the boundary
 
 Current handoff/shared coordination work allows bounded coordination-facing data to cross the peer boundary, especially:
@@ -174,7 +184,7 @@ All three primitives follow the same principle: coordination artifacts are evide
 
 ## Operator and Host-Local Boundary
 
-In the default deployment model, the owner-agent and the local operator are the same principal. The owner-agent holds the `admin:peers` scope and acts as superuser for its own instance. Collaborator agents, if any, are external peers with narrower delegated tokens that do not include `admin:peers`.
+In the default deployment model, the owner-agent and the local operator are the same principal. The owner-agent holds the `admin:peers` scope and acts as full operator/superuser for its own instance. In the implementation, `admin:peers` bypasses both ordinary scope checks and namespace/path restrictions — any token carrying this scope can read any file, write to any namespace, and perform any operation that does not require additional IP-based locality enforcement. Collaborator agents, if any, are external peers with narrower delegated tokens that do not include `admin:peers`.
 
 CogniRelay exposes two distinct operational surfaces:
 
@@ -189,7 +199,7 @@ This surface has two enforcement tiers:
 - **IP-enforced local-only**: ops runner endpoints under `/v1/ops/*` enforce an IP-based local-client check in addition to `admin:peers` scope. These are unreachable from WAN peers even if the scope is present.
 - **Scope-restricted authority**: trust transitions (`/v1/peers/{peer_id}/trust`), token and signing-key lifecycle (`/v1/security/*`), backup creation and restore drills require `admin:peers` scope but do not enforce IP-based locality. They are intended for local use but rely on scope restriction rather than transport-level enforcement.
 
-Both tiers carry system-wide impact — revoking a token, rotating a key, or running a retention job affects every agent using the instance. In the default model, `admin:peers` belongs exclusively to the owner-agent/operator and should not be granted to collaborator peers. The one exception is the `replication_peer` governance template, which carries `admin:peers` because instance-to-instance replication requires full read access — operators should treat replication tokens with the same care as the owner token. If automating authority actions, run them through a local scheduler (`systemd`, `cron`) invoked through a local boundary.
+Both tiers carry system-wide impact — revoking a token, rotating a key, or running a retention job affects every agent using the instance. In the default model, `admin:peers` belongs exclusively to the owner-agent/operator and should not be granted to collaborator peers. The one exception is the `replication_peer` governance template, which carries `admin:peers` because replication requires unrestricted read access across all namespaces. Since `admin:peers` bypasses both scope and namespace checks, a replication token also has equivalent write authority to the owner token outside of IP-enforced localhost operations — operators should treat replication tokens with the same care as the owner token. If automating authority actions, run them through a local scheduler (`systemd`, `cron`) invoked through a local boundary.
 
 The boundary matters for reviewers because it separates what an agent can do to collaborate from what an operator can do to maintain the system. Agents do not have authority over token lifecycle or retention policy unless the operator explicitly grants it.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -17,11 +17,13 @@ The default deployment is one owner-agent per CogniRelay instance.
 - The owner-agent runs a local CogniRelay instance as its own continuity substrate.
 - The same owner-agent is the local operator and superuser of that instance, holding the `admin:peers` scope.
 - Continuity capsules are the owner-agent's local orientation store, not a shared resource. Namespace enforcement supports sub-directory granularity, so tokens can be scoped to specific paths like `memory/coordination` without granting access to `memory/continuity`.
-- If the owner-agent wants inter-agent coordination, it issues narrower delegated API tokens to collaborating peers. The governance policy provides a `collaboration_peer` template as a baseline for these tokens — it grants read and write access to coordination surfaces (`memory/coordination/handoffs`, `memory/coordination/shared`, `memory/coordination/reconciliations`), `messages`, and `tasks`, but not to the full `memory` namespace. A separate `replication_peer` template exists for instance-to-instance replication and carries `admin:peers` scope because replication requires full read access; operators should treat replication tokens with the same care as the owner token.
+- If the owner-agent wants inter-agent coordination, it issues narrower delegated API tokens to collaborating peers. The governance policy provides a `collaboration_peer` template as a baseline for these tokens — it grants read access to all of `memory/coordination` and write access scoped to specific coordination sub-paths (`memory/coordination/handoffs`, `memory/coordination/shared`, `memory/coordination/reconciliations`), plus read and write access to `messages` and `tasks`, but not to the full `memory` namespace. A separate `replication_peer` template exists for instance-to-instance replication and carries `admin:peers` scope because replication requires unrestricted read access across all namespaces. Since `admin:peers` bypasses both scope and namespace checks, a replication token also has equivalent write authority to the owner token outside of IP-enforced localhost operations; operators should treat replication tokens with the same care as the owner token.
 - Collaborator agents interact through the coordination surfaces (handoffs, shared coordination artifacts, reconciliations), messaging, and tasks — not by directly reading the owner's continuity capsules. This separation is enforced by sub-directory namespace restrictions — the `collaboration_peer` template does not grant access to `memory/continuity`, `memory/core`, `memory/episodic`, or `memory/summaries`.
 - An agent that wants its own continuity should run its own CogniRelay instance rather than sharing one.
 
 The system should not be read as a peer-equal shared-instance platform. The collaboration layer is a delegated secondary surface built on top of the owner-agent's local continuity home.
+
+Access isolation between agents is enforced entirely by token scopes and namespace/path restrictions. The system does not provide a separate intrinsic identity-bound ownership or tenant isolation layer beyond that configured access model. Any token with read access to `memory/continuity` can read any capsule in that namespace — capsule privacy depends on the operator not granting that access to collaborator tokens. In the default `collaboration_peer` template this access is excluded, which protects owner-private continuity as configured policy.
 
 ## Architecture
 
@@ -238,6 +240,7 @@ For the complete MCP integration notes, including what is and is not mirrored th
 - The owner-agent holds `admin:peers` and full namespace access in the default model; collaborator peers receive narrower delegated scopes
 - Do not grant `admin:peers` to collaborator peers — it belongs to the owner/operator role and acts as a superuser bypass for both scope and namespace checks. The `replication_peer` template is the exception: it carries `admin:peers` because instance-to-instance replication requires full read access, and should be treated with the same care as the owner token
 - Use the `collaboration_peer` governance template as a baseline for collaborator tokens — it enables creation and mutation of coordination artifacts (handoffs, shared artifacts, reconciliations), task management, and messaging, while keeping continuity capsules and core memory private to the owner
+- Continuity capsule access is governed by the same token scope and namespace mechanism as all other paths — there is no additional per-agent ownership check. The `collaboration_peer` template excludes `memory/continuity` by default, which protects owner-private continuity as configured policy rather than through a built-in ownership enforcement layer
 - Collaboration peers can create handoffs, shared artifacts, reconciliations, tasks, and exchange messages — everything needed for structured inter-agent collaboration without accessing the owner's private continuity substrate
 - Prefer API-driven token lifecycle operations over manual file edits so audit state stays consistent
 - Keep trust transitions explicit through `POST /v1/peers/{peer_id}/trust`
@@ -264,6 +267,8 @@ The following matrix summarizes what each token role can access. The owner token
 | **Run ops jobs** (`/v1/ops/*`, requires localhost) | Yes | No | No |
 | **See all coordination regardless of identity** | Yes | No | Yes |
 | **Risk if token is leaked** | Total compromise | Coordination, task, and message exposure (no continuity/admin access) | Equivalent to owner (minus localhost ops) |
+
+Owner and `replication_peer` "Yes" entries in capability rows reflect `admin:peers` superuser bypass semantics — `admin:peers` bypasses both scope checks and namespace/path restrictions, so these tokens pass every authorization gate regardless of individually configured grants. For example, the `replication_peer` governance template sets `write_namespaces` to `["messages", "peers", "snapshots"]` and does not include `write:projects` in its scopes — access to all other write paths and scope-gated operations comes from `admin:peers` bypassing enforcement entirely.
 
 Operators can issue custom tokens with any combination of scopes and namespace restrictions. The templates above are baselines, not the only options.
 


### PR DESCRIPTION
## Summary

- Add explicit "Access isolation model" subsection to reviewer-guide clarifying that capsule isolation is token/namespace policy, not intrinsic identity-bound ownership
- Spell out that `admin:peers` bypasses both scope and namespace checks (full superuser authority)
- Add access matrix footnote explaining Owner/replication_peer "Yes" entries reflect bypass semantics, not direct namespace grants
- Strengthen `replication_peer` descriptions to disclose full write authority through bypass
- Add brief access-model clarifications to agent-onboarding and README

## Test plan

- [ ] `ruff check app tests tools_hash_token.py` passes (no code changes)
- [ ] Read each modified doc to confirm no contradictions with existing text
- [ ] Verify all five acceptance criteria from #140 are met

Fixes #140