### PR TITLE
docs: link comparative notes to issue 194

### DIFF
--- a/docs/external-references.md
+++ b/docs/external-references.md
@@ -346,6 +346,13 @@ still highest.
   scaffolding and preserved reasoning paths, but not fully solved by
   architecture alone.
 
+**Downstream project work informed by comparative notes**
+
+- [#194](https://github.com/stef-k/CogniRelay/issues/194) structured-entry
+  timestamp refactor (`created_at` / `updated_at` / `last_confirmed_at`) to
+  address recurring external pressure around capsule freshness versus fact
+  freshness in mixed-age continuity state
+
 ## Conceptual and Source Influences
 
 This section records public source material that influenced CogniRelay's design


### PR DESCRIPTION
## Summary
- add a downstream project work subsection under the comparative takeaways
- link issue #194 as the concrete schema-refactor output of the comparative cycle

## Verification
- git diff -- docs/external-references.md
- git status --short --branch