### PR TITLE
Docs: clarify agent-agnostic positioning for v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to CogniRelay are documented in this file.
 This changelog is curated by milestone rather than by individual commit.
 It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
+## [1.0.1] - 2026-03-29
+
+`v1.0.1` is a documentation-only patch release that clarifies a core property
+of the stabilized system.
+
+### Clarified
+
+- Documented explicitly that CogniRelay is agent-agnostic: it does not depend
+  on a specific model provider, agent runtime, or orchestration framework, as
+  long as an agent can call its API surfaces.
+- Added the clarification in the README and the system overview so the project
+  positioning and architecture docs stay aligned with the current system.
+
 ## [1.0.0] - 2026-03-29
 
 v1.0.0 marks the stabilization of the core CogniRelay system: a durable,

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ CogniRelay is an applied continuity-infrastructure project: real, production-ori
 
 CogniRelay uses a local git repository as durable state, exposes a machine-first FastAPI interface, stores content as Markdown and JSON/JSONL, and keeps dependencies minimal. It is not a Git forge — it is infrastructure for memory, retrieval, messaging, coordination, and continuity preservation across context-window resets.
 
+CogniRelay is agent-agnostic: it does not depend on a specific model provider, agent runtime, or orchestration framework, as long as the agent can call its API surfaces.
+
 The default deployment model is one owner-agent per CogniRelay instance. The owner-agent is also the local operator of that instance. An agent that wants its own continuity substrate should run its own instance rather than sharing one. Collaboration with other agents is a delegated secondary surface — the owner-agent issues narrower API tokens to collaborating peers, and those peers interact through the coordination surfaces without access to the owner's continuity capsules. Access isolation between agents is enforced by token scopes and namespace restrictions, not by built-in per-agent tenant isolation.
 
 ## When CogniRelay Is Useful

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -4,6 +4,8 @@
 
 CogniRelay is a self-hosted collaboration and memory service for autonomous agents. It exposes a deterministic HTTP interface over a local git-backed repository so agents can persist state, retrieve context, coordinate work, and exchange messages without depending on a large external platform.
 
+It is agent-agnostic: CogniRelay does not depend on a specific model provider, agent runtime, or orchestration framework, as long as the agent can invoke its API surfaces.
+
 The core design principle is simple:
 
 **git is the storage engine; the API is the machine interface**


### PR DESCRIPTION
## Summary
- clarify in the README that CogniRelay is agent-agnostic
- add the same architectural/property note to the system overview
- add a small `1.0.1` changelog entry for the docs-only patch release

## Verification
- documentation-only change; diff reviewed locally
