### PR TITLE
[codex] Add bounded continuity search filters

### DIFF
--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -160,7 +160,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         )
         body = render_template(
             "continuity_list.html",
-            query_value=html.escape(q or ""),
+            query_value=html.escape(_normalized_query_display(q)),
             selected_kind=html.escape(subject_kind or "all kinds"),
             selected_artifact_state=html.escape(artifact_state or "all lifecycle states"),
             selected_health_status=html.escape(health_status or "all health states"),
@@ -448,6 +448,11 @@ def _search_tokens(value: str | None) -> list[str]:
     if value is None:
         return []
     return [token for token in value.strip().lower().split() if token]
+
+
+def _normalized_query_display(value: str | None) -> str:
+    """Return the displayed query value using the same normalization as matching."""
+    return " ".join(_search_tokens(value))
 
 
 def _row_matches_query(row: dict[str, Any], tokens: list[str]) -> bool:

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -29,6 +29,7 @@ from .render import render_template
 
 UI_SUBJECT_KINDS: tuple[str, ...] = ("user", "peer", "thread", "task")
 UI_ARTIFACT_STATES: tuple[str, ...] = ("active", "fallback", "archived", "cold")
+UI_HEALTH_STATUSES: tuple[str, ...] = ("healthy", "degraded", "conflicted")
 UI_CONTINUITY_DISPLAY_LIMIT = 200
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
 
@@ -109,8 +110,10 @@ def build_ui_router(*, app_version: str) -> APIRouter:
     @router.get("/continuity", response_class=HTMLResponse)
     def ui_continuity(
         request: Request,
+        q: str | None = Query(default=None),
         subject_kind: Literal["user", "peer", "thread", "task"] | None = Query(default=None),
         artifact_state: Literal["active", "fallback", "archived", "cold"] | None = Query(default=None),
+        health_status: Literal["healthy", "degraded", "conflicted"] | None = Query(default=None),
     ) -> HTMLResponse:
         """Render the continuity list view."""
         settings = get_settings()
@@ -126,8 +129,9 @@ def build_ui_router(*, app_version: str) -> APIRouter:
             now=now,
             retention_archive_days=settings.continuity_retention_archive_days,
         )
-        lifecycle_counts = _artifact_state_counts(all_rows)
-        filtered_rows = _filter_rows_by_artifact_state(all_rows, artifact_state)
+        scoped_rows = _filter_rows_by_query_and_health(all_rows, q=q, health_status=health_status)
+        lifecycle_counts = _artifact_state_counts(scoped_rows)
+        filtered_rows = _filter_rows_by_artifact_state(scoped_rows, artifact_state)
         display_rows = filtered_rows[:UI_CONTINUITY_DISPLAY_LIMIT]
         rows = []
         for capsule in display_rows:
@@ -150,12 +154,19 @@ def build_ui_router(*, app_version: str) -> APIRouter:
             _option_row(value=state, selected=(state == artifact_state))
             for state in UI_ARTIFACT_STATES
         )
+        health_options = "".join(
+            _option_row(value=status, selected=(status == health_status))
+            for status in UI_HEALTH_STATUSES
+        )
         body = render_template(
             "continuity_list.html",
+            query_value=html.escape(q or ""),
             selected_kind=html.escape(subject_kind or "all kinds"),
             selected_artifact_state=html.escape(artifact_state or "all lifecycle states"),
+            selected_health_status=html.escape(health_status or "all health states"),
             filter_options=filter_options,
             artifact_options=artifact_options,
+            health_options=health_options,
             displayed_count=str(len(display_rows)),
             matched_count=str(len(filtered_rows)),
             result_truncated=_bool_label(len(filtered_rows) > UI_CONTINUITY_DISPLAY_LIMIT),
@@ -406,6 +417,71 @@ def _filter_rows_by_artifact_state(
     if artifact_state is None:
         return rows
     return [row for row in rows if row.get("artifact_state") == artifact_state]
+
+
+def _filter_rows_by_query_and_health(
+    rows: list[dict[str, Any]],
+    *,
+    q: str | None,
+    health_status: str | None,
+) -> list[dict[str, Any]]:
+    """Apply explicit server-side query and health filters.
+
+    Query matching is deterministic and bounded:
+    - trim and lowercase the query
+    - split on whitespace into tokens
+    - each token must appear as a substring in at least one fixed searchable field
+    """
+    tokens = _search_tokens(q)
+    filtered: list[dict[str, Any]] = []
+    for row in rows:
+        if health_status is not None and row.get("health_status") != health_status:
+            continue
+        if tokens and not _row_matches_query(row, tokens):
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def _search_tokens(value: str | None) -> list[str]:
+    """Normalize one search query into bounded lowercase tokens."""
+    if value is None:
+        return []
+    return [token for token in value.strip().lower().split() if token]
+
+
+def _row_matches_query(row: dict[str, Any], tokens: list[str]) -> bool:
+    """Return whether every token matches one of the row's searchable fields."""
+    fields = _row_search_fields(row)
+    return all(any(token in field for field in fields) for token in tokens)
+
+
+def _row_search_fields(row: dict[str, Any]) -> list[str]:
+    """Return the explicit fields searchable from continuity list rows."""
+    values = [
+        row.get("subject_kind"),
+        row.get("subject_id"),
+        row.get("artifact_state"),
+        row.get("health_status"),
+        row.get("phase"),
+        row.get("verification_status"),
+        row.get("freshness_class"),
+        row.get("verification_kind"),
+        row.get("retention_class"),
+        row.get("path"),
+        row.get("archive_path"),
+        row.get("cold_stub_path"),
+        row.get("source_archive_path"),
+        row.get("cold_storage_path"),
+    ]
+    fields: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        normalized = str(value).strip().lower()
+        if normalized:
+            fields.append(normalized)
+    return fields
 
 
 def _continuity_counts(*, repo_root: Path, auth: AuthContext, now: datetime) -> dict[str, Any]:

--- a/app/ui/templates/continuity_list.html
+++ b/app/ui/templates/continuity_list.html
@@ -1,6 +1,8 @@
 <section class="panel">
   <h2>Filters</h2>
   <form method="get" action="/ui/continuity" class="filter-form">
+    <label for="q">Search query</label>
+    <input id="q" name="q" type="text" value="${query_value}" placeholder="subject, path, state, status" />
     <label for="subject_kind">Subject kind</label>
     <select id="subject_kind" name="subject_kind">
       <option value="">all</option>
@@ -11,6 +13,11 @@
       <option value="">all</option>
       ${artifact_options}
     </select>
+    <label for="health_status">Health</label>
+    <select id="health_status" name="health_status">
+      <option value="">all</option>
+      ${health_options}
+    </select>
     <button type="submit">Apply</button>
   </form>
   <div class="badge-row summary-row">
@@ -19,8 +26,9 @@
     <span class="summary-chip">archived ${archived_count}</span>
     <span class="summary-chip">cold ${cold_count}</span>
   </div>
-  <p class="muted">Showing ${displayed_count} result(s) from ${matched_count} matched row(s). Current filters: ${selected_kind}; ${selected_artifact_state}</p>
+  <p class="muted">Showing ${displayed_count} result(s) from ${matched_count} matched row(s). Current filters: query "${query_value}"; ${selected_kind}; ${selected_artifact_state}; ${selected_health_status}</p>
   <p class="muted">Display truncated: ${result_truncated}</p>
+  <p class="muted">Query tokens use case-insensitive substring matching across subject, lifecycle, health, and artifact path fields.</p>
 </section>
 <section class="panel">
   <h2>Continuity Capsules</h2>

--- a/app/ui/templates/continuity_list.html
+++ b/app/ui/templates/continuity_list.html
@@ -28,6 +28,7 @@
   </div>
   <p class="muted">Showing ${displayed_count} result(s) from ${matched_count} matched row(s). Current filters: query "${query_value}"; ${selected_kind}; ${selected_artifact_state}; ${selected_health_status}</p>
   <p class="muted">Display truncated: ${result_truncated}</p>
+  <p class="muted">Lifecycle chips reflect the current subject/query/health scope before lifecycle-state narrowing, so they may exceed the rows currently listed when a lifecycle state filter is active.</p>
   <p class="muted">Query tokens use case-insensitive substring matching across subject, lifecycle, health, and artifact path fields.</p>
 </section>
 <section class="panel">

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -49,10 +49,10 @@ def _request_with_transport_host(host: str | None, *, headers: list[tuple[bytes,
     return Request(scope)
 
 
-def _capsule_payload(*, subject_kind: str, subject_id: str) -> dict:
+def _capsule_payload(*, subject_kind: str, subject_id: str, capsule_health_status: str | None = None) -> dict:
     """Build a deterministic continuity capsule payload for UI tests."""
     now = datetime(2026, 4, 15, 9, 30, tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
-    return {
+    payload = {
         "schema_version": "1.0",
         "subject_kind": subject_kind,
         "subject_id": subject_id,
@@ -103,14 +103,31 @@ def _capsule_payload(*, subject_kind: str, subject_id: str) -> dict:
         "confidence": {"continuity": 0.82, "relationship_model": 0.0},
         "freshness": {"freshness_class": "situational"},
     }
+    if capsule_health_status is not None:
+        payload["capsule_health"] = {
+            "status": capsule_health_status,
+            "last_checked_at": now,
+            "reasons": [] if capsule_health_status == "healthy" else ["test health override"],
+        }
+    return payload
 
 
-def _write_capsule(repo_root: Path, *, subject_kind: str, subject_id: str) -> None:
+def _write_capsule(
+    repo_root: Path,
+    *,
+    subject_kind: str,
+    subject_id: str,
+    capsule_health_status: str | None = None,
+) -> None:
     """Write one active continuity capsule to the repository fixture."""
     continuity_dir = repo_root / "memory" / "continuity"
     continuity_dir.mkdir(parents=True, exist_ok=True)
     normalized = subject_id.strip().lower().replace(" ", "-")
-    payload = _capsule_payload(subject_kind=subject_kind, subject_id=subject_id)
+    payload = _capsule_payload(
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        capsule_health_status=capsule_health_status,
+    )
     (continuity_dir / f"{subject_kind}-{normalized}.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -369,6 +386,58 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(archived_only.status_code, 200)
         self.assertIn("late-archive", archived_only.text)
         self.assertIn("Showing 1 result(s) from 1 matched row(s).", archived_only.text)
+
+    def test_ui_continuity_query_matches_bounded_fields_case_insensitively(self) -> None:
+        """Search should use deterministic token matching across fixed row fields."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="user", subject_id="Alpha Agent")
+            _write_archive(repo_root, subject_kind="task", subject_id="Beta-Memory")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            response = client.get("/ui/continuity?q=ALPHA+healthy")
+            archive_response = client.get("/ui/continuity?q=archive+beta-memory")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Alpha Agent", response.text)
+        self.assertNotIn("Beta-Memory", response.text)
+        self.assertIn('query "ALPHA healthy"', response.text)
+        self.assertIn("case-insensitive substring matching", response.text)
+        self.assertEqual(archive_response.status_code, 200)
+        self.assertIn("Beta-Memory", archive_response.text)
+        self.assertNotIn("Alpha Agent", archive_response.text)
+
+    def test_ui_continuity_health_filter_and_missing_optional_fields_degrade_cleanly(self) -> None:
+        """Health filtering should work while rows missing optional search fields remain searchable."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(
+                repo_root,
+                subject_kind="user",
+                subject_id="Degraded User",
+                capsule_health_status="degraded",
+            )
+            _write_cold(repo_root, subject_kind="user", subject_id="Cold Only")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            degraded_only = client.get("/ui/continuity?health_status=degraded")
+            cold_search = client.get("/ui/continuity?q=cold+only")
+
+        self.assertEqual(degraded_only.status_code, 200)
+        self.assertIn("Degraded User", degraded_only.text)
+        self.assertNotIn("Cold Only", degraded_only.text)
+        self.assertIn("all lifecycle states; degraded", degraded_only.text)
+        self.assertEqual(cold_search.status_code, 200)
+        self.assertIn("Cold Only", cold_search.text)
+        self.assertIn("memory/continuity/cold/index/user-Cold Only-20260415T093000Z.md", cold_search.text)
 
     def test_ui_detail_page_shows_related_lifecycle_artifacts(self) -> None:
         """The detail page should show related fallback/archive/cold lifecycle visibility for one subject."""

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -153,9 +153,19 @@ def _write_fallback(repo_root: Path, *, subject_kind: str, subject_id: str) -> N
     )
 
 
-def _write_archive(repo_root: Path, *, subject_kind: str, subject_id: str) -> str:
+def _write_archive(
+    repo_root: Path,
+    *,
+    subject_kind: str,
+    subject_id: str,
+    capsule_health_status: str | None = None,
+) -> str:
     """Write an archived continuity envelope and return its repo-relative path."""
-    capsule = _capsule_payload(subject_kind=subject_kind, subject_id=subject_id)
+    capsule = _capsule_payload(
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        capsule_health_status=capsule_health_status,
+    )
     archived_at = capsule["updated_at"]
     archive_rel = f"memory/continuity/archive/{subject_kind}-{subject_id}-20260415T093000Z.json"
     archive_path = repo_root / archive_rel
@@ -405,7 +415,7 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Alpha Agent", response.text)
         self.assertNotIn("Beta-Memory", response.text)
-        self.assertIn('query "ALPHA healthy"', response.text)
+        self.assertIn('query "alpha healthy"', response.text)
         self.assertIn("case-insensitive substring matching", response.text)
         self.assertEqual(archive_response.status_code, 200)
         self.assertIn("Beta-Memory", archive_response.text)
@@ -438,6 +448,50 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(cold_search.status_code, 200)
         self.assertIn("Cold Only", cold_search.text)
         self.assertIn("memory/continuity/cold/index/user-Cold Only-20260415T093000Z.md", cold_search.text)
+
+    def test_ui_continuity_combined_filters_are_conjunctive_and_preserve_chip_scope(self) -> None:
+        """Combined q/kind/health/lifecycle filters should stay conjunctive while chips keep pre-lifecycle scope."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(
+                repo_root,
+                subject_kind="user",
+                subject_id="Scoped Match",
+                capsule_health_status="degraded",
+            )
+            _write_archive(
+                repo_root,
+                subject_kind="user",
+                subject_id="Scoped Match",
+                capsule_health_status="degraded",
+            )
+            _write_capsule(
+                repo_root,
+                subject_kind="peer",
+                subject_id="Scoped Match",
+                capsule_health_status="degraded",
+            )
+            _write_archive(repo_root, subject_kind="user", subject_id="Healthy Match")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            response = client.get(
+                "/ui/continuity?q=%20SCOPED%20MATCH%20&subject_kind=user&artifact_state=archived&health_status=degraded"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('value="scoped match"', response.text)
+        self.assertIn('query "scoped match"; user; archived; degraded', response.text)
+        self.assertIn("Showing 1 result(s) from 1 matched row(s).", response.text)
+        self.assertIn("Scoped Match", response.text)
+        self.assertNotIn("Healthy Match", response.text)
+        self.assertNotIn("/ui/continuity/peer/Scoped%20Match", response.text)
+        self.assertIn("active 1", response.text)
+        self.assertIn("archived 1", response.text)
+        self.assertIn("Lifecycle chips reflect the current subject/query/health scope before lifecycle-state narrowing", response.text)
 
     def test_ui_detail_page_shows_related_lifecycle_artifacts(self) -> None:
         """The detail page should show related fallback/archive/cold lifecycle visibility for one subject."""


### PR DESCRIPTION
Refs #199

## What changed
- adds richer bounded server-rendered filtering and search to `/ui/continuity`
- adds deterministic query normalization and whitespace-token substring matching
- keeps the searchable field set bounded to existing continuity row data and cheap path-derived fields only
- adds `subject_kind`, `artifact_state`, and `health_status` filter support in the UI
- makes lifecycle-chip scope explicit so operators can distinguish chip counts from the currently listed lifecycle rows when `artifact_state` is active

## Search behavior
- query matching is server-side only
- query input is trimmed, lowercased, split on whitespace, and matched token-by-token
- every token must match at least one bounded searchable field on the row
- displayed query state now uses the same normalization as matching, so whitespace-only input is not shown as an active filter

## Bounds and posture
- preserves the local-only operator boundary
- preserves the strictly read-only, server-rendered `/ui` posture
- introduces no hidden durable mutations
- reuses existing continuity list/scanner data rather than adding heavy search logic
- does not add SSE, remote auth, mutability, pagination, or a full-text-search engine in this slice

## Operator impact
- operators can narrow continuity rows by text query, subject kind, lifecycle state, and health state without turning the page into a client-heavy search app
- the UI now states the lifecycle-chip scope explicitly, reducing ambiguity under combined filtering

## Verification
- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `ruff check .`
- `./.venv/bin/python -m unittest discover -s tests -v`
