### PR TITLE
chore: release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-04-16
+
+### Updated
+
+- Polished the shipped operator UI presentation with a locally vendored µCSS
+  Slate theme, dark mode as the default, a user theme selector, smaller shared
+  header/navigation sizing, a shared back-to-top control, and more responsive
+  detail-page layout behavior for dense continuity content.
+- Improved continuity detail rendering so dense summary/trust sections use a
+  flatter full-width layout, stable-preference tables can use the full detail
+  row width, and dedicated sections no longer duplicate the same
+  `trust_signals` or `stable_preferences` data already rendered elsewhere on
+  the page.
+- Fixed `/ui/continuity` filter handling so empty server-rendered select values
+  degrade to “all” instead of producing 422 responses, and repaired the filter
+  form layout so each filter field remains aligned as a single grid item.
+- Updated shared UI table rendering so operator tables use hover states and
+  scroll safely inside bounded panels instead of clipping wide structured
+  content.
+
 ## [1.2.0] - 2026-04-15
 
 ### Added

--- a/app/main.py
+++ b/app/main.py
@@ -262,7 +262,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.2.0", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.2.1", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -247,7 +247,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         )
         capsule = detail.get("capsule") or {}
         continuity = capsule.get("continuity") if isinstance(capsule.get("continuity"), dict) else {}
-        startup_summary = detail.get("startup_summary")
+        startup_summary = _startup_summary_for_ui(detail.get("startup_summary"))
         trust_signals = detail.get("trust_signals")
         related_rows = _related_artifact_rows(
             repo_root=settings.repo_root,
@@ -993,7 +993,7 @@ def _html_table(*, headers: list[str], rows: list[list[str]], empty_message: str
         return f'<p class="muted">{html.escape(empty_message)}</p>'
     head = "".join(f"<th>{html.escape(label)}</th>" for label in headers)
     body_rows = "".join("<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>" for row in rows)
-    return f'<div class="table-wrap"><table><thead><tr>{head}</tr></thead><tbody>{body_rows}</tbody></table></div>'
+    return f'<div class="table-wrap"><table class="table-hover"><thead><tr>{head}</tr></thead><tbody>{body_rows}</tbody></table></div>'
 
 
 def _subject_link(subject_kind: str, subject_id: str) -> str:
@@ -1124,6 +1124,18 @@ def _render_object(value: Any, *, empty_message: str) -> str:
     if value is None:
         return f'<p class="muted">{html.escape(empty_message)}</p>'
     return _render_value(value)
+
+
+def _startup_summary_for_ui(value: Any) -> Any:
+    """Trim startup-summary data to fields that are not already rendered elsewhere."""
+    if not isinstance(value, dict):
+        return value
+    filtered: dict[str, Any] = {}
+    if "recovery" in value:
+        filtered["recovery"] = value.get("recovery")
+    if "updated_at" in value:
+        filtered["updated_at"] = value.get("updated_at")
+    return filtered
 
 
 def _render_summary_document(value: Any, *, empty_message: str) -> str:

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -127,9 +127,9 @@ def build_ui_router(*, app_version: str) -> APIRouter:
     def ui_continuity(
         request: Request,
         q: str | None = Query(default=None),
-        subject_kind: Literal["user", "peer", "thread", "task"] | None = Query(default=None),
-        artifact_state: Literal["active", "fallback", "archived", "cold"] | None = Query(default=None),
-        health_status: Literal["healthy", "degraded", "conflicted"] | None = Query(default=None),
+        subject_kind: str | None = Query(default=None),
+        artifact_state: str | None = Query(default=None),
+        health_status: str | None = Query(default=None),
     ) -> HTMLResponse:
         """Render the continuity list view."""
         settings = get_settings()
@@ -137,6 +137,9 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         _gm = _ui_git_manager(settings)
         auth = _ui_auth(client_ip)
         now = datetime.now(timezone.utc)
+        subject_kind = _normalize_ui_filter(subject_kind, UI_SUBJECT_KINDS)
+        artifact_state = _normalize_ui_filter(artifact_state, UI_ARTIFACT_STATES)
+        health_status = _normalize_ui_filter(health_status, UI_HEALTH_STATUSES)
         all_rows = _ui_continuity_rows(
             repo_root=settings.repo_root,
             auth=auth,
@@ -337,16 +340,20 @@ def build_ui_router(*, app_version: str) -> APIRouter:
     async def ui_events(
         request: Request,
         q: str | None = Query(default=None),
-        subject_kind: Literal["user", "peer", "thread", "task"] | None = Query(default=None),
-        artifact_state: Literal["active", "fallback", "archived", "cold"] | None = Query(default=None),
-        health_status: Literal["healthy", "degraded", "conflicted"] | None = Query(default=None),
-        detail_subject_kind: Literal["user", "peer", "thread", "task"] | None = Query(default=None),
+        subject_kind: str | None = Query(default=None),
+        artifact_state: str | None = Query(default=None),
+        health_status: str | None = Query(default=None),
+        detail_subject_kind: str | None = Query(default=None),
         detail_subject_id: str | None = Query(default=None),
     ) -> StreamingResponse:
         """Stream bounded read-only UI snapshots for progressive enhancement."""
         settings = get_settings()
         client_ip = _enforce_ui_access(request, settings)
         auth = _ui_auth(client_ip)
+        subject_kind = _normalize_ui_filter(subject_kind, UI_SUBJECT_KINDS)
+        artifact_state = _normalize_ui_filter(artifact_state, UI_ARTIFACT_STATES)
+        health_status = _normalize_ui_filter(health_status, UI_HEALTH_STATUSES)
+        detail_subject_kind = _normalize_ui_filter(detail_subject_kind, UI_SUBJECT_KINDS)
 
         async def event_stream() -> Any:
             event_id = 0
@@ -451,6 +458,18 @@ def _page(*, title: str, current_path: str, content: str) -> HTMLResponse:
 def _nav_class(active: bool) -> str:
     """Return the nav link class for the current page."""
     return "nav-link active" if active else "nav-link"
+
+
+def _normalize_ui_filter(value: str | None, allowed: tuple[str, ...]) -> str | None:
+    """Normalize optional UI filters so empty or unsupported values degrade safely."""
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if normalized in allowed:
+        return normalized
+    return None
 
 
 def _bool_label(value: bool) -> str:

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -993,7 +993,7 @@ def _html_table(*, headers: list[str], rows: list[list[str]], empty_message: str
         return f'<p class="muted">{html.escape(empty_message)}</p>'
     head = "".join(f"<th>{html.escape(label)}</th>" for label in headers)
     body_rows = "".join("<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>" for row in rows)
-    return f"<table><thead><tr>{head}</tr></thead><tbody>{body_rows}</tbody></table>"
+    return f'<div class="table-wrap"><table><thead><tr>{head}</tr></thead><tbody>{body_rows}</tbody></table></div>'
 
 
 def _subject_link(subject_kind: str, subject_id: str) -> str:

--- a/app/ui/static/ui.css
+++ b/app/ui/static/ui.css
@@ -414,13 +414,13 @@ main.shell {
 
 .filter-form {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 0.9rem 1rem;
   align-items: end;
   margin-bottom: 1rem;
 }
 
-.filter-form label {
+.filter-field {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
@@ -428,8 +428,21 @@ main.shell {
   font-weight: 600;
 }
 
+.filter-field > span {
+  min-width: 0;
+}
+
 .filter-form button {
   align-self: end;
+}
+
+.filter-actions {
+  display: flex;
+  align-items: end;
+}
+
+.filter-actions button {
+  width: 100%;
 }
 
 .badge-row {

--- a/app/ui/static/ui.css
+++ b/app/ui/static/ui.css
@@ -31,12 +31,26 @@ samp {
 
 table {
   table-layout: auto;
+  width: max-content;
+  min-width: 100%;
 }
 
 th,
 td {
   overflow-wrap: break-word;
   word-break: normal;
+  vertical-align: top;
+}
+
+.table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+.table-wrap table {
+  margin-bottom: 0;
 }
 
 .shell {

--- a/app/ui/templates/continuity_detail.html
+++ b/app/ui/templates/continuity_detail.html
@@ -69,7 +69,7 @@
     ${stance_summary_html}
   </article>
 </section>
-<section class="grid detail-grid--medium">
+<section class="grid detail-grid--stacked">
   <article class="panel">
     <h2>Stable Preferences</h2>
     ${stable_preferences_html}

--- a/app/ui/templates/continuity_list.html
+++ b/app/ui/templates/continuity_list.html
@@ -1,24 +1,34 @@
 <section class="panel">
   <h2>Filters</h2>
   <form method="get" action="/ui/continuity" class="filter-form">
-    <label for="q">Search query</label>
-    <input id="q" name="q" type="text" value="${query_value}" placeholder="subject, path, state, status" />
-    <label for="subject_kind">Subject kind</label>
-    <select id="subject_kind" name="subject_kind">
-      <option value="">all</option>
-      ${filter_options}
-    </select>
-    <label for="artifact_state">Lifecycle state</label>
-    <select id="artifact_state" name="artifact_state">
-      <option value="">all</option>
-      ${artifact_options}
-    </select>
-    <label for="health_status">Health</label>
-    <select id="health_status" name="health_status">
-      <option value="">all</option>
-      ${health_options}
-    </select>
-    <button type="submit">Apply</button>
+    <label class="filter-field" for="q">
+      <span>Search query</span>
+      <input id="q" name="q" type="text" value="${query_value}" placeholder="subject, path, state, status" />
+    </label>
+    <label class="filter-field" for="subject_kind">
+      <span>Subject kind</span>
+      <select id="subject_kind" name="subject_kind">
+        <option value="">all</option>
+        ${filter_options}
+      </select>
+    </label>
+    <label class="filter-field" for="artifact_state">
+      <span>Lifecycle state</span>
+      <select id="artifact_state" name="artifact_state">
+        <option value="">all</option>
+        ${artifact_options}
+      </select>
+    </label>
+    <label class="filter-field" for="health_status">
+      <span>Health</span>
+      <select id="health_status" name="health_status">
+        <option value="">all</option>
+        ${health_options}
+      </select>
+    </label>
+    <div class="filter-actions">
+      <button type="submit">Apply</button>
+    </div>
   </form>
   <div class="badge-row summary-row">
     <span class="summary-chip">active ${active_count}</span>

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -595,8 +595,24 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertIn("Cold artifacts present", detail.text)
         self.assertIn("Open user archived list", detail.text)
         self.assertIn("Open user cold list", detail.text)
-        self.assertIn("memory/continuity/archive/user-stef-20260415T093000Z.json", detail.text)
-        self.assertIn("memory/continuity/cold/index/user-stef-20260415T093000Z.md", detail.text)
+
+    def test_ui_detail_page_startup_summary_omits_dedicated_section_duplicates(self) -> None:
+        """Startup summary should not duplicate dedicated trust/stable-preference sections."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="user", subject_id="stef")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            detail = client.get("/ui/continuity/user/stef")
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertIn("Startup Summary", detail.text)
+        self.assertNotIn("<h3>stable_preferences</h3>", detail.text)
+        self.assertNotIn("<h3>trust_signals</h3>", detail.text)
 
     def test_ui_events_stream_bounded_snapshot_for_current_scope(self) -> None:
         """The SSE endpoint should stream one deterministic bounded snapshot payload."""

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -434,6 +434,24 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertNotIn("fallback-user", archived_only.text)
         self.assertNotIn("cold-user", archived_only.text)
 
+    def test_ui_continuity_empty_filter_values_degrade_to_all_instead_of_422(self) -> None:
+        """Empty select values from the server-rendered filter form should behave like no filter."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="user", subject_id="stef")
+            client = self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+
+            response = client.get("/ui/continuity?subject_kind=user&artifact_state=&health_status=&q=")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('class="filter-field"', response.text)
+        self.assertIn("stef", response.text)
+        self.assertNotIn("Unprocessable Entity", response.text)
+
     def test_ui_continuity_filter_finds_archived_rows_beyond_mixed_display_limit(self) -> None:
         """Lifecycle filtering must stay correct even when the mixed view exceeds the display cap."""
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -358,6 +358,7 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(listing.status_code, 200)
         self.assertIn("Continuity Capsules", listing.text)
         self.assertIn("stef", listing.text)
+        self.assertIn('class="table-wrap"', listing.text)
         self.assertIn("/ui/continuity/user/stef", listing.text)
 
     def test_ui_overview_does_not_initialize_git_when_auto_init_enabled(self) -> None:


### PR DESCRIPTION
## Summary
- polish the shipped operator UI layout and detail rendering after 1.2.0
- fix `/ui/continuity` filter handling so empty select values degrade to all instead of returning 422
- add shared hoverable tables, safer table overflow handling, and remove duplicated startup-summary detail content
- bump the app version to `1.2.1` and document the patch release in the changelog

## Verification
- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`