### PR TITLE
[codex] Fix MCP body binding for HTTP initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-04-17
+
+### Fixed
+
+- MCP HTTP initialize requests now bind JSON-RPC payloads from the request body instead of rejecting standard clients with `422 Unprocessable Entity` due to a mistaken `payload` query parameter requirement.
+- Strengthened MCP regression coverage so the generated `/v1/mcp` HTTP contract requires a JSON request body and no longer advertises `payload` as a query parameter.
+
 ## [1.3.0] - 2026-04-16
 
 ### Added

--- a/app/main.py
+++ b/app/main.py
@@ -262,7 +262,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.3.0", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.3.1", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Annotated, Any, Callable, Literal
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request as FastAPIRequest, Response
+from fastapi import Body, Depends, FastAPI, Header, HTTPException, Query, Request as FastAPIRequest, Response
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
@@ -480,7 +480,7 @@ def _invoke_tool_by_name(name: str, arguments: dict[str, Any], auth: AuthContext
 
 @app.post("/v1/mcp")
 def mcp_rpc(
-    payload: Any,
+    payload: Any = Body(...),
     authorization: str | None = Header(default=None),
     x_forwarded_for: str | None = Header(default=None, alias="X-Forwarded-For"),
     x_real_ip: str | None = Header(default=None, alias="X-Real-IP"),

--- a/tests/test_mcp_rpc.py
+++ b/tests/test_mcp_rpc.py
@@ -3,7 +3,6 @@
 import json
 import tempfile
 import unittest
-from fastapi.routing import APIRoute
 from pathlib import Path
 from unittest.mock import patch
 
@@ -72,13 +71,15 @@ class TestMcpRpcCompatibility(unittest.TestCase):
         self.assertEqual(res["result"]["protocolVersion"], "2026-02-25")
         self.assertIn("tools", res["result"]["capabilities"])
 
-    def test_http_route_binds_payload_from_body(self) -> None:
-        """The HTTP MCP endpoint should register payload as a body param for FastAPI."""
-        route = next(
-            r for r in app.routes if isinstance(r, APIRoute) and r.path == "/v1/mcp" and "POST" in r.methods
-        )
-        self.assertEqual([p.name for p in route.dependant.body_params], ["payload"])
-        self.assertEqual([p.name for p in route.dependant.query_params], [])
+    def test_http_initialize_accepts_jsonrpc_body(self) -> None:
+        """The generated HTTP contract should require a JSON request body for MCP initialize."""
+        operation = app.openapi()["paths"]["/v1/mcp"]["post"]
+        self.assertIn("requestBody", operation)
+        self.assertTrue(operation["requestBody"]["required"])
+        self.assertIn("application/json", operation["requestBody"]["content"])
+        parameters = operation.get("parameters", [])
+        payload_query_params = [p for p in parameters if p.get("name") == "payload" and p.get("in") == "query"]
+        self.assertEqual(payload_query_params, [])
 
     def test_notifications_initialized_no_response_body(self) -> None:
         """Initialization notifications should return an empty 204 response."""

--- a/tests/test_mcp_rpc.py
+++ b/tests/test_mcp_rpc.py
@@ -3,6 +3,7 @@
 import json
 import tempfile
 import unittest
+from fastapi.routing import APIRoute
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,7 +11,7 @@ from starlette.responses import Response
 
 from app.auth import AuthContext
 from app.config import Settings
-from app.main import mcp_rpc, well_known_mcp
+from app.main import app, mcp_rpc, well_known_mcp
 from tests.helpers import SimpleGitManagerStub
 
 
@@ -70,6 +71,14 @@ class TestMcpRpcCompatibility(unittest.TestCase):
         self.assertEqual(res["id"], 99)
         self.assertEqual(res["result"]["protocolVersion"], "2026-02-25")
         self.assertIn("tools", res["result"]["capabilities"])
+
+    def test_http_route_binds_payload_from_body(self) -> None:
+        """The HTTP MCP endpoint should register payload as a body param for FastAPI."""
+        route = next(
+            r for r in app.routes if isinstance(r, APIRoute) and r.path == "/v1/mcp" and "POST" in r.methods
+        )
+        self.assertEqual([p.name for p in route.dependant.body_params], ["payload"])
+        self.assertEqual([p.name for p in route.dependant.query_params], [])
 
     def test_notifications_initialized_no_response_body(self) -> None:
         """Initialization notifications should return an empty 204 response."""


### PR DESCRIPTION
## Summary
Fix the `/v1/mcp` FastAPI route so MCP JSON-RPC payloads are read from the HTTP request body instead of being treated as a required query parameter.

## Why
`POST /v1/mcp` was rejecting standard MCP `initialize` requests with `422 Unprocessable Entity` before the MCP handler ran. The route declared `payload: Any` without explicit body binding, so FastAPI registered it as a query parameter.

Refs #211

## Changes
- add explicit `Body(...)` binding for the MCP `payload` parameter in `app.main.mcp_rpc`
- add a regression test that verifies the `/v1/mcp` POST route registers `payload` as a body param and not a query param

## Impact
Codex and other MCP clients that send JSON-RPC in the request body can complete the standard HTTP `initialize` handshake instead of failing during startup.

## Validation
- `./.venv/bin/python -m unittest tests.test_mcp_rpc -v`
- `./.venv/bin/python -m ruff check app/main.py tests/test_mcp_rpc.py`
