### PR TITLE
Add read-only operator UI slice 1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ COGNIRELAY_AUDIT_LOG_ENABLED=true
 # If true, message ingress endpoints require signed_envelope
 COGNIRELAY_REQUIRE_SIGNED_INGRESS=false
 
+# Optional read-only operator UI (disabled by default)
+COGNIRELAY_UI_ENABLED=false
+COGNIRELAY_UI_REQUIRE_LOCALHOST=true
+COGNIRELAY_UI_READ_ONLY=true
+
 # Key material storage hardening
 COGNIRELAY_USE_EXTERNAL_KEY_STORE=true
 COGNIRELAY_KEY_STORE_PATH=~/.cognirelay/security_keys.json

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ git init
 
 For non-local exposure, prefer file-based peer tokens in `data_repo/config/peer_tokens.json` instead of the plaintext development token in `.env`.
 
+The optional operator UI is disabled by default. To expose the first read-only continuity inspection slice locally, set `COGNIRELAY_UI_ENABLED=true`; keep `COGNIRELAY_UI_REQUIRE_LOCALHOST=true` unless you are intentionally relaxing the boundary, and leave `COGNIRELAY_UI_READ_ONLY=true` for the current UI surface.
+
 Each CogniRelay instance serves a single owner-agent. If you operate multiple agents that each need their own continuity, run a separate instance per agent.
 
 For shell-based agent hooks, the [CLI client](docs/cognirelay-client.md) (`tools/cognirelay_client.py`) can read and upsert continuity capsules without a third-party HTTP library.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ git init
 
 For non-local exposure, prefer file-based peer tokens in `data_repo/config/peer_tokens.json` instead of the plaintext development token in `.env`.
 
-The optional operator UI is disabled by default. To expose the first read-only continuity inspection slice locally, set `COGNIRELAY_UI_ENABLED=true`; keep `COGNIRELAY_UI_REQUIRE_LOCALHOST=true` unless you are intentionally relaxing the boundary, and leave `COGNIRELAY_UI_READ_ONLY=true` for the current UI surface.
+The optional operator UI is disabled by default. To expose the first read-only continuity inspection slice locally, set `COGNIRELAY_UI_ENABLED=true`; keep `COGNIRELAY_UI_REQUIRE_LOCALHOST=true` unless you are intentionally relaxing the boundary, since this slice enforces localhost from the transport peer itself rather than forwarded headers. Leave `COGNIRELAY_UI_READ_ONLY=true`; in this slice it documents and preserves the read-only posture, and no mutable UI actions exist yet.
 
 Each CogniRelay instance serves a single owner-agent. If you operate multiple agents that each need their own continuity, run a separate instance per agent.
 

--- a/app/config.py
+++ b/app/config.py
@@ -74,6 +74,9 @@ class Settings:
     tokens: Dict[str, PeerToken]
     audit_log_enabled: bool
     require_signed_ingress: bool = False
+    ui_enabled: bool = False
+    ui_require_localhost: bool = True
+    ui_read_only: bool = True
 
     # Go-live hardening controls
     use_external_key_store: bool = True
@@ -423,6 +426,9 @@ def get_settings(force_reload: bool = False) -> Settings:
         tokens=_merge_tokens(repo_root),
         audit_log_enabled=_parse_bool(_env_first("COGNIRELAY_AUDIT_LOG_ENABLED", "AMR_AUDIT_LOG_ENABLED"), True),
         require_signed_ingress=_parse_bool(_env_first("COGNIRELAY_REQUIRE_SIGNED_INGRESS", "AMR_REQUIRE_SIGNED_INGRESS"), False),
+        ui_enabled=_parse_bool(_env_first("COGNIRELAY_UI_ENABLED"), False),
+        ui_require_localhost=_parse_bool(_env_first("COGNIRELAY_UI_REQUIRE_LOCALHOST"), True),
+        ui_read_only=_parse_bool(_env_first("COGNIRELAY_UI_READ_ONLY"), True),
         use_external_key_store=_parse_bool(_env_first("COGNIRELAY_USE_EXTERNAL_KEY_STORE", "AMR_USE_EXTERNAL_KEY_STORE"), True),
         key_store_path=Path(key_store_raw).expanduser().resolve(),
         max_payload_bytes=_parse_int(_env_first("COGNIRELAY_MAX_PAYLOAD_BYTES", "AMR_MAX_PAYLOAD_BYTES"), 262_144, minimum=1024),

--- a/app/main.py
+++ b/app/main.py
@@ -207,6 +207,7 @@ from .tasks import (
     tasks_query_service,
     tasks_update_service,
 )
+from .ui import build_ui_router
 
 _log = logging.getLogger(__name__)
 
@@ -262,6 +263,9 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(title="CogniRelay", version="1.1.0", lifespan=_lifespan)
+
+if get_settings().ui_enabled:
+    app.include_router(build_ui_router(app_version=app.version))
 
 
 @app.middleware("http")

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,5 @@
+"""Read-only operator UI routing for CogniRelay."""
+
+from .router import build_ui_router
+
+__all__ = ["build_ui_router"]

--- a/app/ui/render.py
+++ b/app/ui/render.py
@@ -1,0 +1,21 @@
+"""Minimal file-based HTML template helpers for the operator UI."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from string import Template
+
+_TEMPLATE_DIR = Path(__file__).resolve().parent / "templates"
+
+
+@lru_cache(maxsize=None)
+def _load_template(name: str) -> Template:
+    """Load and cache one HTML template file by name."""
+    return Template((_TEMPLATE_DIR / name).read_text(encoding="utf-8"))
+
+
+def render_template(name: str, **context: str) -> str:
+    """Render one cached HTML template with the provided string context."""
+    normalized = {key: str(value) for key, value in context.items()}
+    return _load_template(name).safe_substitute(normalized)

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -12,7 +12,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import FileResponse, HTMLResponse
 
-from app.auth import AuthContext, _extract_client_ip
+from app.auth import AuthContext
 from app.config import Settings, get_settings
 from app.continuity import continuity_list_service, continuity_read_service
 from app.continuity.listing import (
@@ -50,7 +50,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         """Render the operator overview page."""
         settings = get_settings()
         client_ip = _enforce_ui_access(request, settings)
-        _settings, gm = _ui_services()
+        gm = _ui_git_manager(settings)
         auth = _ui_auth(client_ip)
         now = datetime.now(timezone.utc)
         health = health_payload(
@@ -112,7 +112,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         """Render the continuity list view."""
         settings = get_settings()
         client_ip = _enforce_ui_access(request, settings)
-        settings, _gm = _ui_services()
+        _gm = _ui_git_manager(settings)
         auth = _ui_auth(client_ip)
         now = datetime.now(timezone.utc)
         listing = continuity_list_service(
@@ -176,7 +176,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         """Render one continuity detail page with graceful degradation."""
         settings = get_settings()
         client_ip = _enforce_ui_access(request, settings)
-        settings, _gm = _ui_services()
+        _gm = _ui_git_manager(settings)
         auth = _ui_auth(client_ip)
         detail = continuity_read_service(
             repo_root=settings.repo_root,
@@ -251,16 +251,13 @@ def build_ui_router(*, app_version: str) -> APIRouter:
     return router
 
 
-def _ui_services() -> tuple[Settings, GitManager]:
-    """Load settings and ensure the repository-backed git manager is ready."""
-    settings = get_settings()
-    gm = GitManager(
+def _ui_git_manager(settings: Settings) -> GitManager:
+    """Build a git manager for read-only metadata access without repo initialization."""
+    return GitManager(
         repo_root=settings.repo_root,
         author_name=settings.git_author_name,
         author_email=settings.git_author_email,
     )
-    gm.ensure_repo(settings.auto_init_git)
-    return settings, gm
 
 
 def _ui_auth(client_ip: str | None) -> AuthContext:
@@ -277,24 +274,20 @@ def _ui_auth(client_ip: str | None) -> AuthContext:
 
 def _enforce_ui_access(request: Request, settings: Settings) -> str | None:
     """Enforce the optional local-only UI policy."""
-    client_ip = _ui_client_ip(request)
+    client_ip = _ui_transport_client_ip(request)
     if settings.ui_require_localhost and not _is_local_client_ip(client_ip):
         raise HTTPException(status_code=403, detail="Operator UI is local-only")
     return client_ip
 
 
-def _ui_client_ip(request: Request) -> str | None:
-    """Resolve the best available client IP for UI access checks."""
-    request_ip = None
-    if request.client is not None:
-        request_ip = request.client.host
-        if request_ip == "testclient":
-            request_ip = None
-    return _extract_client_ip(
-        request.headers.get("X-Forwarded-For"),
-        request.headers.get("X-Real-IP"),
-        request_ip,
-    )
+def _ui_transport_client_ip(request: Request) -> str | None:
+    """Return the transport peer host for strict UI localhost enforcement."""
+    if request.client is None or request.client.host is None:
+        return None
+    value = str(request.client.host).strip()
+    if not value:
+        return None
+    return value
 
 
 def _is_local_client_ip(client_ip: str | None) -> bool:

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -1,0 +1,445 @@
+"""Server-rendered read-only operator UI routes."""
+
+from __future__ import annotations
+
+import html
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import quote
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import FileResponse, HTMLResponse
+
+from app.auth import AuthContext, _extract_client_ip
+from app.config import Settings, get_settings
+from app.continuity import continuity_list_service, continuity_read_service
+from app.continuity.listing import (
+    _scan_active_summaries,
+    _scan_archive_summaries,
+    _scan_cold_summaries,
+    _scan_fallback_summaries,
+)
+from app.discovery import capabilities_payload, health_payload
+from app.git_manager import GitManager
+from app.models import ContinuityListRequest, ContinuityReadRequest
+
+from .render import render_template
+
+UI_SUBJECT_KINDS: tuple[str, ...] = ("user", "peer", "thread", "task")
+_STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+def build_ui_router(*, app_version: str) -> APIRouter:
+    """Build the optional server-rendered operator UI router."""
+    router = APIRouter(prefix="/ui")
+
+    @router.get("/static/{asset_name}")
+    def ui_static(request: Request, asset_name: str) -> FileResponse:
+        """Serve one local operator UI asset."""
+        settings = get_settings()
+        _enforce_ui_access(request, settings)
+        asset_path = (_STATIC_DIR / asset_name).resolve()
+        if asset_path.parent != _STATIC_DIR or not asset_path.is_file():
+            raise HTTPException(status_code=404, detail="UI asset not found")
+        return FileResponse(asset_path)
+
+    @router.get("/", response_class=HTMLResponse)
+    def ui_overview(request: Request) -> HTMLResponse:
+        """Render the operator overview page."""
+        settings = get_settings()
+        client_ip = _enforce_ui_access(request, settings)
+        _settings, gm = _ui_services()
+        auth = _ui_auth(client_ip)
+        now = datetime.now(timezone.utc)
+        health = health_payload(
+            app_version=app_version,
+            contract_version=settings.contract_version,
+            repo_root=str(settings.repo_root),
+            git_initialized=gm.is_repo(),
+            latest_commit=gm.latest_commit(),
+            signed_ingress_required=bool(settings.require_signed_ingress),
+        )
+        capabilities = capabilities_payload()
+        continuity_counts = _continuity_counts(repo_root=settings.repo_root, auth=auth, now=now)
+        security_rows = [
+            ("UI enabled", "true"),
+            ("Require localhost", _bool_label(settings.ui_require_localhost)),
+            ("Configured read only", _bool_label(settings.ui_read_only)),
+            ("Effective mode", "read-only"),
+            ("Resolved client IP", client_ip or "unknown"),
+        ]
+        body = render_template(
+            "overview.html",
+            health_rows=_definition_rows(
+                [
+                    ("Service", str(health.get("service", ""))),
+                    ("Version", str(health.get("version", ""))),
+                    ("Contract version", str(health.get("contract_version", ""))),
+                    ("Git initialized", _bool_label(bool(health.get("git_initialized")))),
+                    ("Latest commit", str(health.get("latest_commit") or "none")),
+                    ("Signed ingress required", _bool_label(bool(health.get("signed_ingress_required")))),
+                    ("Reported at", str(health.get("time", ""))),
+                ]
+            ),
+            ui_rows=_definition_rows(security_rows),
+            capability_list=_html_list([str(item) for item in capabilities.get("features", [])]),
+            continuity_rows=_definition_rows(
+                [
+                    ("Active capsules", str(continuity_counts["active"])),
+                    ("Fallback snapshots", str(continuity_counts["fallback"])),
+                    ("Archived envelopes", str(continuity_counts["archived"])),
+                    ("Cold stubs", str(continuity_counts["cold"])),
+                    ("User capsules", str(continuity_counts["by_subject_kind"].get("user", 0))),
+                    ("Peer capsules", str(continuity_counts["by_subject_kind"].get("peer", 0))),
+                    ("Thread capsules", str(continuity_counts["by_subject_kind"].get("thread", 0))),
+                    ("Task capsules", str(continuity_counts["by_subject_kind"].get("task", 0))),
+                ]
+            ),
+        )
+        return _page(
+            title="Operator Overview",
+            current_path="/ui/",
+            content=body,
+        )
+
+    @router.get("/continuity", response_class=HTMLResponse)
+    def ui_continuity(
+        request: Request,
+        subject_kind: Literal["user", "peer", "thread", "task"] | None = Query(default=None),
+    ) -> HTMLResponse:
+        """Render the continuity list view."""
+        settings = get_settings()
+        client_ip = _enforce_ui_access(request, settings)
+        settings, _gm = _ui_services()
+        auth = _ui_auth(client_ip)
+        now = datetime.now(timezone.utc)
+        listing = continuity_list_service(
+            repo_root=settings.repo_root,
+            auth=auth,
+            req=ContinuityListRequest(
+                subject_kind=subject_kind,
+                limit=200,
+                include_fallback=True,
+                include_archived=False,
+                include_cold=False,
+            ),
+            now=now,
+            retention_archive_days=settings.continuity_retention_archive_days,
+            audit=_noop_audit,
+        )
+        rows = []
+        for capsule in listing["capsules"]:
+            rows.append(
+                [
+                    html.escape(str(capsule.get("subject_kind", ""))),
+                    _subject_link(str(capsule.get("subject_kind", "")), str(capsule.get("subject_id", ""))),
+                    html.escape(str(capsule.get("artifact_state", ""))),
+                    html.escape(str(capsule.get("health_status", ""))),
+                    html.escape(str(capsule.get("updated_at", ""))),
+                    html.escape(str(capsule.get("stable_preference_count", 0))),
+                    html.escape(str(capsule.get("rationale_entry_count", 0))),
+                ]
+            )
+        filter_options = "".join(
+            _option_row(value=kind, selected=(kind == subject_kind))
+            for kind in UI_SUBJECT_KINDS
+        )
+        body = render_template(
+            "continuity_list.html",
+            selected_kind=html.escape(subject_kind or "all"),
+            filter_options=filter_options,
+            result_count=str(listing["count"]),
+            continuity_table=_html_table(
+                headers=[
+                    "Kind",
+                    "Subject",
+                    "Source",
+                    "Health",
+                    "Updated",
+                    "Stable prefs",
+                    "Rationale entries",
+                ],
+                rows=rows,
+                empty_message="No continuity capsules matched the current filter.",
+            ),
+        )
+        return _page(title="Continuity Capsules", current_path="/ui/continuity", content=body)
+
+    @router.get("/continuity/{subject_kind}/{subject_id}", response_class=HTMLResponse)
+    def ui_continuity_detail(
+        request: Request,
+        subject_kind: Literal["user", "peer", "thread", "task"],
+        subject_id: str,
+    ) -> HTMLResponse:
+        """Render one continuity detail page with graceful degradation."""
+        settings = get_settings()
+        client_ip = _enforce_ui_access(request, settings)
+        settings, _gm = _ui_services()
+        auth = _ui_auth(client_ip)
+        detail = continuity_read_service(
+            repo_root=settings.repo_root,
+            auth=auth,
+            req=ContinuityReadRequest(
+                subject_kind=subject_kind,
+                subject_id=subject_id,
+                allow_fallback=True,
+                view="startup",
+            ),
+            now=datetime.now(timezone.utc),
+            audit=_noop_audit,
+        )
+        capsule = detail.get("capsule") or {}
+        continuity = capsule.get("continuity") if isinstance(capsule.get("continuity"), dict) else {}
+        startup_summary = detail.get("startup_summary")
+        trust_signals = detail.get("trust_signals")
+        detail_sections = {
+            "top_priorities": _html_list(_coerce_str_list(continuity.get("top_priorities"))),
+            "active_concerns": _html_list(_coerce_str_list(continuity.get("active_concerns"))),
+            "active_constraints": _html_list(_coerce_str_list(continuity.get("active_constraints"))),
+            "open_loops": _html_list(_coerce_str_list(continuity.get("open_loops"))),
+            "session_trajectory": _html_list(_coerce_str_list(continuity.get("session_trajectory"))),
+            "stance_summary": _paragraph(continuity.get("stance_summary")),
+        }
+        body = render_template(
+            "continuity_detail.html",
+            subject_kind=html.escape(subject_kind),
+            subject_id=html.escape(subject_id),
+            source_state=html.escape(str(detail.get("source_state", "unknown"))),
+            recovery_warnings=_html_list([str(item) for item in detail.get("recovery_warnings", [])]),
+            capsule_meta_rows=_definition_rows(
+                [
+                    ("Path", str(detail.get("path", ""))),
+                    ("Source state", str(detail.get("source_state", "unknown"))),
+                    ("Archived", _bool_label(bool(detail.get("archived")))),
+                    ("Updated at", str(capsule.get("updated_at") or "n/a")),
+                    ("Verified at", str(capsule.get("verified_at") or "n/a")),
+                    ("Verification kind", str(capsule.get("verification_kind") or "n/a")),
+                ]
+            ),
+            startup_summary_html=_render_object(startup_summary, empty_message="Startup summary unavailable."),
+            trust_signals_html=_render_object(trust_signals, empty_message="Trust signals unavailable."),
+            top_priorities_html=detail_sections["top_priorities"],
+            active_concerns_html=detail_sections["active_concerns"],
+            active_constraints_html=detail_sections["active_constraints"],
+            open_loops_html=detail_sections["open_loops"],
+            session_trajectory_html=detail_sections["session_trajectory"],
+            stance_summary_html=detail_sections["stance_summary"],
+            stable_preferences_html=_structured_table(
+                rows=list(capsule.get("stable_preferences") or []),
+                columns=["tag", "content", "created_at", "updated_at", "last_confirmed_at"],
+                empty_message="No stable preferences recorded.",
+            ),
+            negative_decisions_html=_structured_table(
+                rows=list(continuity.get("negative_decisions") or []),
+                columns=["decision", "rationale", "created_at", "updated_at", "last_confirmed_at"],
+                empty_message="No negative decisions recorded.",
+            ),
+            rationale_entries_html=_structured_table(
+                rows=list(continuity.get("rationale_entries") or []),
+                columns=["tag", "kind", "status", "summary", "reasoning", "updated_at"],
+                empty_message="No rationale entries recorded.",
+            ),
+        )
+        return _page(
+            title=f"Continuity Detail: {subject_kind}/{subject_id}",
+            current_path="/ui/continuity",
+            content=body,
+        )
+
+    return router
+
+
+def _ui_services() -> tuple[Settings, GitManager]:
+    """Load settings and ensure the repository-backed git manager is ready."""
+    settings = get_settings()
+    gm = GitManager(
+        repo_root=settings.repo_root,
+        author_name=settings.git_author_name,
+        author_email=settings.git_author_email,
+    )
+    gm.ensure_repo(settings.auto_init_git)
+    return settings, gm
+
+
+def _ui_auth(client_ip: str | None) -> AuthContext:
+    """Build a read-only internal auth context for UI read paths."""
+    return AuthContext(
+        token="ui-operator",
+        peer_id="ui-operator",
+        scopes={"read:files"},
+        read_namespaces={"*"},
+        write_namespaces=set(),
+        client_ip=client_ip,
+    )
+
+
+def _enforce_ui_access(request: Request, settings: Settings) -> str | None:
+    """Enforce the optional local-only UI policy."""
+    client_ip = _ui_client_ip(request)
+    if settings.ui_require_localhost and not _is_local_client_ip(client_ip):
+        raise HTTPException(status_code=403, detail="Operator UI is local-only")
+    return client_ip
+
+
+def _ui_client_ip(request: Request) -> str | None:
+    """Resolve the best available client IP for UI access checks."""
+    request_ip = None
+    if request.client is not None:
+        request_ip = request.client.host
+        if request_ip == "testclient":
+            request_ip = None
+    return _extract_client_ip(
+        request.headers.get("X-Forwarded-For"),
+        request.headers.get("X-Real-IP"),
+        request_ip,
+    )
+
+
+def _is_local_client_ip(client_ip: str | None) -> bool:
+    """Return whether the resolved client IP belongs to localhost."""
+    if not client_ip:
+        return False
+    value = str(client_ip).strip().lower()
+    if not value:
+        return False
+    if value.startswith("::ffff:"):
+        value = value[7:]
+    if value in {"127.0.0.1", "::1", "localhost"}:
+        return True
+    return value.startswith("127.")
+
+
+def _page(*, title: str, current_path: str, content: str) -> HTMLResponse:
+    """Render one full HTML document."""
+    html_doc = render_template(
+        "layout.html",
+        title=html.escape(title),
+        overview_nav_class=_nav_class(current_path == "/ui/"),
+        continuity_nav_class=_nav_class(current_path.startswith("/ui/continuity")),
+        content=content,
+    )
+    return HTMLResponse(html_doc)
+
+
+def _nav_class(active: bool) -> str:
+    """Return the nav link class for the current page."""
+    return "nav-link active" if active else "nav-link"
+
+
+def _bool_label(value: bool) -> str:
+    """Return a lowercase boolean label for human-readable tables."""
+    return "true" if value else "false"
+
+
+def _continuity_counts(*, repo_root: Path, auth: AuthContext, now: datetime) -> dict[str, Any]:
+    """Collect cheap high-level continuity counts for the overview page."""
+    active = _scan_active_summaries(repo_root, auth, None, now)
+    fallback = _scan_fallback_summaries(repo_root, auth, None, now)
+    archived = _scan_archive_summaries(repo_root, auth, None, now, get_settings().continuity_retention_archive_days)
+    cold = _scan_cold_summaries(repo_root, auth, None)
+    kind_counts = Counter(str(item.get("subject_kind", "")) for item in active)
+    return {
+        "active": len(active),
+        "fallback": len(fallback),
+        "archived": len(archived),
+        "cold": len(cold),
+        "by_subject_kind": dict(kind_counts),
+    }
+
+
+def _noop_audit(_auth: AuthContext, _event: str, _detail: dict[str, Any]) -> None:
+    """Skip audit writes for read-only UI rendering paths."""
+    return None
+
+
+def _definition_rows(rows: list[tuple[str, str]]) -> str:
+    """Render key/value rows as a definition list."""
+    parts = ['<dl class="kv-list">']
+    for label, value in rows:
+        parts.append(f"<dt>{html.escape(label)}</dt><dd>{html.escape(value)}</dd>")
+    parts.append("</dl>")
+    return "".join(parts)
+
+
+def _html_list(items: list[str]) -> str:
+    """Render a list of strings as a bullet list."""
+    if not items:
+        return '<p class="muted">None</p>'
+    return "<ul>" + "".join(f"<li>{html.escape(item)}</li>" for item in items) + "</ul>"
+
+
+def _html_table(*, headers: list[str], rows: list[list[str]], empty_message: str) -> str:
+    """Render a deterministic HTML table."""
+    if not rows:
+        return f'<p class="muted">{html.escape(empty_message)}</p>'
+    head = "".join(f"<th>{html.escape(label)}</th>" for label in headers)
+    body_rows = "".join("<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>" for row in rows)
+    return f"<table><thead><tr>{head}</tr></thead><tbody>{body_rows}</tbody></table>"
+
+
+def _subject_link(subject_kind: str, subject_id: str) -> str:
+    """Render the continuity detail link for one subject."""
+    href = f"/ui/continuity/{quote(subject_kind, safe='')}/{quote(subject_id, safe='')}"
+    return f'<a href="{href}">{html.escape(subject_id)}</a>'
+
+
+def _option_row(*, value: str, selected: bool) -> str:
+    """Render one filter option."""
+    selected_attr = ' selected="selected"' if selected else ""
+    return f'<option value="{html.escape(value)}"{selected_attr}>{html.escape(value)}</option>'
+
+
+def _render_object(value: Any, *, empty_message: str) -> str:
+    """Render nested JSON-like data as human-readable HTML."""
+    if value is None:
+        return f'<p class="muted">{html.escape(empty_message)}</p>'
+    return _render_value(value)
+
+
+def _render_value(value: Any) -> str:
+    """Render one JSON-like value recursively."""
+    if value is None:
+        return '<span class="muted">null</span>'
+    if isinstance(value, bool):
+        return html.escape(_bool_label(value))
+    if isinstance(value, (int, float)):
+        return html.escape(str(value))
+    if isinstance(value, str):
+        return html.escape(value)
+    if isinstance(value, dict):
+        parts = ['<dl class="kv-list">']
+        for key, item in value.items():
+            parts.append(f"<dt>{html.escape(str(key))}</dt><dd>{_render_value(item)}</dd>")
+        parts.append("</dl>")
+        return "".join(parts)
+    if isinstance(value, list):
+        if not value:
+            return '<p class="muted">None</p>'
+        return "<ul>" + "".join(f"<li>{_render_value(item)}</li>" for item in value) + "</ul>"
+    return html.escape(str(value))
+
+
+def _structured_table(*, rows: list[Any], columns: list[str], empty_message: str) -> str:
+    """Render a table for a list of structured dictionaries."""
+    normalized: list[list[str]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        normalized.append([html.escape(str(row.get(column, ""))) for column in columns])
+    return _html_table(headers=[column.replace("_", " ") for column in columns], rows=normalized, empty_message=empty_message)
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    """Normalize a list-like field into a string list for rendering."""
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _paragraph(value: Any) -> str:
+    """Render a short paragraph or a muted placeholder."""
+    if value is None or value == "":
+        return '<p class="muted">None</p>'
+    return f"<p>{html.escape(str(value))}</p>"

--- a/app/ui/static/ui.css
+++ b/app/ui/static/ui.css
@@ -1,0 +1,181 @@
+:root {
+  --bg: #f5f1e8;
+  --panel: #fffdf8;
+  --text: #1f2933;
+  --muted: #5f6b76;
+  --border: #d6cfbf;
+  --accent: #1f5c4a;
+  --accent-soft: #e4f0eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  background: linear-gradient(180deg, #f8f4ec 0%, var(--bg) 100%);
+  color: var(--text);
+}
+
+a {
+  color: var(--accent);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+th {
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.site-header {
+  border-bottom: 1px solid var(--border);
+  background: rgba(255, 253, 248, 0.95);
+}
+
+.site-header .shell {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem 0;
+  align-items: end;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.page-title {
+  margin: 0;
+  font-size: clamp(1.8rem, 2.2vw, 2.5rem);
+}
+
+.site-nav {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.nav-link {
+  padding: 0.6rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  text-decoration: none;
+  color: var(--text);
+}
+
+.nav-link.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+main.shell {
+  padding: 1.5rem 0 2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.two-up {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1rem 1.1rem;
+  box-shadow: 0 12px 30px rgba(31, 41, 51, 0.05);
+}
+
+.panel h2 {
+  margin-top: 0;
+}
+
+.kv-list {
+  display: grid;
+  grid-template-columns: minmax(140px, 220px) 1fr;
+  gap: 0.55rem 1rem;
+  margin: 0;
+}
+
+.kv-list dt {
+  font-weight: 700;
+}
+
+.kv-list dd {
+  margin: 0;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.filter-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+select,
+button {
+  font: inherit;
+  padding: 0.55rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+}
+
+button {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+  cursor: pointer;
+}
+
+ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+p {
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .site-header .shell {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .kv-list {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/ui/templates/continuity_detail.html
+++ b/app/ui/templates/continuity_detail.html
@@ -1,0 +1,64 @@
+<section class="panel">
+  <h2>Capsule</h2>
+  <p><strong>${subject_kind}/${subject_id}</strong></p>
+  <p class="muted">Source state: ${source_state}</p>
+  ${capsule_meta_rows}
+</section>
+<section class="panel">
+  <h2>Recovery Warnings</h2>
+  ${recovery_warnings}
+</section>
+<section class="grid two-up">
+  <article class="panel">
+    <h2>Startup Summary</h2>
+    ${startup_summary_html}
+  </article>
+  <article class="panel">
+    <h2>Trust Signals</h2>
+    ${trust_signals_html}
+  </article>
+</section>
+<section class="grid two-up">
+  <article class="panel">
+    <h2>Top Priorities</h2>
+    ${top_priorities_html}
+  </article>
+  <article class="panel">
+    <h2>Active Concerns</h2>
+    ${active_concerns_html}
+  </article>
+</section>
+<section class="grid two-up">
+  <article class="panel">
+    <h2>Active Constraints</h2>
+    ${active_constraints_html}
+  </article>
+  <article class="panel">
+    <h2>Open Loops</h2>
+    ${open_loops_html}
+  </article>
+</section>
+<section class="grid two-up">
+  <article class="panel">
+    <h2>Session Trajectory</h2>
+    ${session_trajectory_html}
+  </article>
+  <article class="panel">
+    <h2>Stance Summary</h2>
+    ${stance_summary_html}
+  </article>
+</section>
+<section class="grid two-up">
+  <article class="panel">
+    <h2>Stable Preferences</h2>
+    ${stable_preferences_html}
+  </article>
+  <article class="panel">
+    <h2>Negative Decisions</h2>
+    ${negative_decisions_html}
+  </article>
+</section>
+<section class="panel">
+  <h2>Rationale Entries</h2>
+  ${rationale_entries_html}
+</section>

--- a/app/ui/templates/continuity_list.html
+++ b/app/ui/templates/continuity_list.html
@@ -1,0 +1,16 @@
+<section class="panel">
+  <h2>Filters</h2>
+  <form method="get" action="/ui/continuity" class="filter-form">
+    <label for="subject_kind">Subject kind</label>
+    <select id="subject_kind" name="subject_kind">
+      <option value="">all</option>
+      ${filter_options}
+    </select>
+    <button type="submit">Apply</button>
+  </form>
+  <p class="muted">Showing ${result_count} result(s). Current filter: ${selected_kind}</p>
+</section>
+<section class="panel">
+  <h2>Continuity Capsules</h2>
+  ${continuity_table}
+</section>

--- a/app/ui/templates/layout.html
+++ b/app/ui/templates/layout.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+  <link rel="stylesheet" href="/ui/static/ui.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="shell">
+      <div>
+        <p class="eyebrow">CogniRelay</p>
+        <h1 class="page-title">${title}</h1>
+      </div>
+      <nav class="site-nav">
+        <a class="${overview_nav_class}" href="/ui/">Overview</a>
+        <a class="${continuity_nav_class}" href="/ui/continuity">Continuity</a>
+      </nav>
+    </div>
+  </header>
+  <main class="shell">
+    ${content}
+  </main>
+</body>
+</html>

--- a/app/ui/templates/overview.html
+++ b/app/ui/templates/overview.html
@@ -1,0 +1,20 @@
+<section class="grid two-up">
+  <article class="panel">
+    <h2>Health</h2>
+    ${health_rows}
+  </article>
+  <article class="panel">
+    <h2>UI Posture</h2>
+    ${ui_rows}
+  </article>
+</section>
+<section class="grid two-up">
+  <article class="panel">
+    <h2>Capabilities</h2>
+    ${capability_list}
+  </article>
+  <article class="panel">
+    <h2>Continuity Counts</h2>
+    ${continuity_rows}
+  </article>
+</section>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,6 +65,32 @@ class TestConfigTokens(unittest.TestCase):
 
             self.assertEqual(settings.continuity_retention_archive_days, 1)
 
+    def test_ui_flags_load_from_env_with_expected_defaults(self) -> None:
+        """UI flags should load from env and default to safe read-only posture."""
+        with tempfile.TemporaryDirectory() as td:
+            with patch.dict(os.environ, {"COGNIRELAY_REPO_ROOT": td}, clear=True):
+                defaults = get_settings(force_reload=True)
+
+            self.assertFalse(defaults.ui_enabled)
+            self.assertTrue(defaults.ui_require_localhost)
+            self.assertTrue(defaults.ui_read_only)
+
+            with patch.dict(
+                os.environ,
+                {
+                    "COGNIRELAY_REPO_ROOT": td,
+                    "COGNIRELAY_UI_ENABLED": "true",
+                    "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false",
+                    "COGNIRELAY_UI_READ_ONLY": "false",
+                },
+                clear=True,
+            ):
+                configured = get_settings(force_reload=True)
+
+            self.assertTrue(configured.ui_enabled)
+            self.assertFalse(configured.ui_require_localhost)
+            self.assertFalse(configured.ui_read_only)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -1,0 +1,199 @@
+"""Tests for the first bounded operator UI slice of issue #199."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+def _reload_main_module():
+    """Reload config and main so env-controlled UI mounting is recalculated."""
+    import app.config as config_module
+    import app.main as main_module
+
+    importlib.reload(config_module)
+    return importlib.reload(main_module)
+
+
+def _capsule_payload(*, subject_kind: str, subject_id: str) -> dict:
+    """Build a deterministic continuity capsule payload for UI tests."""
+    now = datetime(2026, 4, 15, 9, 30, tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+    return {
+        "schema_version": "1.0",
+        "subject_kind": subject_kind,
+        "subject_id": subject_id,
+        "updated_at": now,
+        "verified_at": now,
+        "verification_kind": "self_review",
+        "source": {
+            "producer": "handoff-hook",
+            "update_reason": "pre_compaction",
+            "inputs": ["memory/core/identity.md"],
+        },
+        "continuity": {
+            "top_priorities": [f"priority for {subject_id}"],
+            "active_concerns": [f"concern for {subject_id}"],
+            "active_constraints": [f"constraint for {subject_id}"],
+            "open_loops": [f"loop for {subject_id}"],
+            "stance_summary": f"stance for {subject_id}",
+            "session_trajectory": [f"trajectory for {subject_id}"],
+            "negative_decisions": [
+                {
+                    "decision": "skip unsafe mutation",
+                    "rationale": "read-only slice",
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            ],
+            "rationale_entries": [
+                {
+                    "tag": "ui-slice",
+                    "kind": "decision",
+                    "status": "active",
+                    "summary": "ship a thin server-rendered UI",
+                    "reasoning": "keep the first slice reviewable",
+                    "created_at": now,
+                    "updated_at": now,
+                }
+            ],
+            "drift_signals": [],
+        },
+        "stable_preferences": [
+            {
+                "tag": "operator-style",
+                "content": "prefer readable tables",
+                "created_at": now,
+                "updated_at": now,
+            }
+        ],
+        "confidence": {"continuity": 0.82, "relationship_model": 0.0},
+        "freshness": {"freshness_class": "situational"},
+    }
+
+
+def _write_capsule(repo_root: Path, *, subject_kind: str, subject_id: str) -> None:
+    """Write one active continuity capsule to the repository fixture."""
+    continuity_dir = repo_root / "memory" / "continuity"
+    continuity_dir.mkdir(parents=True, exist_ok=True)
+    normalized = subject_id.strip().lower().replace(" ", "-")
+    payload = _capsule_payload(subject_kind=subject_kind, subject_id=subject_id)
+    (continuity_dir / f"{subject_kind}-{normalized}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_fallback(repo_root: Path, *, subject_kind: str, subject_id: str) -> None:
+    """Write a fallback-only continuity snapshot for degraded UI reads."""
+    fallback_dir = repo_root / "memory" / "continuity" / "fallback"
+    fallback_dir.mkdir(parents=True, exist_ok=True)
+    normalized = subject_id.strip().lower().replace(" ", "-")
+    capsule = _capsule_payload(subject_kind=subject_kind, subject_id=subject_id)
+    (fallback_dir / f"{subject_kind}-{normalized}.json").write_text(
+        json.dumps(
+            {
+                "schema_type": "continuity_fallback_snapshot",
+                "schema_version": "1.0",
+                "captured_at": capsule["updated_at"],
+                "source_path": f"memory/continuity/{subject_kind}-{normalized}.json",
+                "verification_status": "system_confirmed",
+                "health_status": "healthy",
+                "capsule": capsule,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestOperatorUiSlice1(unittest.TestCase):
+    """Validate the first bounded operator UI slice."""
+
+    def _client(self, repo_root: Path, **env_overrides: str) -> TestClient:
+        """Load a TestClient with UI flags recalculated from env."""
+        env = {
+            "COGNIRELAY_REPO_ROOT": str(repo_root),
+            "COGNIRELAY_AUTO_INIT_GIT": "true",
+            "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
+            **env_overrides,
+        }
+        patcher = patch.dict(os.environ, env, clear=False)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        main_module = _reload_main_module()
+        return TestClient(main_module.app)
+
+    def test_ui_disabled_does_not_expose_ui_routes(self) -> None:
+        """When UI is disabled, the /ui surface should not be mounted."""
+        with tempfile.TemporaryDirectory() as td:
+            client = self._client(Path(td), COGNIRELAY_UI_ENABLED="false")
+            response = client.get("/ui/")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_ui_localhost_restriction_blocks_non_local_requests(self) -> None:
+        """The local-only UI posture should reject non-loopback callers."""
+        with tempfile.TemporaryDirectory() as td:
+            client = self._client(
+                Path(td),
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="true",
+            )
+            response = client.get("/ui/", headers={"X-Forwarded-For": "10.20.30.40"})
+
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("local-only", response.text)
+
+    def test_ui_overview_and_list_pages_render_key_data(self) -> None:
+        """Overview and list pages should render health and continuity summaries."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="user", subject_id="stef")
+            _write_capsule(repo_root, subject_kind="thread", subject_id="guestbook-1")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="true",
+            )
+
+            overview = client.get("/ui/", headers={"X-Forwarded-For": "127.0.0.1"})
+            listing = client.get("/ui/continuity?subject_kind=user", headers={"X-Forwarded-For": "127.0.0.1"})
+
+        self.assertEqual(overview.status_code, 200)
+        self.assertIn("Operator Overview", overview.text)
+        self.assertIn("Continuity Counts", overview.text)
+        self.assertIn("Active capsules", overview.text)
+        self.assertEqual(listing.status_code, 200)
+        self.assertIn("Continuity Capsules", listing.text)
+        self.assertIn("stef", listing.text)
+        self.assertIn("/ui/continuity/user/stef", listing.text)
+
+    def test_ui_detail_page_handles_fallback_and_missing_capsules(self) -> None:
+        """Detail pages should degrade gracefully for fallback-only and missing continuity."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_fallback(repo_root, subject_kind="user", subject_id="fallback-only")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="true",
+            )
+
+            fallback = client.get("/ui/continuity/user/fallback-only", headers={"X-Forwarded-For": "127.0.0.1"})
+            missing = client.get("/ui/continuity/user/missing-user", headers={"X-Forwarded-For": "127.0.0.1"})
+
+        self.assertEqual(fallback.status_code, 200)
+        self.assertIn("Source state: fallback", fallback.text)
+        self.assertIn("skip unsafe mutation", fallback.text)
+        self.assertIn("prefer readable tables", fallback.text)
+        self.assertEqual(missing.status_code, 200)
+        self.assertIn("Source state: missing", missing.text)
+        self.assertIn("No stable preferences recorded.", missing.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -9,18 +9,40 @@ import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
 
 def _reload_main_module():
     """Reload config and main so env-controlled UI mounting is recalculated."""
     import app.config as config_module
     import app.main as main_module
+    import app.ui.router as ui_router_module
 
     importlib.reload(config_module)
+    importlib.reload(ui_router_module)
     return importlib.reload(main_module)
+
+
+def _request_with_transport_host(host: str | None, *, headers: list[tuple[bytes, bytes]] | None = None) -> Request:
+    """Build a Request carrying an explicit transport client host."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/ui/",
+        "raw_path": b"/ui/",
+        "query_string": b"",
+        "headers": headers or [],
+        "client": None if host is None else (host, 12345),
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "http_version": "1.1",
+    }
+    return Request(scope)
 
 
 def _capsule_payload(*, subject_kind: str, subject_id: str) -> dict:
@@ -136,17 +158,38 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_ui_localhost_restriction_blocks_non_local_requests(self) -> None:
-        """The local-only UI posture should reject non-loopback callers."""
-        with tempfile.TemporaryDirectory() as td:
-            client = self._client(
-                Path(td),
-                COGNIRELAY_UI_ENABLED="true",
-                COGNIRELAY_UI_REQUIRE_LOCALHOST="true",
-            )
-            response = client.get("/ui/", headers={"X-Forwarded-For": "10.20.30.40"})
+        """The local-only UI posture should reject non-loopback transport peers."""
+        import app.ui.router as ui_router
 
-        self.assertEqual(response.status_code, 403)
-        self.assertIn("local-only", response.text)
+        request = _request_with_transport_host("10.20.30.40")
+        with self.assertRaises(HTTPException) as err:
+            ui_router._enforce_ui_access(request, SimpleNamespace(ui_require_localhost=True))
+
+        self.assertEqual(err.exception.status_code, 403)
+        self.assertIn("local-only", str(err.exception.detail))
+
+    def test_ui_localhost_restriction_ignores_forwarded_localhost_spoof(self) -> None:
+        """Forwarded localhost headers must not bypass a non-local transport source."""
+        import app.ui.router as ui_router
+
+        request = _request_with_transport_host(
+            "10.20.30.40",
+            headers=[
+                (b"x-forwarded-for", b"127.0.0.1"),
+                (b"x-real-ip", b"127.0.0.1"),
+            ],
+        )
+        with self.assertRaises(HTTPException) as err:
+            ui_router._enforce_ui_access(request, SimpleNamespace(ui_require_localhost=True))
+
+        self.assertEqual(err.exception.status_code, 403)
+
+    def test_ui_localhost_restriction_allows_loopback_transport(self) -> None:
+        """Loopback transport peers should satisfy the strict local-only gate."""
+        import app.ui.router as ui_router
+
+        request = _request_with_transport_host("127.0.0.1")
+        self.assertEqual(ui_router._enforce_ui_access(request, SimpleNamespace(ui_require_localhost=True)), "127.0.0.1")
 
     def test_ui_overview_and_list_pages_render_key_data(self) -> None:
         """Overview and list pages should render health and continuity summaries."""
@@ -157,11 +200,11 @@ class TestOperatorUiSlice1(unittest.TestCase):
             client = self._client(
                 repo_root,
                 COGNIRELAY_UI_ENABLED="true",
-                COGNIRELAY_UI_REQUIRE_LOCALHOST="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
             )
 
-            overview = client.get("/ui/", headers={"X-Forwarded-For": "127.0.0.1"})
-            listing = client.get("/ui/continuity?subject_kind=user", headers={"X-Forwarded-For": "127.0.0.1"})
+            overview = client.get("/ui/")
+            listing = client.get("/ui/continuity?subject_kind=user")
 
         self.assertEqual(overview.status_code, 200)
         self.assertIn("Operator Overview", overview.text)
@@ -172,6 +215,28 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertIn("stef", listing.text)
         self.assertIn("/ui/continuity/user/stef", listing.text)
 
+    def test_ui_overview_does_not_initialize_git_when_auto_init_enabled(self) -> None:
+        """UI GETs must not create .git even when service-wide auto-init is enabled."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            git_dir = repo_root / ".git"
+            self.assertFalse(git_dir.exists())
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+                COGNIRELAY_AUTO_INIT_GIT="true",
+            )
+
+            overview = client.get("/ui/")
+
+        self.assertEqual(overview.status_code, 200)
+        self.assertFalse(git_dir.exists())
+        self.assertIn("Git initialized", overview.text)
+        self.assertIn("false", overview.text)
+        self.assertIn("Latest commit", overview.text)
+        self.assertIn("none", overview.text)
+
     def test_ui_detail_page_handles_fallback_and_missing_capsules(self) -> None:
         """Detail pages should degrade gracefully for fallback-only and missing continuity."""
         with tempfile.TemporaryDirectory() as td:
@@ -180,11 +245,11 @@ class TestOperatorUiSlice1(unittest.TestCase):
             client = self._client(
                 repo_root,
                 COGNIRELAY_UI_ENABLED="true",
-                COGNIRELAY_UI_REQUIRE_LOCALHOST="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
             )
 
-            fallback = client.get("/ui/continuity/user/fallback-only", headers={"X-Forwarded-For": "127.0.0.1"})
-            missing = client.get("/ui/continuity/user/missing-user", headers={"X-Forwarded-For": "127.0.0.1"})
+            fallback = client.get("/ui/continuity/user/fallback-only")
+            missing = client.get("/ui/continuity/user/missing-user")
 
         self.assertEqual(fallback.status_code, 200)
         self.assertIn("Source state: fallback", fallback.text)


### PR DESCRIPTION
Refs #199

## Summary

This PR adds the first bounded slice of an optional server-rendered operator UI under `/ui` for continuity inspection.

It is disabled by default and keeps conservative defaults from the start:
- `COGNIRELAY_UI_ENABLED=false`
- `COGNIRELAY_UI_REQUIRE_LOCALHOST=true`
- `COGNIRELAY_UI_READ_ONLY=true`

This first slice is strictly read-only. It mounts `/ui` only when explicitly enabled, serves server-rendered HTML with local assets only, and does not use npm, a SPA frontend, or any CDN-hosted resources.

## What Changed

- Added an optional server-rendered operator UI surface under `/ui`
- Added overview, continuity list, and continuity detail pages
- Kept the UI disabled by default with explicit UI config flags
- Enforced localhost gating from the transport peer when `COGNIRELAY_UI_REQUIRE_LOCALHOST=true`
- Ignored forwarded headers for UI allow/deny decisions
- Kept the UI read-only in both intent and implementation
- Ensured UI GET requests do not initialize git/repo state or otherwise mutate durable state
- Rendered graceful degraded views for missing/fallback continuity and absent git state
- Kept assets local only with no npm / no SPA / no bundler

## Operator / Security Posture

- Optional UI surface only
- Disabled by default
- Localhost-restricted by default
- `COGNIRELAY_UI_READ_ONLY=true` remains explicit even though this slice has no mutation actions
- UI handlers reuse existing read-side service logic and do not introduce a parallel business-logic path

## Verification

```bash
./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v
./.venv/bin/python -m ruff check app tests tools
./.venv/bin/python -m unittest discover -s tests -v
```

## Follow-up Work Out Of Scope

Later slices still need to handle, separately and explicitly:
- SSE/live updates
- richer filtering/search
- archive/fallback/cold browsing
- an explicit auth model if non-local or mutable UI is ever introduced
