### PR TITLE
Issue #199: tighten final bounded SSE UI follow-up slice

### DIFF
--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -277,6 +277,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
             ),
             live_detail_updated_at=html.escape(str(capsule.get("updated_at") or "n/a")),
             live_detail_verified_at=html.escape(str(capsule.get("verified_at") or "n/a")),
+            live_detail_warning_count=html.escape(str(len(list(detail.get("recovery_warnings") or [])))),
             live_detail_latest_recorded_at=html.escape(_continuity_live_latest_recorded_at(related_rows)),
             live_detail_source_state=html.escape(str(detail.get("source_state", "unknown"))),
             live_detail_active_count=html.escape(str(related_counts["active"])),
@@ -574,7 +575,6 @@ def _ui_live_overview_summary(
         "git_initialized": bool(health.get("git_initialized")),
         "latest_commit": str(health.get("latest_commit") or "none"),
         "reported_at": str(health.get("time", "")),
-        "status_label": "connected",
         "continuity_counts": continuity_counts,
     }
 

--- a/app/ui/static/ui_live.js
+++ b/app/ui/static/ui_live.js
@@ -36,6 +36,10 @@
     return Math.min(LIVE_MAX_DELAY_MS, LIVE_BASE_DELAY_MS * Math.pow(2, exponent));
   }
 
+  function reconnectState(attempt) {
+    return attempt >= LIVE_OFFLINE_THRESHOLD ? "offline" : "reconnecting";
+  }
+
   function applyOverview(root, payload) {
     if (!payload.overview) {
       return;
@@ -87,6 +91,7 @@
     setText(root, "[data-live-detail-source-state]", payload.detail.source_state || "unavailable");
     setText(root, "[data-live-detail-updated-at]", payload.detail.updated_at || "unavailable");
     setText(root, "[data-live-detail-verified-at]", payload.detail.verified_at || "unavailable");
+    setText(root, "[data-live-detail-warning-count]", String(payload.detail.recovery_warning_count || 0));
     setText(root, "[data-live-latest-recorded-at]", payload.detail.latest_recorded_at || "unavailable");
   }
 
@@ -133,7 +138,7 @@
       }
       reconnectAttempt += 1;
       var delayMs = backoffDelay(reconnectAttempt);
-      var state = reconnectAttempt >= LIVE_OFFLINE_THRESHOLD ? "offline" : "reconnecting";
+      var state = reconnectState(reconnectAttempt);
       setState(root, state, "Live updates reconnecting in " + formatDelay(delayMs) + ".");
       reconnectTimer = window.setTimeout(function () {
         reconnectTimer = null;

--- a/app/ui/templates/continuity_detail.html
+++ b/app/ui/templates/continuity_detail.html
@@ -17,6 +17,7 @@
   <p class="muted">Current source state: <span data-live-detail-source-state>${live_detail_source_state}</span></p>
   <p class="muted">Capsule updated at: <span data-live-detail-updated-at>${live_detail_updated_at}</span></p>
   <p class="muted">Capsule verified at: <span data-live-detail-verified-at>${live_detail_verified_at}</span></p>
+  <p class="muted">Recovery warnings: <span data-live-detail-warning-count>${live_detail_warning_count}</span></p>
   <p class="muted">Latest lifecycle timestamp: <span data-live-latest-recorded-at>${live_detail_latest_recorded_at}</span></p>
   <noscript><p class="muted">JavaScript disabled; live updates are unavailable.</p></noscript>
 </section>

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -6,6 +6,7 @@ import importlib
 import asyncio
 import json
 import os
+import re
 import tempfile
 import unittest
 import gzip
@@ -76,6 +77,36 @@ async def _read_first_sse_event_chunk(response: Any) -> dict[str, str]:
             event[key] = value
     await response.body_iterator.aclose()
     raise AssertionError("No SSE event payload received")
+
+
+def _ui_live_script() -> str:
+    """Return the current UI live-update script text."""
+    return (Path(__file__).resolve().parents[1] / "app" / "ui" / "static" / "ui_live.js").read_text(encoding="utf-8")
+
+
+def _ui_live_backoff_policy() -> dict[str, int]:
+    """Parse the reconnect policy constants declared in ui_live.js."""
+    script = _ui_live_script()
+    policy: dict[str, int] = {}
+    for name in ("LIVE_BASE_DELAY_MS", "LIVE_MAX_DELAY_MS", "LIVE_OFFLINE_THRESHOLD"):
+        match = re.search(rf"var {name} = (\d+);", script)
+        if not match:
+            raise AssertionError(f"Could not find {name} in ui_live.js")
+        policy[name] = int(match.group(1))
+    return policy
+
+
+def _simulated_backoff_delay(attempt: int) -> int:
+    """Simulate the reconnect delay policy declared in ui_live.js."""
+    policy = _ui_live_backoff_policy()
+    exponent = max(attempt - 1, 0)
+    return min(policy["LIVE_MAX_DELAY_MS"], policy["LIVE_BASE_DELAY_MS"] * (2 ** exponent))
+
+
+def _simulated_reconnect_state(attempt: int) -> str:
+    """Simulate the operator-visible reconnect state declared in ui_live.js."""
+    threshold = _ui_live_backoff_policy()["LIVE_OFFLINE_THRESHOLD"]
+    return "offline" if attempt >= threshold else "reconnecting"
 
 
 def _capsule_payload(*, subject_kind: str, subject_id: str, capsule_health_status: str | None = None) -> dict:
@@ -590,6 +621,7 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(payload["continuity"]["matched_count"], 1)
         self.assertEqual(payload["continuity"]["artifact_counts"]["archived"], 1)
         self.assertEqual(payload["continuity"]["recent_change"]["subject_id"], "archived-user")
+        self.assertNotIn("status_label", payload["overview"])
 
     def test_ui_events_stream_degrades_instead_of_failing_on_snapshot_error(self) -> None:
         """Snapshot failures should stay in-band as degraded SSE payloads instead of breaking the stream."""
@@ -669,6 +701,7 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(payload["detail"]["artifact_counts"]["active"], 1)
         self.assertEqual(payload["detail"]["artifact_counts"]["archived"], 1)
         self.assertEqual(payload["detail"]["source_state"], "active")
+        self.assertEqual(payload["detail"]["recovery_warning_count"], 0)
 
     def test_ui_pages_include_progressive_live_update_hooks_without_js_requirement(self) -> None:
         """Overview, continuity, and detail pages should expose optional live hooks while remaining server-rendered."""
@@ -698,19 +731,40 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertIn('data-live-page="detail"', detail.text)
         self.assertIn("Current source state:", detail.text)
         self.assertIn("Capsule updated at:", detail.text)
+        self.assertIn("Recovery warnings:", detail.text)
 
-    def test_ui_live_script_contains_bounded_backoff_and_operator_states(self) -> None:
-        """The live-update script should use bounded backoff and explicit operator-visible states."""
-        script = (Path(__file__).resolve().parents[1] / "app" / "ui" / "static" / "ui_live.js").read_text(encoding="utf-8")
+    def test_ui_live_script_backoff_grows_and_caps_at_declared_max_delay(self) -> None:
+        """Reconnect delay should grow exponentially and then stop at the declared cap."""
+        policy = _ui_live_backoff_policy()
 
-        self.assertIn("LIVE_BASE_DELAY_MS = 1000", script)
-        self.assertIn("LIVE_MAX_DELAY_MS = 16000", script)
-        self.assertIn("Math.min(LIVE_MAX_DELAY_MS, LIVE_BASE_DELAY_MS * Math.pow(2, exponent))", script)
+        self.assertEqual(policy["LIVE_BASE_DELAY_MS"], 1000)
+        self.assertEqual(policy["LIVE_MAX_DELAY_MS"], 16000)
+        self.assertEqual(
+            [_simulated_backoff_delay(attempt) for attempt in range(1, 8)],
+            [1000, 2000, 4000, 8000, 16000, 16000, 16000],
+        )
+
+    def test_ui_live_script_reconnect_state_transitions_match_threshold(self) -> None:
+        """Reconnect attempts should stay reconnecting until the offline threshold is reached."""
+        policy = _ui_live_backoff_policy()
+
+        self.assertEqual(policy["LIVE_OFFLINE_THRESHOLD"], 4)
+        self.assertEqual(
+            [_simulated_reconnect_state(attempt) for attempt in range(1, 6)],
+            ["reconnecting", "reconnecting", "reconnecting", "offline", "offline"],
+        )
+
+    def test_ui_live_script_declares_visible_connection_states_and_degraded_paths(self) -> None:
+        """The script should still explicitly surface connected, reconnecting, degraded, and offline states."""
+        script = _ui_live_script()
+
+        self.assertIn("function reconnectState(attempt)", script)
         self.assertIn('setState(root, "connected"', script)
         self.assertIn('setState(root, "reconnecting"', script)
         self.assertIn('setState(root, "degraded"', script)
         self.assertIn('setState(root, "offline"', script)
-
+        self.assertIn("Live updates degraded; malformed snapshot ignored.", script)
+        self.assertIn("Live updates connected with degraded snapshot data.", script)
 
     def test_ui_detail_page_keeps_degraded_reads_while_showing_archived_and_cold_visibility(self) -> None:
         """Missing active/fallback continuity should still render related archived/cold lifecycle visibility."""
@@ -732,6 +786,23 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertIn("Cold artifacts present", detail.text)
         self.assertIn(">true<", detail.text)
         self.assertIn("memory/continuity/archive/user-history-only-20260415T093000Z.json", detail.text)
+
+    def test_ui_detail_page_live_region_includes_bounded_recovery_warning_count(self) -> None:
+        """Detail live coverage may expand only within the header/meta region."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_archive(repo_root, subject_kind="user", subject_id="history-only")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            detail = client.get("/ui/continuity/user/history-only")
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertIn('data-live-detail-warning-count', detail.text)
+        self.assertIn("Recovery warnings: <span data-live-detail-warning-count>2</span>", detail.text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #199

## Summary

This final bounded follow-up slice for issue #199 tightens the local SSE operator UI without reopening broader client-state or transport questions.

It includes:

- stronger reconnect/backoff coverage for the bounded SSE UI slice
- SSE payload cleanup removing unused `status_label`
- minimal continuity-detail live expansion limited to header/meta `recovery_warning_count`

This slice preserves the existing posture:

- local-only
- read-only
- SSE-only
- no hidden durable mutations
- no WebSockets
- no remote auth changes
- no mutability
- no reactive detail/body rerendering

## What Changed

- tightened reconnect/backoff test coverage around bounded delay growth, max-delay capping, and visible reconnecting/offline state thresholds
- kept degraded/connected UI-state handling explicit in the plain local JS SSE client
- removed the unused `status_label` field from the SSE overview payload
- added one bounded detail live field for header/meta status only: `recovery_warning_count`

## Validation

- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`

## Residual Risk

Non-blocking: reconnect/backoff browser-runtime behavior is still only indirectly covered without a true JS event/timer execution harness.
