### PR TITLE
docs: define canonical hook contract for #215 slice 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,21 @@ For external experiments, third-party usage notes, and public case studies, see 
 
 Agents integrate with CogniRelay through hook points in their runtime loop. CogniRelay does not control when it is invoked — agents own invocation timing, and CogniRelay owns response quality once invoked.
 
-**Minimum viable integration** (two hook points):
+**Minimum viable integration** (two canonical hook points):
 
-- `startup`: read continuity capsule and retrieve context to restore orientation after a reset
-- `pre-compaction / handoff`: upsert continuity capsule to preserve current orientation before the context window compacts or the agent hands off
+- `startup`: call `POST /v1/continuity/read` / `continuity.read` with `view: "startup"` and `allow_fallback: true` to restore orientation after a reset
+- `pre_compaction_or_handoff`: evaluate write eligibility and call `POST /v1/continuity/upsert` / `continuity.upsert` only when the closed persisted-orientation field set changed, before known context loss or a real inter-agent handoff
 
 This is enough for basic orientation recovery across resets.
 
-**Recommended fuller integration** (four hook points):
+**Recommended fuller integration** (four canonical hook points):
 
 - `startup`: restore orientation (same as above)
-- `pre-prompt`: retrieve fresh context and check for pending messages, coordination artifacts, or task updates
-- `post-prompt`: persist any orientation changes, new decisions, or negative decisions after the agent acts
-- `pre-compaction / handoff`: ensure the latest orientation is durable before context loss
+- `pre_prompt`: read-only retrieval hook bound to `POST /v1/context/retrieve` / `context.retrieve`
+- `post_prompt`: persist orientation changes with `POST /v1/continuity/upsert` / `continuity.upsert` only when at least one meaning-bearing field changed
+- `pre_compaction_or_handoff`: satisfy the local continuity step before compaction or a real inter-agent handoff; only after that step completes may a real handoff additionally call `POST /v1/coordination/handoff/create` / `coordination.handoff_create`
 
-The fuller pattern gives tighter continuity — the agent's orientation stays current within the session, not just across resets.
+The fuller pattern gives tighter continuity without widening the write surface: `startup` and `pre_prompt` stay read-only by default, `post_prompt` skips writes when nothing meaning-bearing changed, and `pre_compaction_or_handoff` remains the primary write-before-context-loss hook. For the authoritative contract, including anti-noise rules and deterministic examples, see [Agent Onboarding](docs/agent-onboarding.md#canonical-hook-contract).
 
 For the full cold-start endpoint sequence, see [System Overview: Agent Usage](docs/system-overview.md#agent-usage).
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ This is enough for basic orientation recovery across resets.
 
 - `startup`: restore orientation (same as above)
 - `pre_prompt`: read-only retrieval hook bound to `POST /v1/context/retrieve` / `context.retrieve`
-- `post_prompt`: persist orientation changes with `POST /v1/continuity/upsert` / `continuity.upsert` only when at least one meaning-bearing field changed
+- `post_prompt`: persist orientation changes with `POST /v1/continuity/upsert` / `continuity.upsert` only when at least one closed persisted-orientation field changed
 - `pre_compaction_or_handoff`: satisfy the local continuity step before compaction or a real inter-agent handoff; only after that step completes may a real handoff additionally call `POST /v1/coordination/handoff/create` / `coordination.handoff_create`
 
-The fuller pattern gives tighter continuity without widening the write surface: `startup` and `pre_prompt` stay read-only by default, `post_prompt` skips writes when nothing meaning-bearing changed, and `pre_compaction_or_handoff` remains the primary write-before-context-loss hook. For the authoritative contract, including anti-noise rules and deterministic examples, see [Agent Onboarding](docs/agent-onboarding.md#canonical-hook-contract).
+The fuller pattern gives tighter continuity without widening the write surface: `startup` and `pre_prompt` stay read-only by default, `post_prompt` skips writes when the closed persisted-orientation field set is unchanged, and `pre_compaction_or_handoff` remains the primary write-before-context-loss hook. For the authoritative contract, including anti-noise rules and deterministic examples, see [Agent Onboarding](docs/agent-onboarding.md#canonical-hook-contract).
 
 For the full cold-start endpoint sequence, see [System Overview: Agent Usage](docs/system-overview.md#agent-usage).
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -19,42 +19,50 @@ CogniRelay does not make decisions for you. It does not silently rewrite your st
 
 ## Integration Levels
 
-### Minimum viable: two hook points
+### Minimum viable: two canonical hook points
 
 If you are adding CogniRelay to an existing agent loop and want the smallest useful integration, use two hook points:
 
-**On startup (or after any context reset):**
+**At `startup` (or after any context reset):**
 
-1. `POST /v1/continuity/read` with your selector — returns your last persisted orientation capsule. Pass `view="startup"` to include a pre-structured `startup_summary` with recovery, orientation, and context tiers alongside the full capsule (see [Payload Reference: Startup view](payload-reference.md#startup-view-viewstartup))
-2. `POST /v1/context/retrieve` for your active task — returns a continuity-shaped context bundle including relevant memory, recent items, and any loaded capsule state
+1. `POST /v1/continuity/read` with your selector, `view="startup"`, and `allow_fallback=true` — returns your last persisted orientation capsule plus the startup-oriented `startup_summary` view (see [Payload Reference: Startup view](payload-reference.md#startup-view-viewstartup))
+2. Forward that `continuity.read` result unchanged into your runtime. Do not translate or rewrite the read result under the canonical `startup` contract.
+3. Optionally call `POST /v1/context/retrieve` for your active task after the startup read if you need fresh bounded working context for the first work step
 
 Use the returned capsule to restore your constraints, drift signals, open loops, and stance before you begin working.
 
 Continuity schema note: newly written continuity capsules now use schema `1.1`. Stabilized legacy `1.0` continuity payloads are still supported when they already have the modern required capsule structure and only need structured-entry timestamp upgrade or top-level timestamp repair. Sammy's oldest real continuity capsule sample falls into that supported bucket. Truly pre-stabilization payloads missing required modern capsule fields are not auto-migrated.
 
-**Before compaction or handoff (when you are about to lose context):**
+**At `pre_compaction_or_handoff` (when you are about to lose context):**
 
-1. `POST /v1/continuity/upsert` with your current orientation — persists your active constraints, drift signals, open loops, stance summary, and any negative decisions you want to survive the reset
+1. Compare your candidate orientation state to the last persisted capsule for the same subject, including fallback-only state when that is the most recent persisted capsule.
+2. Call `POST /v1/continuity/upsert` only when at least one field in the canonical closed persisted-orientation field list changed.
+3. If nothing changed, satisfy the hook with an explicit skip. Do not invent a write because compaction or handoff is happening.
 
-You can include an optional `session_end_snapshot` in the upsert request to focus on the six startup-critical fields without rebuilding the entire capsule. Send your base capsule (from the last read — stale continuity fields are fine, but `updated_at` must still be set to the current time) and a snapshot containing fresh values for `open_loops`, `top_priorities`, `active_constraints`, `stance_summary`, and optionally `negative_decisions` and `session_trajectory`. The server merges the snapshot into the capsule before persisting. See [Payload Reference](payload-reference.md#session-end-snapshot-helper) for details.
+You can include an optional `session_end_snapshot` only when you are refreshing only the snapshot field set: required P0 fields `open_loops`, `top_priorities`, `active_constraints`, `stance_summary`, plus optional P1 fields `negative_decisions`, `session_trajectory`, and `rationale_entries`. Send the base capsule plus the snapshot, and the server merges those fields before persisting. If any write-eligible field outside that set changed, omit `session_end_snapshot` and send a full capsule upsert instead. See [Payload Reference](payload-reference.md#session-end-snapshot-helper) for details.
 
 This is enough for basic orientation recovery. Your next startup will retrieve what you persisted here.
 
-### Recommended fuller integration: four hook points
+### Recommended fuller integration: four canonical hook points
 
 For tighter continuity within a session, add two more hook points:
 
-**Before each prompt (pre-prompt):**
+**At `pre_prompt`:**
 
 1. `POST /v1/context/retrieve` — refresh your context with the latest indexed material
-2. `GET /v1/messages/pending` — check for messages, delivery state, or coordination artifacts
-3. `GET /v1/tasks/query` — check for task updates if you are coordinating shared work
+2. Optionally `GET /v1/messages/pending` — check for messages or coordination artifacts if your runtime uses messaging
+3. Optionally `GET /v1/tasks/query` — check for task updates if you are coordinating shared work
+4. Do not write continuity here under the canonical default contract
+5. Do not persist prompt text, retrieved snippets, or transcript material here
 
-**After each prompt (post-prompt):**
+**At `post_prompt`:**
 
-1. `POST /v1/continuity/upsert` — persist any orientation changes, new constraints, or negative decisions from the work you just did
+1. Compare the candidate orientation state to the last persisted capsule for the same subject
+2. `POST /v1/continuity/upsert` only when at least one field in the canonical closed persisted-orientation field list changed
+3. Skip the write when none of those fields changed
+4. Never persist raw prompt text, response text, or chat transcript here
 
-With the fuller pattern, your orientation stays current within the session — not just across resets. If you crash mid-session, your last post-prompt upsert is recoverable.
+With the fuller pattern, your orientation stays current within the session — not just across resets. If you crash mid-session, your last `post_prompt` upsert is recoverable.
 
 ### Full cold-start sequence
 
@@ -68,13 +76,340 @@ If your agent is already running and you want to integrate CogniRelay incrementa
 
 1. **Start with the two-hook minimum.** Add continuity upsert before your next compaction and continuity read on your next startup. This gives you orientation recovery with no changes to your prompt-level loop.
 
-2. **Add pre-prompt and post-prompt hooks when ready.** These tighten within-session continuity but are not required for basic operation.
+2. **Add `pre_prompt` and `post_prompt` hooks when ready.** These tighten within-session continuity but are not required for basic operation.
 
 3. **Add coordination when you need it.** Handoffs, shared artifacts, and reconciliation records are useful when you need to coordinate with external collaborator peers. As the owner-agent, you issue delegated tokens to those peers and they interact through these coordination surfaces. You can ignore coordination until you have a multi-agent use case.
 
 4. **Use MCP if your runtime speaks JSON-RPC.** The same capabilities are available through `POST /v1/mcp` as through the HTTP endpoints. See [MCP Guide](mcp.md) for the bootstrap flow.
 
 5. **Use the CLI client for shell-based hooks.** If your agent runtime invokes hooks as shell commands, `tools/cognirelay_client.py` can read and upsert capsules without a third-party HTTP library. See [CLI Client](cognirelay-client.md) for usage.
+
+## Canonical Hook Contract
+
+Runtime-specific hook names may differ, but each runtime hook must map 1:1 to exactly one canonical identifier:
+
+- `startup`
+- `pre_prompt`
+- `post_prompt`
+- `pre_compaction_or_handoff`
+
+This section is normative for slice 1 of `#215`.
+
+### Exact operation mapping
+
+| Canonical hook | HTTP operation | MCP tool | Write allowed | Default action |
+|---|---|---|---|---|
+| `startup` | `POST /v1/continuity/read` | `continuity.read` | no | read only |
+| `pre_prompt` | `POST /v1/context/retrieve` | `context.retrieve` | no | read only |
+| `post_prompt` | `POST /v1/continuity/upsert` | `continuity.upsert` | yes | write only when eligible |
+| `pre_compaction_or_handoff` | `POST /v1/continuity/upsert` | `continuity.upsert` | yes | write only when eligible |
+
+Additional real-handoff-only operation:
+
+- After `pre_compaction_or_handoff` satisfies the local continuity step, a real inter-agent handoff may additionally call HTTP `POST /v1/coordination/handoff/create` or MCP `coordination.handoff_create`.
+
+### Closed write eligibility and skip rules
+
+Only these persisted-orientation fields are allowed to make `post_prompt` or `pre_compaction_or_handoff` eligible for a continuity write:
+
+- `top_priorities`
+- `open_loops`
+- `active_constraints`
+- `active_concerns`
+- `drift_signals`
+- `stance_summary`
+- `negative_decisions`
+- `session_trajectory`
+- `rationale_entries`
+- `stable_preferences`
+- `thread_descriptor.lifecycle`
+- `thread_descriptor.superseded_by`
+
+Write-decision anchor:
+
+- Compare against the most recent persisted continuity capsule for the subject, even when that capsule is only reachable through fallback.
+
+First-write baseline:
+
+- Use the first-write baseline only when no persisted capsule exists at all for the subject.
+- Compare against `[]` for list fields, `""` for `stance_summary`, and `null` for `thread_descriptor.lifecycle` and `thread_descriptor.superseded_by`.
+
+Exact change-comparison semantics:
+
+- Comparison is direct field-by-field equality with no normalization.
+- Array order is significant; reorder-only changes count as changes.
+- Arrays must not be sorted or deduplicated before comparison.
+- Strings must not be trimmed or normalized before comparison.
+- `null`, omitted, `[]`, and `""` stay distinct except for the explicit first-write baseline above.
+
+Skip rules:
+
+- `startup` skips writes by default.
+- `pre_prompt` skips writes by default.
+- `post_prompt` skips writes when none of the closed persisted-orientation fields changed.
+- `pre_compaction_or_handoff` is the primary write-before-context-loss hook, but it still skips when none of the closed persisted-orientation fields changed.
+
+### Startup and fallback rules
+
+- Canonical `startup` must call `continuity.read` with `view: "startup"` and `allow_fallback: true`.
+- No other `view` value and no omitted `view` is allowed for canonical `startup`.
+- The runtime must forward the normal `continuity.read` result unchanged.
+- Missing active continuity during `startup` must degrade to the contract-defined fallback or missing result, not to a synthetic HTTP error.
+
+### Session-end snapshot rules
+
+- `session_end_snapshot` is for `pre_compaction_or_handoff`, not for `startup` or `pre_prompt`.
+- Use it only when you are refreshing only the snapshot field set:
+  - P0 required: `open_loops`, `top_priorities`, `active_constraints`, `stance_summary`
+  - P1 optional: `negative_decisions`, `session_trajectory`, `rationale_entries`
+- If any write-eligible field outside that set changed, omit `session_end_snapshot` and send a full `capsule`-only upsert.
+- Snapshot mode requires both `capsule` and `session_end_snapshot`.
+
+### Real inter-agent handoff definition and ordering
+
+For this contract, a real inter-agent handoff means task control transfers to a different agent identity that is expected to continue execution after the current agent stops.
+
+These are not real inter-agent handoffs:
+
+- local compaction
+- same-agent resume or re-entry
+- tool calls
+- internal helper or subtask execution without continuity-ownership transfer
+
+Required ordering:
+
+1. Evaluate local write eligibility first.
+2. Satisfy the local continuity step as either an eligible `continuity.upsert` write or an explicit skip.
+3. Only then may a real handoff call `coordination.handoff_create`.
+
+Parallel execution of `continuity.upsert` and `coordination.handoff_create` is not allowed.
+
+### Anti-noise rules
+
+- Do not persist raw prompt text, response text, retrieved snippets, shell output, or transcript material in continuity.
+- Do not write merely because a prompt completed, a tool ran, a summary was generated, the runtime reached a stop hook, a compaction boundary occurred, or a handoff boundary occurred.
+- Do not use `post_prompt` or `pre_compaction_or_handoff` as interaction-log, transcript-archive, or prompt/response-summary sinks.
+
+## Deterministic Examples
+
+### Example A: `startup`
+
+Trigger condition:
+
+- The agent is starting, resuming after a context reset, or re-entering after losing local working context.
+
+Exact operation:
+
+- HTTP: `POST /v1/continuity/read`
+- MCP: `continuity.read`
+
+Minimal request payload:
+
+```json
+{
+  "subject_kind": "thread",
+  "subject_id": "issue-215",
+  "view": "startup",
+  "allow_fallback": true
+}
+```
+
+Expected decision:
+
+- Skip writes. `startup` is read-only by default.
+
+Persisted fields if a write occurs:
+
+- None. A canonical `startup` call does not perform a continuity write.
+
+Explicit non-example:
+
+- Do not call `continuity.upsert` at `startup` merely to mark that the agent resumed.
+
+### Example B: `pre_prompt`
+
+Trigger condition:
+
+- The agent is about to start a major work step and needs fresh bounded working context.
+
+Exact operation:
+
+- HTTP: `POST /v1/context/retrieve`
+- MCP: `context.retrieve`
+
+Minimal request payload:
+
+```json
+{
+  "task_id": "issue-215-slice-1",
+  "query": "canonical hook contract for issue 215",
+  "max_tokens_estimate": 2500
+}
+```
+
+Expected decision:
+
+- Skip writes. `pre_prompt` is read-only by default.
+
+Persisted fields if a write occurs:
+
+- None. A canonical `pre_prompt` call does not perform a continuity write.
+
+Explicit non-example:
+
+- Do not persist the prompt body or retrieved snippets because `pre_prompt` fired.
+
+### Example C: `post_prompt`
+
+Trigger condition:
+
+- The agent completed a work step and updated durable orientation state in a meaning-bearing way.
+
+Exact operation:
+
+- HTTP: `POST /v1/continuity/upsert`
+- MCP: `continuity.upsert`
+
+Minimal request payload:
+
+```json
+{
+  "subject_kind": "thread",
+  "subject_id": "issue-215",
+  "capsule": {
+    "schema_version": "1.1",
+    "subject_kind": "thread",
+    "subject_id": "issue-215",
+    "updated_at": "2026-04-21T12:00:00Z",
+    "verified_at": "2026-04-21T12:00:00Z",
+    "source": {
+      "producer": "agent-runtime",
+      "update_reason": "interaction_boundary",
+      "inputs": []
+    },
+    "continuity": {
+      "top_priorities": ["publish the canonical hook contract docs"],
+      "active_concerns": ["keep slice 1 documentation-only"],
+      "active_constraints": ["follow issue #215 exactly"],
+      "open_loops": ["verify the examples match HTTP and MCP names"],
+      "stance_summary": "The hook contract is now documented as a closed, deterministic mapping.",
+      "drift_signals": [],
+      "negative_decisions": [
+        {
+          "decision": "Do not add runtime help surfaces",
+          "rationale": "Issue #214 is out of scope for slice 1."
+        }
+      ],
+      "session_trajectory": ["spec_hardened", "docs_updated"],
+      "rationale_entries": [],
+      "stable_preferences": []
+    },
+    "confidence": {
+      "continuity": 0.92,
+      "relationship_model": 0.0
+    }
+  }
+}
+```
+
+Expected decision:
+
+- Write only if at least one closed persisted-orientation field changed compared with the last persisted capsule.
+- Skip if the candidate values are exactly equal to the last persisted values.
+
+Persisted fields if a write occurs:
+
+- `top_priorities`
+- `open_loops`
+- `active_constraints`
+- `active_concerns`
+- `drift_signals`
+- `stance_summary`
+- `negative_decisions`
+- `session_trajectory`
+- `rationale_entries`
+
+Explicit non-example:
+
+- Do not persist a prompt/response summary such as `"Discussed the docs update and produced a final answer."`
+
+### Example D: `pre_compaction_or_handoff`
+
+Trigger condition:
+
+- The runtime is about to compact local context, lose local working state, or transfer control to a different agent identity that will continue the task.
+
+Exact operation:
+
+- HTTP: `POST /v1/continuity/upsert`
+- MCP: `continuity.upsert`
+- Optional additional real-handoff-only HTTP call after the local continuity step completes: `POST /v1/coordination/handoff/create`
+- Optional additional real-handoff-only MCP call after the local continuity step completes: `coordination.handoff_create`
+
+Minimal request payload:
+
+```json
+{
+  "subject_kind": "thread",
+  "subject_id": "issue-215",
+  "capsule": {
+    "schema_version": "1.1",
+    "subject_kind": "thread",
+    "subject_id": "issue-215",
+    "updated_at": "2026-04-21T12:30:00Z",
+    "verified_at": "2026-04-21T12:30:00Z",
+    "source": {
+      "producer": "agent-runtime",
+      "update_reason": "pre_compaction",
+      "inputs": []
+    },
+    "continuity": {
+      "top_priorities": ["land deterministic wording for issue #215"],
+      "active_concerns": ["do not broaden scope into #214"],
+      "active_constraints": ["documentation slice only"],
+      "open_loops": ["confirm the hook examples match the issue body"],
+      "stance_summary": "The canonical hook contract is documented and ready for review.",
+      "drift_signals": [],
+      "negative_decisions": [],
+      "session_trajectory": ["docs_ready_for_review"],
+      "rationale_entries": []
+    },
+    "confidence": {
+      "continuity": 0.9,
+      "relationship_model": 0.0
+    }
+  },
+  "session_end_snapshot": {
+    "open_loops": ["confirm the hook examples match the issue body"],
+    "top_priorities": ["land deterministic wording for issue #215"],
+    "active_constraints": ["documentation slice only"],
+    "stance_summary": "The canonical hook contract is documented and ready for review.",
+    "negative_decisions": [],
+    "session_trajectory": ["docs_ready_for_review"],
+    "rationale_entries": []
+  }
+}
+```
+
+Expected decision:
+
+- Write if one or more snapshot fields changed and no write-eligible field outside the snapshot field set changed.
+- Skip the local continuity write if no write-eligible field changed.
+- For a real inter-agent handoff, `coordination.handoff_create` may run only after the local continuity step completed as either a write or an explicit skip.
+
+Persisted fields if a write occurs:
+
+- `open_loops`
+- `top_priorities`
+- `active_constraints`
+- `stance_summary`
+- `negative_decisions`
+- `session_trajectory`
+- `rationale_entries`
+
+Explicit non-example:
+
+- Do not treat same-agent resume, local compaction alone, or an internal helper subtask as a real inter-agent handoff.
 
 ## The Responsibility Boundary
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -217,6 +217,9 @@ Minimal request payload:
 Expected decision:
 
 - Skip writes. `startup` is read-only by default.
+- Forward the `continuity.read` result unchanged into the runtime.
+- If no active capsule exists, degrade to the normal fallback or missing result defined by the `continuity.read` contract.
+- Do not synthesize an HTTP error just because the active capsule is missing.
 
 Persisted fields if a write occurs:
 
@@ -226,11 +229,15 @@ Explicit non-example:
 
 - Do not call `continuity.upsert` at `startup` merely to mark that the agent resumed.
 
-### Example B: `pre_prompt`
+### Example B: `pre_prompt` bounded context retrieval
+
+Hook identifier:
+
+- `pre_prompt`
 
 Trigger condition:
 
-- The agent is about to start a major work step and needs fresh bounded working context.
+- The agent is about to start a major work step and needs bounded retrieval.
 
 Exact operation:
 
@@ -241,29 +248,34 @@ Minimal request payload:
 
 ```json
 {
-  "task_id": "issue-215-slice-1",
-  "query": "canonical hook contract for issue 215",
-  "max_tokens_estimate": 2500
+  "task": "Address determinism findings on issue #215 only.",
+  "subject_kind": "thread",
+  "subject_id": "issue-215",
+  "continuity_mode": "required"
 }
 ```
 
 Expected decision:
 
-- Skip writes. `pre_prompt` is read-only by default.
+- Skip write.
 
-Persisted fields if a write occurs:
+Exact persisted fields:
 
-- None. A canonical `pre_prompt` call does not perform a continuity write.
+- none
 
 Explicit non-example:
 
-- Do not persist the prompt body or retrieved snippets because `pre_prompt` fired.
+- Do **not** persist the task text `"Address determinism findings on issue #215 only."` or any retrieved snippet summary during `pre_prompt`.
 
-### Example C: `post_prompt`
+### Example C: `post_prompt` first eligible write
+
+Hook identifier:
+
+- `post_prompt`
 
 Trigger condition:
 
-- The agent completed a work step and updated durable orientation state in a meaning-bearing way.
+- No persisted capsule exists at all for the subject, and the completed work step produced a meaningful persisted-orientation value that differs from the first-write baseline in this issue.
 
 Exact operation:
 
@@ -288,25 +300,26 @@ Minimal request payload:
       "inputs": []
     },
     "continuity": {
-      "top_priorities": ["publish the canonical hook contract docs"],
-      "active_concerns": ["keep slice 1 documentation-only"],
-      "active_constraints": ["follow issue #215 exactly"],
-      "open_loops": ["verify the examples match HTTP and MCP names"],
-      "stance_summary": "The hook contract is now documented as a closed, deterministic mapping.",
+      "top_priorities": ["land deterministic wording for issue #215"],
+      "active_concerns": ["do not broaden scope into #214/#216/#217"],
+      "active_constraints": ["edit the issue body in place"],
+      "open_loops": ["replace ambiguous examples with normative examples"],
+      "stance_summary": "Issue #215 is being narrowed into a closed hook contract spec.",
       "drift_signals": [],
-      "negative_decisions": [
-        {
-          "decision": "Do not add runtime help surfaces",
-          "rationale": "Issue #214 is out of scope for slice 1."
-        }
-      ],
-      "session_trajectory": ["spec_hardened", "docs_updated"],
-      "rationale_entries": [],
-      "stable_preferences": []
+      "session_trajectory": ["moved from loose guidance to closed write rules"],
+      "negative_decisions": [],
+      "rationale_entries": []
     },
     "confidence": {
-      "continuity": 0.92,
+      "continuity": 0.9,
       "relationship_model": 0.0
+    },
+    "thread_descriptor": {
+      "label": "Issue 215",
+      "keywords": ["determinism"],
+      "scope_anchors": ["CogniRelay"],
+      "identity_anchors": [],
+      "lifecycle": "active"
     }
   }
 }
@@ -314,39 +327,45 @@ Minimal request payload:
 
 Expected decision:
 
-- Write only if at least one closed persisted-orientation field changed compared with the last persisted capsule.
-- Skip if the candidate values are exactly equal to the last persisted values.
+- Write.
 
-Persisted fields if a write occurs:
+Exact persisted fields:
 
 - `top_priorities`
 - `open_loops`
 - `active_constraints`
 - `active_concerns`
-- `drift_signals`
 - `stance_summary`
-- `negative_decisions`
 - `session_trajectory`
-- `rationale_entries`
+- `thread_descriptor.lifecycle`
+
+Why this writes:
+
+- There is no persisted capsule at all for the subject, so comparison uses the first-write baseline in this issue.
+- At least one field in the closed persisted-orientation field list differs from that baseline.
 
 Explicit non-example:
 
-- Do not persist a prompt/response summary such as `"Discussed the docs update and produced a final answer."`
+- Do **not** add a field or note containing a summarized exchange such as `"We discussed six ambiguities and then used gh to patch the issue body."`
 
-### Example D: `pre_compaction_or_handoff`
+### Example D: `pre_compaction_or_handoff` ordering and snapshot closure
+
+Hook identifier:
+
+- `pre_compaction_or_handoff`
 
 Trigger condition:
 
-- The runtime is about to compact local context, lose local working state, or transfer control to a different agent identity that will continue the task.
+- The runtime is about to compact local context or transfer control to a different agent identity that is expected to continue execution after the current agent stops.
 
 Exact operation:
 
 - HTTP: `POST /v1/continuity/upsert`
 - MCP: `continuity.upsert`
-- Optional additional real-handoff-only HTTP call after the local continuity step completes: `POST /v1/coordination/handoff/create`
-- Optional additional real-handoff-only MCP call after the local continuity step completes: `coordination.handoff_create`
+- Optional additional HTTP call for a real inter-agent handoff after the local continuity step completes: `POST /v1/coordination/handoff/create`
+- Optional additional MCP call for a real inter-agent handoff after the local continuity step completes: `coordination.handoff_create`
 
-Minimal request payload:
+Minimal request payload for the snapshot-eligible branch:
 
 ```json
 {
@@ -365,27 +384,34 @@ Minimal request payload:
     },
     "continuity": {
       "top_priorities": ["land deterministic wording for issue #215"],
-      "active_concerns": ["do not broaden scope into #214"],
-      "active_constraints": ["documentation slice only"],
-      "open_loops": ["confirm the hook examples match the issue body"],
-      "stance_summary": "The canonical hook contract is documented and ready for review.",
+      "active_concerns": ["do not broaden scope into #214/#216/#217"],
+      "active_constraints": ["edit the issue body in place"],
+      "open_loops": ["confirm the issue text now binds all four hooks"],
+      "stance_summary": "Issue #215 now defines closed hook behavior before compaction or handoff.",
       "drift_signals": [],
+      "session_trajectory": [],
       "negative_decisions": [],
-      "session_trajectory": ["docs_ready_for_review"],
       "rationale_entries": []
     },
     "confidence": {
       "continuity": 0.9,
       "relationship_model": 0.0
+    },
+    "thread_descriptor": {
+      "label": "Issue 215",
+      "keywords": ["determinism"],
+      "scope_anchors": ["CogniRelay"],
+      "identity_anchors": [],
+      "lifecycle": "active"
     }
   },
   "session_end_snapshot": {
-    "open_loops": ["confirm the hook examples match the issue body"],
+    "open_loops": ["confirm the issue text now binds all four hooks"],
     "top_priorities": ["land deterministic wording for issue #215"],
-    "active_constraints": ["documentation slice only"],
-    "stance_summary": "The canonical hook contract is documented and ready for review.",
+    "active_constraints": ["edit the issue body in place"],
+    "stance_summary": "Issue #215 now defines closed hook behavior before compaction or handoff.",
     "negative_decisions": [],
-    "session_trajectory": ["docs_ready_for_review"],
+    "session_trajectory": [],
     "rationale_entries": []
   }
 }
@@ -394,10 +420,12 @@ Minimal request payload:
 Expected decision:
 
 - Write if one or more snapshot fields changed and no write-eligible field outside the snapshot field set changed.
+- A reorder-only change to any array-valued persisted field counts as a change.
+- Exact comparison uses direct field-by-field equality with no normalization.
 - Skip the local continuity write if no write-eligible field changed.
-- For a real inter-agent handoff, `coordination.handoff_create` may run only after the local continuity step completed as either a write or an explicit skip.
+- For a real inter-agent handoff, `coordination.handoff_create` may run only after the local continuity step completes, whether that step completed as a write or as an explicit skip.
 
-Persisted fields if a write occurs:
+Exact persisted fields for the snapshot-eligible branch:
 
 - `open_loops`
 - `top_priorities`
@@ -407,9 +435,18 @@ Persisted fields if a write occurs:
 - `session_trajectory`
 - `rationale_entries`
 
+Boundary rules illustrated:
+
+- This uses snapshot mode because the request sends both `capsule` and `session_end_snapshot`.
+- `coordination.handoff_create` is in scope only when control transfers to a different agent identity that is expected to continue execution after the current agent stops.
+- Snapshot mode is allowed only when no write-eligible field outside the `session_end_snapshot` field set differs from the last persisted capsule.
+- If `active_concerns`, `drift_signals`, `stable_preferences`, `thread_descriptor.lifecycle`, or `thread_descriptor.superseded_by` changed, the request must omit `session_end_snapshot` and perform a full `continuity.upsert` using `capsule` only.
+- A handoff boundary alone never authorizes inventing a continuity write.
+- Parallel execution of `continuity.upsert` and `coordination.handoff_create` is not allowed.
+
 Explicit non-example:
 
-- Do not treat same-agent resume, local compaction alone, or an internal helper subtask as a real inter-agent handoff.
+- Do **not** persist a compaction note such as `"Summarized the previous 40 messages before handoff"` into continuity.
 
 ## The Responsibility Boundary
 

--- a/docs/cognirelay-client.md
+++ b/docs/cognirelay-client.md
@@ -53,16 +53,15 @@ python tools/cognirelay_client.py read \
   --base-url http://localhost:8080 \
   --token-file /run/secrets/agent_token \
   --subject-kind user \
-  --subject-id agent-1 \
-  --format startup
+  --subject-id agent-1
 ```
 
-`--subject-kind` accepts: `user`, `peer`, `thread`, `task`. This calls `POST /v1/continuity/read` with `allow_fallback: true` and prints the response.
+`--subject-kind` accepts: `user`, `peer`, `thread`, `task`. This calls `POST /v1/continuity/read` with `allow_fallback: true` and prints either the raw JSON response or a client-side text rendering.
 
 ### Output formats
 
-- `--format json` (default): pretty-printed JSON response body. Does not send `view` in the request — returns the full server response unchanged.
-- `--format startup`: sends `view="startup"` to the server and renders the `startup_summary` block as compact section-based text. If the server predates `view="startup"` (response lacks `startup_summary`), the client falls back to a legacy renderer that extracts fields from `capsule.continuity` directly.
+- `--format json` (default): pretty-printed JSON response body. Does not send `view` in the request and preserves the server response body unchanged.
+- `--format startup`: sends `view="startup"` to the server and renders the `startup_summary` block as compact section-based text. This is a CLI presentation convenience layered on top of the canonical `continuity.read` response, not a different hook contract. If the server predates `view="startup"` (response lacks `startup_summary`), the client falls back to a legacy renderer that extracts fields from `capsule.continuity` directly.
 
 The client tolerates both continuity schema `1.0` and `1.1` payloads on read surfaces. For issue #194, newly written continuity capsules and continuity archive/fallback/cold artifacts move to schema `1.1`; stabilized-shape legacy `1.0` continuity payloads remain readable and upgrade safely where supported. Truly pre-stabilization payloads missing required modern continuity fields are still outside the automatic migration boundary.
 
@@ -230,13 +229,26 @@ Use this to generate token hashes for `peer_tokens.json` and other config files.
 
 **Canonical `startup` hook** — restore orientation after a context reset:
 
+Send `POST /v1/continuity/read` with `view: "startup"` and `allow_fallback: true`, then forward the response unchanged into the runtime.
+
+Canonical request shape:
+
+```json
+{
+  "subject_kind": "user",
+  "subject_id": "$AGENT_ID",
+  "view": "startup",
+  "allow_fallback": true
+}
+```
+
+If you need an operator-facing local rendering instead of unchanged forwarding, use the CLI convenience mode:
+
 ```bash
 python tools/cognirelay_client.py read \
   --subject-kind user --subject-id "$AGENT_ID" \
   --format startup
 ```
-
-This client read path sends `allow_fallback: true`. Under the canonical `startup` contract, pair it with `--format startup` so the request uses `view: "startup"` and the runtime forwards the response unchanged.
 
 **Canonical `pre_compaction_or_handoff` hook** — persist orientation before context loss:
 

--- a/docs/cognirelay-client.md
+++ b/docs/cognirelay-client.md
@@ -133,13 +133,13 @@ python tools/cognirelay_client.py upsert \
 
 The JSON file is the complete `POST /v1/continuity/upsert` request body (must include `subject_kind`, `subject_id`, `capsule`). The client sends it verbatim — no field injection or validation.
 
-The request body may include an optional `session_end_snapshot` to merge fresh startup-critical fields into the capsule before persistence — see [Payload Reference](payload-reference.md#session-end-snapshot-helper) for the merge algorithm and field constraints. It may also include `lifecycle_transition` and `superseded_by` to atomically transition a thread capsule's lifecycle — see [Payload Reference](payload-reference.md#upsert--post-v1continuityupsert).
+The request body may include an optional `session_end_snapshot` to merge the fixed startup-critical snapshot field set into the capsule before persistence — see [Payload Reference](payload-reference.md#session-end-snapshot-helper) for the merge algorithm and field constraints. It may also include `lifecycle_transition` and `superseded_by` to atomically transition a thread capsule's lifecycle — see [Payload Reference](payload-reference.md#upsert--post-v1continuityupsert).
 
 Use `--stdin` instead of `--input` to pipe JSON from another process. Exactly one of the two is required. Payloads over 256 KiB are rejected client-side.
 
 ### Session-End Snapshot
 
-Include `session_end_snapshot` in the upsert request body to merge fresh startup-critical fields into the capsule before persistence — the server applies the merge, the client sends it verbatim.
+Include `session_end_snapshot` in the upsert request body to merge the fixed startup-critical snapshot field set into the capsule before persistence — the server applies the merge, the client sends it verbatim.
 
 ```json
 {
@@ -228,7 +228,7 @@ Use this to generate token hashes for `peer_tokens.json` and other config files.
 
 ## Usage Patterns
 
-**Agent startup hook** — restore orientation after a context reset:
+**Canonical `startup` hook** — restore orientation after a context reset:
 
 ```bash
 python tools/cognirelay_client.py read \
@@ -236,7 +236,9 @@ python tools/cognirelay_client.py read \
   --format startup
 ```
 
-**Pre-compaction hook** — persist orientation before context loss:
+This client read path sends `allow_fallback: true`. Under the canonical `startup` contract, pair it with `--format startup` so the request uses `view: "startup"` and the runtime forwards the response unchanged.
+
+**Canonical `pre_compaction_or_handoff` hook** — persist orientation before context loss:
 
 ```bash
 python tools/cognirelay_client.py upsert --input /tmp/capsule.json

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -46,9 +46,10 @@ In other words, the usable application capabilities are available through MCP to
 
 The post-#119 continuity enhancements are not separate MCP tools — they are parameters and response fields on existing tools. When calling continuity tools through MCP, pass the same parameters as the HTTP API:
 
-- **Startup view**: Pass `view: "startup"` in `continuity.read` to include the `startup_summary` extraction alongside the full capsule. See [Payload Reference](payload-reference.md#startup-view-viewstartup) for the response shape.
+- **Canonical hook mapping**: Runtime hook names may differ, but they must map 1:1 to `startup`, `pre_prompt`, `post_prompt`, or `pre_compaction_or_handoff`. See [Agent Onboarding](agent-onboarding.md#canonical-hook-contract) for the normative contract and examples.
+- **Startup view**: Canonical `startup` uses `continuity.read` with `view: "startup"` and `allow_fallback: true`, and forwards the read result unchanged. See [Payload Reference](payload-reference.md#startup-view-viewstartup) for the response shape.
 - **Trust signals**: `continuity.read` and `context.retrieve` responses include `trust_signals` automatically — no extra parameter needed. See [Payload Reference](payload-reference.md#read--post-v1continuityread) for the four dimensions.
-- **Session-end snapshot**: Pass `session_end_snapshot` in `continuity.upsert` to merge startup-critical fields at session end. See [Payload Reference](payload-reference.md#session-end-snapshot-helper) for the merge algorithm.
+- **Session-end snapshot**: Canonical `pre_compaction_or_handoff` may pass `session_end_snapshot` only when no write-eligible non-snapshot field changed. See [Payload Reference](payload-reference.md#session-end-snapshot-helper) for the merge algorithm.
 - **Thread identity filters**: Pass `lifecycle`, `scope_anchor`, `keyword`, `label_exact`, `anchor_kind`, and `anchor_value` in `continuity.list` to filter by thread scope. See [Payload Reference](payload-reference.md#threaddescriptor) for the model.
 - **Lifecycle transitions**: Pass `lifecycle_transition` and `superseded_by` in `continuity.upsert` to transition thread lifecycle. See [Payload Reference](payload-reference.md#upsert--post-v1continuityupsert) for constraints.
 - **Salience ranking**: Pass `sort: "salience"` in `continuity.list` for deterministic multi-signal salience sorting. See [Payload Reference](payload-reference.md#salience-ranking) for the sort key.

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -294,7 +294,7 @@ Response includes `normalizations_applied` (list of strings) describing write-pa
 
 #### Session-end snapshot helper
 
-When `session_end_snapshot` is provided, the server merges its fields into `capsule.continuity` before validation and persistence. This reduces caller burden at session end by focusing on the six startup-critical fields. The base capsule carries forward all non-snapshot fields unchanged.
+When `session_end_snapshot` is provided, the server merges its fields into `capsule.continuity` before validation and persistence. This reduces caller burden at session end by focusing on the fixed startup-critical snapshot field set: required P0 fields `open_loops`, `top_priorities`, `active_constraints`, `stance_summary`, plus optional P1 fields `negative_decisions`, `session_trajectory`, and `rationale_entries`. The base capsule carries forward all non-snapshot fields unchanged.
 
 **`SessionEndSnapshot` fields:**
 
@@ -309,6 +309,8 @@ When `session_end_snapshot` is provided, the server merges its fields into `caps
 | `rationale_entries` | list of RationaleEntry (max 6) | no | `capsule.continuity.rationale_entries` | `null` = preserve capsule value; explicit value = override |
 
 **Merge algorithm:** P0 fields (required) always override their `capsule.continuity` counterparts. P1 fields (optional) override only when non-null; null means the capsule's existing value is preserved. All other `ContinuityState` fields remain from the capsule unchanged. The merged capsule is then validated and persisted through the standard path. Note: the snapshot does not update `capsule.updated_at` — the caller must still set `updated_at` to the current time on the base capsule to avoid a 409 conflict rejection.
+
+**Canonical hook-contract usage rule:** Under the canonical `pre_compaction_or_handoff` contract, use `session_end_snapshot` only when no write-eligible field outside the snapshot field set changed relative to the last persisted capsule. If `active_concerns`, `drift_signals`, `stable_preferences`, `thread_descriptor.lifecycle`, `thread_descriptor.superseded_by`, or any other write-eligible non-snapshot field changed, omit `session_end_snapshot` and send a full `capsule`-only upsert instead.
 
 Per-item string length constraints (e.g. each ≤ 160 chars for list fields, each ≤ 80 chars for `session_trajectory`) are enforced by capsule validation after the merge, consistent with `ContinuityState` validation. See [NegativeDecision](#negativedecision) for per-item constraints on `negative_decisions` items.
 


### PR DESCRIPTION
Refs #215

## Summary

This PR finalizes `#215` slice 1 only. Scope is docs/spec only.

It covers:
- canonical hook identifiers
- exact HTTP/MCP operation bindings
- closed write eligibility / skip rules
- canonical `startup` requirements: `view: "startup"` and `allow_fallback: true`
- unchanged forwarding of `startup` read results
- `session_end_snapshot` rules
- real inter-agent handoff definition and ordering
- anti-noise rules
- deterministic examples aligned to the hardened `#215` issue body

The slice remains bounded to `#215` slice 1 and does not broaden into `#214`, `#216`, `#217`, or `#213` implementation work.

## Verification

- `./.venv/bin/python -m ruff check app tests tools`
