### PR TITLE
Add operator UI lifecycle visibility slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ git init
 
 For non-local exposure, prefer file-based peer tokens in `data_repo/config/peer_tokens.json` instead of the plaintext development token in `.env`.
 
-The optional operator UI is disabled by default. To expose the first read-only continuity inspection slice locally, set `COGNIRELAY_UI_ENABLED=true`; keep `COGNIRELAY_UI_REQUIRE_LOCALHOST=true` unless you are intentionally relaxing the boundary, since this slice enforces localhost from the transport peer itself rather than forwarded headers. Leave `COGNIRELAY_UI_READ_ONLY=true`; in this slice it documents and preserves the read-only posture, and no mutable UI actions exist yet.
+The optional operator UI is disabled by default. To expose the read-only continuity inspection surface locally, set `COGNIRELAY_UI_ENABLED=true`; keep `COGNIRELAY_UI_REQUIRE_LOCALHOST=true` unless you are intentionally relaxing the boundary, since this slice enforces localhost from the transport peer itself rather than forwarded headers. Leave `COGNIRELAY_UI_READ_ONLY=true`; the current UI remains strictly read-only and now includes bounded lifecycle visibility across active, fallback, archived, and cold continuity artifacts without introducing any maintenance actions.
 
 Each CogniRelay instance serves a single owner-agent. If you operate multiple agents that each need their own continuity, run a separate instance per agent.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ git init
 
 For non-local exposure, prefer file-based peer tokens in `data_repo/config/peer_tokens.json` instead of the plaintext development token in `.env`.
 
-The optional operator UI is disabled by default. To expose the read-only continuity inspection surface locally, set `COGNIRELAY_UI_ENABLED=true`; keep `COGNIRELAY_UI_REQUIRE_LOCALHOST=true` unless you are intentionally relaxing the boundary, since this slice enforces localhost from the transport peer itself rather than forwarded headers. Leave `COGNIRELAY_UI_READ_ONLY=true`; the current UI remains strictly read-only and now includes bounded lifecycle visibility across active, fallback, archived, and cold continuity artifacts without introducing any maintenance actions.
+The optional operator UI is disabled by default. To expose the read-only continuity inspection surface in the supported posture for issue `#199`, set `COGNIRELAY_UI_ENABLED=true` and keep `COGNIRELAY_UI_REQUIRE_LOCALHOST=true`, since this slice enforces localhost from the transport peer itself rather than forwarded headers. Leave `COGNIRELAY_UI_READ_ONLY=true`; the current UI remains strictly read-only and now includes bounded lifecycle visibility across active, fallback, archived, and cold continuity artifacts without introducing any maintenance actions.
 
 Each CogniRelay instance serves a single owner-agent. If you operate multiple agents that each need their own continuity, run a separate instance per agent.
 

--- a/app/continuity/listing.py
+++ b/app/continuity/listing.py
@@ -185,6 +185,10 @@ def _scan_archive_summaries(
                 now=now,
                 artifact_state="archived",
                 retention_class=retention_class,
+                extra={
+                    "archive_path": rel,
+                    "archived_at": envelope.get("archived_at"),
+                },
             )
         )
     return summaries

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -28,6 +28,7 @@ from app.models import ContinuityListRequest, ContinuityReadRequest
 from .render import render_template
 
 UI_SUBJECT_KINDS: tuple[str, ...] = ("user", "peer", "thread", "task")
+UI_ARTIFACT_STATES: tuple[str, ...] = ("active", "fallback", "archived", "cold")
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
 
 
@@ -108,6 +109,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
     def ui_continuity(
         request: Request,
         subject_kind: Literal["user", "peer", "thread", "task"] | None = Query(default=None),
+        artifact_state: Literal["active", "fallback", "archived", "cold"] | None = Query(default=None),
     ) -> HTMLResponse:
         """Render the continuity list view."""
         settings = get_settings()
@@ -122,44 +124,57 @@ def build_ui_router(*, app_version: str) -> APIRouter:
                 subject_kind=subject_kind,
                 limit=200,
                 include_fallback=True,
-                include_archived=False,
-                include_cold=False,
+                include_archived=True,
+                include_cold=True,
             ),
             now=now,
             retention_archive_days=settings.continuity_retention_archive_days,
             audit=_noop_audit,
         )
+        all_rows = list(listing["capsules"])
+        lifecycle_counts = _artifact_state_counts(all_rows)
+        filtered_rows = _filter_rows_by_artifact_state(all_rows, artifact_state)
         rows = []
-        for capsule in listing["capsules"]:
+        for capsule in filtered_rows:
             rows.append(
                 [
                     html.escape(str(capsule.get("subject_kind", ""))),
                     _subject_link(str(capsule.get("subject_kind", "")), str(capsule.get("subject_id", ""))),
-                    html.escape(str(capsule.get("artifact_state", ""))),
+                    _lifecycle_badges(capsule),
+                    _artifact_location_cell(capsule),
+                    html.escape(_display_recorded_at(capsule)),
                     html.escape(str(capsule.get("health_status", ""))),
-                    html.escape(str(capsule.get("updated_at", ""))),
-                    html.escape(str(capsule.get("stable_preference_count", 0))),
-                    html.escape(str(capsule.get("rationale_entry_count", 0))),
+                    _signal_counts_cell(capsule),
                 ]
             )
         filter_options = "".join(
             _option_row(value=kind, selected=(kind == subject_kind))
             for kind in UI_SUBJECT_KINDS
         )
+        artifact_options = "".join(
+            _option_row(value=state, selected=(state == artifact_state))
+            for state in UI_ARTIFACT_STATES
+        )
         body = render_template(
             "continuity_list.html",
-            selected_kind=html.escape(subject_kind or "all"),
+            selected_kind=html.escape(subject_kind or "all kinds"),
+            selected_artifact_state=html.escape(artifact_state or "all lifecycle states"),
             filter_options=filter_options,
-            result_count=str(listing["count"]),
+            artifact_options=artifact_options,
+            result_count=str(len(filtered_rows)),
+            active_count=str(lifecycle_counts["active"]),
+            fallback_count=str(lifecycle_counts["fallback"]),
+            archived_count=str(lifecycle_counts["archived"]),
+            cold_count=str(lifecycle_counts["cold"]),
             continuity_table=_html_table(
                 headers=[
                     "Kind",
                     "Subject",
-                    "Source",
+                    "Lifecycle",
+                    "Artifact",
+                    "Recorded",
                     "Health",
-                    "Updated",
-                    "Stable prefs",
-                    "Rationale entries",
+                    "Signals",
                 ],
                 rows=rows,
                 empty_message="No continuity capsules matched the current filter.",
@@ -194,6 +209,15 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         continuity = capsule.get("continuity") if isinstance(capsule.get("continuity"), dict) else {}
         startup_summary = detail.get("startup_summary")
         trust_signals = detail.get("trust_signals")
+        related_rows = _related_artifact_rows(
+            repo_root=settings.repo_root,
+            auth=auth,
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            now=datetime.now(timezone.utc),
+            retention_archive_days=settings.continuity_retention_archive_days,
+        )
+        related_summary = _related_artifact_summary_rows(subject_kind=subject_kind, rows=related_rows)
         detail_sections = {
             "top_priorities": _html_list(_coerce_str_list(continuity.get("top_priorities"))),
             "active_concerns": _html_list(_coerce_str_list(continuity.get("active_concerns"))),
@@ -213,10 +237,18 @@ def build_ui_router(*, app_version: str) -> APIRouter:
                     ("Path", str(detail.get("path", ""))),
                     ("Source state", str(detail.get("source_state", "unknown"))),
                     ("Archived", _bool_label(bool(detail.get("archived")))),
+                    ("Fallback snapshot present", _bool_label(any(row["artifact_state"] == "fallback" for row in related_rows))),
+                    ("Archived artifacts present", _bool_label(any(row["artifact_state"] == "archived" for row in related_rows))),
+                    ("Cold artifacts present", _bool_label(any(row["artifact_state"] == "cold" for row in related_rows))),
                     ("Updated at", str(capsule.get("updated_at") or "n/a")),
                     ("Verified at", str(capsule.get("verified_at") or "n/a")),
                     ("Verification kind", str(capsule.get("verification_kind") or "n/a")),
                 ]
+            ),
+            related_artifact_rows=_html_table(
+                headers=["Lifecycle", "Present", "Count", "Latest artifact", "Recorded", "Browse"],
+                rows=related_summary,
+                empty_message="No related lifecycle artifacts were found for this subject.",
             ),
             startup_summary_html=_render_object(startup_summary, empty_message="Startup summary unavailable."),
             trust_signals_html=_render_object(trust_signals, empty_message="Trust signals unavailable."),
@@ -326,6 +358,26 @@ def _bool_label(value: bool) -> str:
     return "true" if value else "false"
 
 
+def _artifact_state_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
+    """Count continuity rows by lifecycle state for list-view summaries."""
+    counts = {state: 0 for state in UI_ARTIFACT_STATES}
+    for row in rows:
+        state = str(row.get("artifact_state") or "")
+        if state in counts:
+            counts[state] += 1
+    return counts
+
+
+def _filter_rows_by_artifact_state(
+    rows: list[dict[str, Any]],
+    artifact_state: str | None,
+) -> list[dict[str, Any]]:
+    """Apply the optional lifecycle filter used by the continuity list page."""
+    if artifact_state is None:
+        return rows
+    return [row for row in rows if row.get("artifact_state") == artifact_state]
+
+
 def _continuity_counts(*, repo_root: Path, auth: AuthContext, now: datetime) -> dict[str, Any]:
     """Collect cheap high-level continuity counts for the overview page."""
     active = _scan_active_summaries(repo_root, auth, None, now)
@@ -382,6 +434,123 @@ def _option_row(*, value: str, selected: bool) -> str:
     """Render one filter option."""
     selected_attr = ' selected="selected"' if selected else ""
     return f'<option value="{html.escape(value)}"{selected_attr}>{html.escape(value)}</option>'
+
+
+def _badge(*, label: str, tone: str = "default") -> str:
+    """Render a compact badge label."""
+    safe_label = html.escape(label)
+    safe_tone = html.escape(tone)
+    return f'<span class="badge badge-{safe_tone}">{safe_label}</span>'
+
+
+def _lifecycle_badges(row: dict[str, Any]) -> str:
+    """Render lifecycle-related badges for one continuity row."""
+    state = str(row.get("artifact_state") or "unknown")
+    parts = [_badge(label=state, tone=state)]
+    retention_class = str(row.get("retention_class") or "")
+    if retention_class and retention_class not in {"active", "fallback", "cold"}:
+        parts.append(_badge(label=retention_class.replace("_", " "), tone="retention"))
+    return '<div class="badge-row">' + "".join(parts) + "</div>"
+
+
+def _artifact_location_cell(row: dict[str, Any]) -> str:
+    """Render the most useful artifact path metadata for one continuity row."""
+    parts = []
+    state = str(row.get("artifact_state") or "")
+    primary_path = _primary_artifact_path(row)
+    if primary_path:
+        parts.append(f"<div>{html.escape(primary_path)}</div>")
+    if state == "cold" and row.get("source_archive_path"):
+        parts.append(f'<div class="muted">archive: {html.escape(str(row.get("source_archive_path")))}</div>')
+    elif state == "archived" and row.get("path"):
+        parts.append(f'<div class="muted">active path: {html.escape(str(row.get("path")))}</div>')
+    return "".join(parts) or '<span class="muted">n/a</span>'
+
+
+def _primary_artifact_path(row: dict[str, Any]) -> str:
+    """Return the most relevant artifact path for one continuity row."""
+    state = str(row.get("artifact_state") or "")
+    if state == "archived":
+        return str(row.get("archive_path") or row.get("path") or "")
+    if state == "cold":
+        return str(row.get("cold_stub_path") or row.get("path") or "")
+    return str(row.get("path") or "")
+
+
+def _display_recorded_at(row: dict[str, Any]) -> str:
+    """Return the best lifecycle timestamp to show for one row."""
+    state = str(row.get("artifact_state") or "")
+    if state == "cold":
+        return str(row.get("cold_stored_at") or row.get("archived_at") or "n/a")
+    if state == "archived":
+        return str(row.get("archived_at") or row.get("updated_at") or "n/a")
+    return str(row.get("updated_at") or "n/a")
+
+
+def _signal_counts_cell(row: dict[str, Any]) -> str:
+    """Render stable-preference and rationale-entry counts for one row."""
+    stable = row.get("stable_preference_count")
+    rationale = row.get("rationale_entry_count")
+    stable_label = "n/a" if stable is None else str(stable)
+    rationale_label = "n/a" if rationale is None else str(rationale)
+    return html.escape(f"{stable_label} prefs / {rationale_label} rationale")
+
+
+def _related_artifact_rows(
+    *,
+    repo_root: Path,
+    auth: AuthContext,
+    subject_kind: str,
+    subject_id: str,
+    now: datetime,
+    retention_archive_days: int,
+) -> list[dict[str, Any]]:
+    """Collect all lifecycle rows for one subject using existing continuity scanners."""
+    rows: list[dict[str, Any]] = []
+    rows.extend(_scan_active_summaries(repo_root, auth, subject_kind, now))
+    rows.extend(_scan_fallback_summaries(repo_root, auth, subject_kind, now))
+    rows.extend(_scan_archive_summaries(repo_root, auth, subject_kind, now, retention_archive_days))
+    rows.extend(_scan_cold_summaries(repo_root, auth, subject_kind))
+    filtered = [row for row in rows if str(row.get("subject_id")) == subject_id]
+    artifact_order = {state: idx for idx, state in enumerate(UI_ARTIFACT_STATES)}
+    filtered.sort(
+        key=lambda row: (
+            artifact_order.get(str(row.get("artifact_state")), 99),
+            str(_display_recorded_at(row)),
+            str(_primary_artifact_path(row)),
+        ),
+        reverse=False,
+    )
+    return filtered
+
+
+def _related_artifact_summary_rows(
+    *,
+    subject_kind: str,
+    rows: list[dict[str, Any]],
+) -> list[list[str]]:
+    """Build a bounded per-lifecycle summary table for the detail page."""
+    summary_rows: list[list[str]] = []
+    for state in UI_ARTIFACT_STATES:
+        matching = [row for row in rows if row.get("artifact_state") == state]
+        latest = matching[-1] if matching else None
+        browse_href = f"/ui/continuity?subject_kind={quote(subject_kind, safe='')}&artifact_state={quote(state, safe='')}"
+        latest_html = '<span class="muted">None</span>'
+        recorded = "n/a"
+        if latest is not None:
+            latest_html = _artifact_location_cell(latest)
+            recorded = _display_recorded_at(latest)
+        summary_rows.append(
+            [
+                _lifecycle_badges({"artifact_state": state, "retention_class": latest.get("retention_class") if latest else ""}),
+                html.escape(_bool_label(bool(matching))),
+                html.escape(str(len(matching))),
+                latest_html,
+                html.escape(recorded),
+                f'<a href="{browse_href}">Browse {html.escape(state)}</a>',
+            ]
+        )
+    return summary_rows
 
 
 def _render_object(value: Any, *, empty_message: str) -> str:

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -14,7 +14,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 
 from app.auth import AuthContext
 from app.config import Settings, get_settings
-from app.continuity import continuity_list_service, continuity_read_service
+from app.continuity import continuity_read_service
 from app.continuity.listing import (
     _scan_active_summaries,
     _scan_archive_summaries,
@@ -23,12 +23,13 @@ from app.continuity.listing import (
 )
 from app.discovery import capabilities_payload, health_payload
 from app.git_manager import GitManager
-from app.models import ContinuityListRequest, ContinuityReadRequest
+from app.models import ContinuityReadRequest
 
 from .render import render_template
 
 UI_SUBJECT_KINDS: tuple[str, ...] = ("user", "peer", "thread", "task")
 UI_ARTIFACT_STATES: tuple[str, ...] = ("active", "fallback", "archived", "cold")
+UI_CONTINUITY_DISPLAY_LIMIT = 200
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
 
 
@@ -117,25 +118,19 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         _gm = _ui_git_manager(settings)
         auth = _ui_auth(client_ip)
         now = datetime.now(timezone.utc)
-        listing = continuity_list_service(
+        all_rows = _ui_continuity_rows(
             repo_root=settings.repo_root,
             auth=auth,
-            req=ContinuityListRequest(
-                subject_kind=subject_kind,
-                limit=200,
-                include_fallback=True,
-                include_archived=True,
-                include_cold=True,
-            ),
+            subject_kind=subject_kind,
+            artifact_state=None,
             now=now,
             retention_archive_days=settings.continuity_retention_archive_days,
-            audit=_noop_audit,
         )
-        all_rows = list(listing["capsules"])
         lifecycle_counts = _artifact_state_counts(all_rows)
         filtered_rows = _filter_rows_by_artifact_state(all_rows, artifact_state)
+        display_rows = filtered_rows[:UI_CONTINUITY_DISPLAY_LIMIT]
         rows = []
-        for capsule in filtered_rows:
+        for capsule in display_rows:
             rows.append(
                 [
                     html.escape(str(capsule.get("subject_kind", ""))),
@@ -161,7 +156,9 @@ def build_ui_router(*, app_version: str) -> APIRouter:
             selected_artifact_state=html.escape(artifact_state or "all lifecycle states"),
             filter_options=filter_options,
             artifact_options=artifact_options,
-            result_count=str(len(filtered_rows)),
+            displayed_count=str(len(display_rows)),
+            matched_count=str(len(filtered_rows)),
+            result_truncated=_bool_label(len(filtered_rows) > UI_CONTINUITY_DISPLAY_LIMIT),
             active_count=str(lifecycle_counts["active"]),
             fallback_count=str(lifecycle_counts["fallback"]),
             archived_count=str(lifecycle_counts["archived"]),
@@ -368,6 +365,39 @@ def _artifact_state_counts(rows: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
+def _ui_continuity_rows(
+    *,
+    repo_root: Path,
+    auth: AuthContext,
+    subject_kind: str | None,
+    artifact_state: str | None,
+    now: datetime,
+    retention_archive_days: int,
+) -> list[dict[str, Any]]:
+    """Collect lifecycle rows for the UI without pre-filter truncation."""
+    states = [artifact_state] if artifact_state in UI_ARTIFACT_STATES else list(UI_ARTIFACT_STATES)
+    rows: list[dict[str, Any]] = []
+    for state in states:
+        if state == "active":
+            rows.extend(_scan_active_summaries(repo_root, auth, subject_kind, now))
+        elif state == "fallback":
+            rows.extend(_scan_fallback_summaries(repo_root, auth, subject_kind, now))
+        elif state == "archived":
+            rows.extend(_scan_archive_summaries(repo_root, auth, subject_kind, now, retention_archive_days))
+        elif state == "cold":
+            rows.extend(_scan_cold_summaries(repo_root, auth, subject_kind))
+    artifact_order = {state: idx for idx, state in enumerate(UI_ARTIFACT_STATES)}
+    rows.sort(
+        key=lambda row: (
+            str(row.get("subject_kind")),
+            str(row.get("subject_id")),
+            artifact_order.get(str(row.get("artifact_state")), 99),
+            str(_primary_artifact_path(row)),
+        )
+    )
+    return rows
+
+
 def _filter_rows_by_artifact_state(
     rows: list[dict[str, Any]],
     artifact_state: str | None,
@@ -506,21 +536,15 @@ def _related_artifact_rows(
     retention_archive_days: int,
 ) -> list[dict[str, Any]]:
     """Collect all lifecycle rows for one subject using existing continuity scanners."""
-    rows: list[dict[str, Any]] = []
-    rows.extend(_scan_active_summaries(repo_root, auth, subject_kind, now))
-    rows.extend(_scan_fallback_summaries(repo_root, auth, subject_kind, now))
-    rows.extend(_scan_archive_summaries(repo_root, auth, subject_kind, now, retention_archive_days))
-    rows.extend(_scan_cold_summaries(repo_root, auth, subject_kind))
-    filtered = [row for row in rows if str(row.get("subject_id")) == subject_id]
-    artifact_order = {state: idx for idx, state in enumerate(UI_ARTIFACT_STATES)}
-    filtered.sort(
-        key=lambda row: (
-            artifact_order.get(str(row.get("artifact_state")), 99),
-            str(_display_recorded_at(row)),
-            str(_primary_artifact_path(row)),
-        ),
-        reverse=False,
+    rows = _ui_continuity_rows(
+        repo_root=repo_root,
+        auth=auth,
+        subject_kind=subject_kind,
+        artifact_state=None,
+        now=now,
+        retention_archive_days=retention_archive_days,
     )
+    filtered = [row for row in rows if str(row.get("subject_id")) == subject_id]
     return filtered
 
 
@@ -547,7 +571,7 @@ def _related_artifact_summary_rows(
                 html.escape(str(len(matching))),
                 latest_html,
                 html.escape(recorded),
-                f'<a href="{browse_href}">Browse {html.escape(state)}</a>',
+                f'<a href="{browse_href}">Open {html.escape(subject_kind)} {html.escape(state)} list</a>',
             ]
         )
     return summary_rows

--- a/app/ui/static/ui.css
+++ b/app/ui/static/ui.css
@@ -145,6 +145,62 @@ main.shell {
   align-items: end;
 }
 
+.badge-row {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.22rem 0.55rem;
+  font-size: 0.78rem;
+  line-height: 1.2;
+  border: 1px solid var(--border);
+  background: #f2ede2;
+}
+
+.badge-active {
+  background: #e4f0eb;
+  border-color: #b7d3c7;
+}
+
+.badge-fallback {
+  background: #f4ead9;
+  border-color: #d7c3a2;
+}
+
+.badge-archived {
+  background: #e8edf5;
+  border-color: #c0cadb;
+}
+
+.badge-cold {
+  background: #e3eef6;
+  border-color: #b0cadf;
+}
+
+.badge-retention {
+  background: #f5efe3;
+  border-color: #dbc7a1;
+}
+
+.summary-row {
+  margin-top: 0.9rem;
+}
+
+.summary-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: #f2ede2;
+  border: 1px solid var(--border);
+  font-size: 0.85rem;
+}
+
 select,
 button {
   font: inherit;

--- a/app/ui/templates/continuity_detail.html
+++ b/app/ui/templates/continuity_detail.html
@@ -5,6 +5,10 @@
   ${capsule_meta_rows}
 </section>
 <section class="panel">
+  <h2>Related Lifecycle Artifacts</h2>
+  ${related_artifact_rows}
+</section>
+<section class="panel">
   <h2>Recovery Warnings</h2>
   ${recovery_warnings}
 </section>

--- a/app/ui/templates/continuity_list.html
+++ b/app/ui/templates/continuity_list.html
@@ -19,7 +19,8 @@
     <span class="summary-chip">archived ${archived_count}</span>
     <span class="summary-chip">cold ${cold_count}</span>
   </div>
-  <p class="muted">Showing ${result_count} result(s). Current filters: ${selected_kind}; ${selected_artifact_state}</p>
+  <p class="muted">Showing ${displayed_count} result(s) from ${matched_count} matched row(s). Current filters: ${selected_kind}; ${selected_artifact_state}</p>
+  <p class="muted">Display truncated: ${result_truncated}</p>
 </section>
 <section class="panel">
   <h2>Continuity Capsules</h2>

--- a/app/ui/templates/continuity_list.html
+++ b/app/ui/templates/continuity_list.html
@@ -6,9 +6,20 @@
       <option value="">all</option>
       ${filter_options}
     </select>
+    <label for="artifact_state">Lifecycle state</label>
+    <select id="artifact_state" name="artifact_state">
+      <option value="">all</option>
+      ${artifact_options}
+    </select>
     <button type="submit">Apply</button>
   </form>
-  <p class="muted">Showing ${result_count} result(s). Current filter: ${selected_kind}</p>
+  <div class="badge-row summary-row">
+    <span class="summary-chip">active ${active_count}</span>
+    <span class="summary-chip">fallback ${fallback_count}</span>
+    <span class="summary-chip">archived ${archived_count}</span>
+    <span class="summary-chip">cold ${cold_count}</span>
+  </div>
+  <p class="muted">Showing ${result_count} result(s). Current filters: ${selected_kind}; ${selected_artifact_state}</p>
 </section>
 <section class="panel">
   <h2>Continuity Capsules</h2>

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -7,6 +7,7 @@ import json
 import os
 import tempfile
 import unittest
+import gzip
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -15,6 +16,9 @@ from unittest.mock import patch
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from starlette.requests import Request
+
+from app.continuity.cold import _build_cold_stub_text
+from app.continuity.paths import continuity_cold_storage_rel_path, continuity_cold_stub_rel_path
 
 
 def _reload_main_module():
@@ -130,6 +134,60 @@ def _write_fallback(repo_root: Path, *, subject_kind: str, subject_id: str) -> N
         ),
         encoding="utf-8",
     )
+
+
+def _write_archive(repo_root: Path, *, subject_kind: str, subject_id: str) -> str:
+    """Write an archived continuity envelope and return its repo-relative path."""
+    capsule = _capsule_payload(subject_kind=subject_kind, subject_id=subject_id)
+    archived_at = capsule["updated_at"]
+    archive_rel = f"memory/continuity/archive/{subject_kind}-{subject_id}-20260415T093000Z.json"
+    archive_path = repo_root / archive_rel
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    archive_path.write_text(
+        json.dumps(
+            {
+                "schema_type": "continuity_archive_envelope",
+                "schema_version": "1.0",
+                "archived_at": archived_at,
+                "active_path": f"memory/continuity/{subject_kind}-{subject_id}.json",
+                "capsule": capsule,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return archive_rel
+
+
+def _write_cold(repo_root: Path, *, subject_kind: str, subject_id: str) -> str:
+    """Write a cold continuity stub and payload pair for UI lifecycle tests."""
+    capsule = _capsule_payload(subject_kind=subject_kind, subject_id=subject_id)
+    archived_at = capsule["updated_at"]
+    source_archive_path = f"memory/continuity/archive/{subject_kind}-{subject_id}-20260415T093000Z.json"
+    cold_storage_path = continuity_cold_storage_rel_path(source_archive_path)
+    cold_stub_path = continuity_cold_stub_rel_path(source_archive_path)
+    envelope = {
+        "schema_type": "continuity_archive_envelope",
+        "schema_version": "1.0",
+        "archived_at": archived_at,
+        "active_path": f"memory/continuity/{subject_kind}-{subject_id}.json",
+        "capsule": capsule,
+    }
+    payload_path = repo_root / cold_storage_path
+    payload_path.parent.mkdir(parents=True, exist_ok=True)
+    payload_path.write_bytes(gzip.compress(json.dumps(envelope).encode("utf-8")))
+    stub_path = repo_root / cold_stub_path
+    stub_path.parent.mkdir(parents=True, exist_ok=True)
+    stub_path.write_text(
+        _build_cold_stub_text(
+            envelope=envelope,
+            source_archive_path=source_archive_path,
+            cold_storage_path=cold_storage_path,
+            cold_stored_at=archived_at,
+            now=datetime.now(timezone.utc),
+        ),
+        encoding="utf-8",
+    )
+    return cold_stub_path
 
 
 class TestOperatorUiSlice1(unittest.TestCase):
@@ -258,6 +316,83 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(missing.status_code, 200)
         self.assertIn("Source state: missing", missing.text)
         self.assertIn("No stable preferences recorded.", missing.text)
+
+    def test_ui_continuity_list_surfaces_lifecycle_states_and_filters_them(self) -> None:
+        """The continuity list should show active/fallback/archived/cold states with a simple lifecycle filter."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="user", subject_id="active-user")
+            _write_fallback(repo_root, subject_kind="user", subject_id="fallback-user")
+            _write_archive(repo_root, subject_kind="user", subject_id="archived-user")
+            _write_cold(repo_root, subject_kind="user", subject_id="cold-user")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            listing = client.get("/ui/continuity")
+            archived_only = client.get("/ui/continuity?artifact_state=archived")
+
+        self.assertEqual(listing.status_code, 200)
+        self.assertIn("active", listing.text)
+        self.assertIn("fallback", listing.text)
+        self.assertIn("archived", listing.text)
+        self.assertIn("cold", listing.text)
+        self.assertIn("memory/continuity/archive/user-archived-user-20260415T093000Z.json", listing.text)
+        self.assertIn("memory/continuity/cold/index/user-cold-user-20260415T093000Z.md", listing.text)
+        self.assertEqual(archived_only.status_code, 200)
+        self.assertIn("archived-user", archived_only.text)
+        self.assertNotIn("active-user", archived_only.text)
+        self.assertNotIn("fallback-user", archived_only.text)
+        self.assertNotIn("cold-user", archived_only.text)
+
+    def test_ui_detail_page_shows_related_lifecycle_artifacts(self) -> None:
+        """The detail page should show related fallback/archive/cold lifecycle visibility for one subject."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="user", subject_id="stef")
+            _write_fallback(repo_root, subject_kind="user", subject_id="stef")
+            _write_archive(repo_root, subject_kind="user", subject_id="stef")
+            _write_cold(repo_root, subject_kind="user", subject_id="stef")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            detail = client.get("/ui/continuity/user/stef")
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertIn("Related Lifecycle Artifacts", detail.text)
+        self.assertIn("Fallback snapshot present", detail.text)
+        self.assertIn("Archived artifacts present", detail.text)
+        self.assertIn("Cold artifacts present", detail.text)
+        self.assertIn("Browse archived", detail.text)
+        self.assertIn("Browse cold", detail.text)
+        self.assertIn("memory/continuity/archive/user-stef-20260415T093000Z.json", detail.text)
+        self.assertIn("memory/continuity/cold/index/user-stef-20260415T093000Z.md", detail.text)
+
+    def test_ui_detail_page_keeps_degraded_reads_while_showing_archived_and_cold_visibility(self) -> None:
+        """Missing active/fallback continuity should still render related archived/cold lifecycle visibility."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_archive(repo_root, subject_kind="user", subject_id="history-only")
+            _write_cold(repo_root, subject_kind="user", subject_id="history-only")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            detail = client.get("/ui/continuity/user/history-only")
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertIn("Source state: missing", detail.text)
+        self.assertIn("Archived artifacts present", detail.text)
+        self.assertIn("Cold artifacts present", detail.text)
+        self.assertIn(">true<", detail.text)
+        self.assertIn("memory/continuity/archive/user-history-only-20260415T093000Z.json", detail.text)
 
 
 if __name__ == "__main__":

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -347,6 +347,29 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertNotIn("fallback-user", archived_only.text)
         self.assertNotIn("cold-user", archived_only.text)
 
+    def test_ui_continuity_filter_finds_archived_rows_beyond_mixed_display_limit(self) -> None:
+        """Lifecycle filtering must stay correct even when the mixed view exceeds the display cap."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            for idx in range(205):
+                _write_capsule(repo_root, subject_kind="user", subject_id=f"active-{idx:03d}")
+            _write_archive(repo_root, subject_kind="user", subject_id="late-archive")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            listing = client.get("/ui/continuity")
+            archived_only = client.get("/ui/continuity?artifact_state=archived")
+
+        self.assertEqual(listing.status_code, 200)
+        self.assertIn("archived 1", listing.text)
+        self.assertIn("Display truncated: true", listing.text)
+        self.assertEqual(archived_only.status_code, 200)
+        self.assertIn("late-archive", archived_only.text)
+        self.assertIn("Showing 1 result(s) from 1 matched row(s).", archived_only.text)
+
     def test_ui_detail_page_shows_related_lifecycle_artifacts(self) -> None:
         """The detail page should show related fallback/archive/cold lifecycle visibility for one subject."""
         with tempfile.TemporaryDirectory() as td:
@@ -368,8 +391,8 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertIn("Fallback snapshot present", detail.text)
         self.assertIn("Archived artifacts present", detail.text)
         self.assertIn("Cold artifacts present", detail.text)
-        self.assertIn("Browse archived", detail.text)
-        self.assertIn("Browse cold", detail.text)
+        self.assertIn("Open user archived list", detail.text)
+        self.assertIn("Open user cold list", detail.text)
         self.assertIn("memory/continuity/archive/user-stef-20260415T093000Z.json", detail.text)
         self.assertIn("memory/continuity/cold/index/user-stef-20260415T093000Z.md", detail.text)
 


### PR DESCRIPTION
Refs #199

## Summary

This PR adds the next bounded operator UI slice for issue #199: read-only lifecycle visibility for continuity artifacts in the existing `/ui/continuity` list and continuity detail pages.

It extends the current local-only, server-rendered operator UI without changing the supported posture:
- local-only operator surface
- strictly read-only behavior
- server-rendered HTML with local assets only
- no hidden durable mutations from UI GETs

## What Changed

- Added bounded lifecycle visibility for `active`, `fallback`, `archived`, and `cold` continuity artifacts on `/ui/continuity`
- Extended continuity detail pages to show related lifecycle artifact presence and bounded related-artifact metadata
- Kept lifecycle filtering semantically correct by resolving lifecycle rows before applying the UI display cap
- Added explicit displayed-vs-matched counts and truncation messaging on the continuity list page
- Relabeled related-artifact links so they honestly describe the broader kind/state list they open
- Kept the implementation scanner-backed and read-only, reusing existing continuity listing/read logic rather than introducing a maintenance console or mutation path

## Operator / Security Posture

This slice preserves the issue #199 posture:
- localhost-only when `COGNIRELAY_UI_REQUIRE_LOCALHOST=true`
- read-only only
- server-rendered only
- no auth redesign
- no SSE or WebSockets
- no mutability
- no standalone archive/cold console

## Out Of Scope In This Slice

- SSE or live updates
- remote/non-local auth
- mutable UI actions
- archive/cold maintenance workflows
- standalone archive/fallback/cold consoles
- SPA / npm / frontend toolchain expansion

## Verification

```bash
./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v
./.venv/bin/python -m ruff check app tests tools
./.venv/bin/python -m unittest discover -s tests -v
```
