### PR TITLE
Prepare 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-15
+
+### Added
+
+- Shipped issue `#199`: an optional local-only read-only operator UI under
+  `/ui`, implemented as a server-rendered observability surface with local
+  assets only and no SPA/npm toolchain.
+- Added lifecycle visibility across active, fallback, archived, and cold
+  continuity artifacts on the overview, continuity list, and continuity detail
+  UI surfaces.
+- Added bounded server-rendered filtering and search on `/ui/continuity` by
+  query, subject kind, lifecycle artifact state, and health status.
+- Added bounded `/ui/events` SSE live updates with reconnect backoff for small
+  progressive live regions on the overview, continuity list, and continuity
+  detail pages.
+
 ### Updated
 
 - Aligned issue `#199` documentation, env guidance, changelog text, and

--- a/app/main.py
+++ b/app/main.py
@@ -262,7 +262,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.1.0", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.2.0", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))


### PR DESCRIPTION
## Summary

Prepare the `1.2.0` release after the merge of issue `#199`.

## What changed

- bump the app version from `1.1.0` to `1.2.0`
- cut the `1.2.0` changelog section dated `2026-04-15`
- summarize the shipped operator UI scope and the explicit deferred boundary

## 1.2.0 release scope

- optional local-only read-only `/ui`
- lifecycle visibility for active/fallback/archived/cold continuity artifacts
- bounded server-rendered filtering/search on `/ui/continuity`
- SSE live updates with reconnect backoff
- deployment/docs/config alignment for the local-only boundary

## Deferred items

- non-local auth/session model
- mutable UI behavior
- WebSockets
- standalone archive/cold consoles
- broader reactive UI behavior

## Verification

- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`
