### PR TITLE
fix: close #214 slice 1 HTTP help baseline

### DIFF
--- a/app/help/__init__.py
+++ b/app/help/__init__.py
@@ -6,6 +6,7 @@ from .service import (
     help_root_payload,
     help_tool_payload,
     help_topic_payload,
+    is_forbidden_help_alias_path,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "help_root_payload",
     "help_tool_payload",
     "help_topic_payload",
+    "is_forbidden_help_alias_path",
 ]

--- a/app/help/__init__.py
+++ b/app/help/__init__.py
@@ -1,0 +1,17 @@
+"""Machine-facing HTTP help payload helpers."""
+
+from .service import (
+    help_error_payload,
+    help_hooks_payload,
+    help_root_payload,
+    help_tool_payload,
+    help_topic_payload,
+)
+
+__all__ = [
+    "help_error_payload",
+    "help_hooks_payload",
+    "help_root_payload",
+    "help_tool_payload",
+    "help_topic_payload",
+]

--- a/app/help/service.py
+++ b/app/help/service.py
@@ -25,6 +25,19 @@ _ERROR_CODES = [
     "unknown_help_topic",
 ]
 
+_EXACT_HELP_PATHS = frozenset(
+    {
+        "/v1/help",
+        "/v1/help/hooks",
+    }
+)
+
+_PARAMETERIZED_HELP_PREFIXES = (
+    "/v1/help/tools/",
+    "/v1/help/topics/",
+    "/v1/help/errors/",
+)
+
 _ROOT_BODY = {
     "http_endpoints": [
         "GET /v1/help",
@@ -465,6 +478,21 @@ def _validation_error(
 def help_root_payload() -> dict[str, Any]:
     """Return the exact slice-1 HTTP help root body."""
     return _copy(_ROOT_BODY)
+
+
+def is_forbidden_help_alias_path(path: str) -> bool:
+    """Return ``True`` when a slash-suffixed alias targets the closed help surface."""
+    if not path.startswith("/v1/help") or not path.endswith("/"):
+        return False
+
+    canonical_path = path[:-1]
+    if canonical_path in _EXACT_HELP_PATHS:
+        return True
+
+    return any(
+        canonical_path.startswith(prefix) and len(canonical_path) > len(prefix)
+        for prefix in _PARAMETERIZED_HELP_PREFIXES
+    )
 
 
 def help_tool_payload(name: str) -> dict[str, Any] | JSONResponse:

--- a/app/help/service.py
+++ b/app/help/service.py
@@ -1,0 +1,511 @@
+"""Deterministic machine-facing help payloads for issue #214 slice 1."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+_TOOL_IDS = [
+    "continuity.read",
+    "continuity.upsert",
+    "context.retrieve",
+]
+
+_TOPIC_IDS = [
+    "continuity.read.startup_view",
+    "continuity.read.trust_signals",
+    "continuity.upsert.session_end_snapshot",
+]
+
+_ERROR_CODES = [
+    "validation",
+    "tool_not_found",
+    "unknown_help_topic",
+]
+
+_ROOT_BODY = {
+    "http_endpoints": [
+        "GET /v1/help",
+        "GET /v1/help/tools/{name}",
+        "GET /v1/help/topics/{id}",
+        "GET /v1/help/hooks",
+        "GET /v1/help/errors/{code}",
+    ],
+    "mcp_tools": [
+        "system.help",
+        "system.tool_usage",
+        "system.topic_help",
+        "system.hook_guide",
+        "system.error_guide",
+    ],
+    "tool_topics": _TOOL_IDS,
+    "non_tool_topics": _TOPIC_IDS,
+    "hook_ids": [
+        "startup",
+        "pre_prompt",
+        "post_prompt",
+        "pre_compaction_or_handoff",
+    ],
+    "errors": _ERROR_CODES,
+}
+
+_TOOLS = {
+    "continuity.read": {
+        "kind": "tool",
+        "id": "continuity.read",
+        "purpose": "Read continuity state for a subject.",
+        "when_to_use": [
+            "Use when the runtime needs persisted orientation for a subject.",
+            "Use at session start when continuity is needed before prompting.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "view": "startup",
+            "allow_fallback": True,
+        },
+        "common_mistakes": [
+            "Using a view value that is not defined by the continuity.read contract.",
+            "Omitting subject_kind or subject_id.",
+        ],
+        "correction_hints": [
+            "Use view: startup and allow_fallback: true for startup continuity guidance.",
+            "Provide both subject_kind and subject_id.",
+        ],
+    },
+    "continuity.upsert": {
+        "kind": "tool",
+        "id": "continuity.upsert",
+        "purpose": "Create or update continuity state for a subject.",
+        "when_to_use": [
+            "Use when the runtime needs to persist an updated continuity capsule.",
+            "Use at session end when storing a bounded snapshot for the next startup read.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [
+            "POST /v1/continuity/upsert",
+            "continuity.upsert",
+        ],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "capsule": {
+                "updated_at": "2026-04-21T12:00:00Z",
+                "open_loops": [],
+                "top_priorities": [],
+                "active_constraints": [],
+                "stance_summary": "Ready to continue issue 214 work.",
+            },
+        },
+        "common_mistakes": [
+            "Sending a capsule without updated_at.",
+            "Sending session_end_snapshot with fields outside the closed field set in this issue.",
+        ],
+        "correction_hints": [
+            "Include updated_at in the capsule using an explicit UTC timestamp.",
+            "Use only the session_end_snapshot fields closed by this issue.",
+        ],
+    },
+    "context.retrieve": {
+        "kind": "tool",
+        "id": "context.retrieve",
+        "purpose": "Retrieve a bounded context package for a task, thread, or subject.",
+        "when_to_use": [
+            "Use when the runtime needs a compact context package instead of a raw continuity capsule.",
+            "Use before prompting when context retrieval is the contract-defined entrypoint.",
+        ],
+        "read_operations": [
+            "POST /v1/context/retrieve",
+            "context.retrieve",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "task": "Address determinism findings on issue #214 only.",
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "continuity_mode": "required",
+        },
+        "common_mistakes": [
+            "Using continuity.read fields as if they were context.retrieve fields.",
+            "Persisting prompt text, retrieved snippets, or transcript material through context.retrieve.",
+        ],
+        "correction_hints": [
+            "Use exactly task, subject_kind, subject_id, and continuity_mode in the minimal payload shape defined by this issue.",
+            "Keep context.retrieve read-only and do not persist prompt or retrieval transcript material.",
+        ],
+    },
+}
+
+_TOPICS = {
+    "continuity.read.startup_view": {
+        "kind": "topic",
+        "id": "continuity.read.startup_view",
+        "purpose": "Explain the startup continuity view used to re-establish orientation.",
+        "when_to_use": [
+            "Use when selecting the startup view for continuity.read.",
+            "Use when a runtime needs startup-oriented continuity guidance rather than a full raw capsule.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "view": "startup",
+            "allow_fallback": True,
+        },
+        "common_mistakes": [
+            "Using startup_view as if it were a literal request value.",
+            "Disabling allow_fallback when degraded startup continuity is acceptable.",
+        ],
+        "correction_hints": [
+            "Use view: startup in the request payload.",
+            "Set allow_fallback to true when fallback continuity is acceptable.",
+        ],
+    },
+    "continuity.read.trust_signals": {
+        "kind": "topic",
+        "id": "continuity.read.trust_signals",
+        "purpose": "Explain trust-oriented continuity signals surfaced by continuity.read.",
+        "when_to_use": [
+            "Use when interpreting trust signals returned with a continuity read.",
+            "Use when a caller needs to distinguish healthy continuity from degraded continuity.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "view": "startup",
+            "allow_fallback": True,
+        },
+        "common_mistakes": [
+            "Treating trust signals as a separate request field.",
+            "Ignoring degraded trust signals when choosing the next runtime action.",
+        ],
+        "correction_hints": [
+            "Read trust signals from the continuity.read response rather than inventing a request field.",
+            "Use degraded trust signals to trigger a cautious or recovery-oriented next step.",
+        ],
+    },
+    "continuity.upsert.session_end_snapshot": {
+        "kind": "topic",
+        "id": "continuity.upsert.session_end_snapshot",
+        "purpose": "Explain the bounded session_end_snapshot helper for continuity.upsert.",
+        "when_to_use": [
+            "Use when persisting a startup-focused summary at session end.",
+            "Use when the runtime needs to update startup-critical continuity fields without rebuilding the full capsule.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [
+            "POST /v1/continuity/upsert",
+            "continuity.upsert",
+        ],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "capsule": {
+                "updated_at": "2026-04-21T12:00:00Z",
+                "open_loops": [],
+                "top_priorities": [],
+                "active_constraints": [],
+                "stance_summary": "Ready to continue issue 214 work.",
+            },
+            "session_end_snapshot": {
+                "open_loops": [],
+                "top_priorities": [],
+                "active_constraints": [],
+                "stance_summary": "Ready to continue issue 214 work.",
+                "negative_decisions": [],
+                "session_trajectory": [],
+                "rationale_entries": [],
+            },
+        },
+        "common_mistakes": [
+            "Sending session_end_snapshot without a base capsule.",
+            "Sending fields in session_end_snapshot that are outside the closed field set in this issue.",
+        ],
+        "correction_hints": [
+            "Include the base capsule and then provide session_end_snapshot as a bounded helper.",
+            "Use only open_loops, top_priorities, active_constraints, stance_summary, negative_decisions, session_trajectory, and rationale_entries in session_end_snapshot.",
+        ],
+    },
+}
+
+_HOOKS = {
+    "hooks": [
+        {
+            "id": "startup",
+            "purpose": "Re-establish orientation at session start or agent re-entry.",
+            "when_to_use": [
+                "Use when a runtime is about to begin work and needs startup continuity guidance.",
+            ],
+            "read_operations": [
+                "POST /v1/continuity/read",
+                "continuity.read",
+            ],
+            "write_operations": [],
+            "minimal_payload": {
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "view": "startup",
+                "allow_fallback": True,
+            },
+            "common_mistakes": [
+                "Using a hook ID that is not one of the four canonical hook IDs in this issue.",
+            ],
+            "correction_hints": [
+                "Use startup exactly for the startup hook.",
+            ],
+        },
+        {
+            "id": "pre_prompt",
+            "purpose": "Retrieve bounded working context before a major work step.",
+            "when_to_use": [
+                "Use when the runtime is about to start a major work step and needs bounded retrieval.",
+            ],
+            "read_operations": [
+                "POST /v1/context/retrieve",
+                "context.retrieve",
+            ],
+            "write_operations": [],
+            "minimal_payload": {
+                "task": "Address determinism findings on issue #214 only.",
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "continuity_mode": "required",
+            },
+            "common_mistakes": [
+                "Using continuity.read fields as if pre_prompt were bound to continuity.read.",
+                "Persisting prompt text, retrieved snippets, or transcript material through pre_prompt.",
+            ],
+            "correction_hints": [
+                "Use exactly task, subject_kind, subject_id, and continuity_mode in the minimal payload shape defined by this issue.",
+                "Keep pre_prompt read-only and do not persist prompt or retrieval transcript material.",
+            ],
+        },
+        {
+            "id": "post_prompt",
+            "purpose": "Persist durable orientation changes caused by the completed work step.",
+            "when_to_use": [
+                "Use when a completed work step changed durable continuity state that should persist.",
+            ],
+            "read_operations": [],
+            "write_operations": [
+                "POST /v1/continuity/upsert",
+                "continuity.upsert",
+            ],
+            "minimal_payload": {
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "capsule": {
+                    "updated_at": "2026-04-21T12:00:00Z",
+                    "open_loops": [],
+                    "top_priorities": [],
+                    "active_constraints": [],
+                    "stance_summary": "Ready to continue issue 214 work.",
+                },
+            },
+            "common_mistakes": [
+                "Treating post_prompt as read-oriented guidance.",
+                "Using post_prompt as an interaction log or prompt/response summary sink.",
+            ],
+            "correction_hints": [
+                "Use continuity.upsert only when a completed work step produced durable orientation state that should persist.",
+                "Keep post_prompt focused on durable continuity rather than transcript material.",
+            ],
+        },
+        {
+            "id": "pre_compaction_or_handoff",
+            "purpose": "Persist a bounded savepoint immediately before context loss, compaction, or a real inter-agent handoff boundary.",
+            "when_to_use": [
+                "Use when a runtime is about to compact local context or cross a real inter-agent handoff boundary.",
+            ],
+            "read_operations": [],
+            "write_operations": [
+                "POST /v1/continuity/upsert",
+                "continuity.upsert",
+            ],
+            "additional_operations_for_real_handoff": [
+                "POST /v1/coordination/handoff/create",
+                "coordination.handoff_create",
+            ],
+            "minimal_payload": {
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "capsule": {
+                    "updated_at": "2026-04-21T12:00:00Z",
+                    "open_loops": [],
+                    "top_priorities": [],
+                    "active_constraints": [],
+                    "stance_summary": "Ready to continue issue 214 work.",
+                },
+                "session_end_snapshot": {
+                    "open_loops": [],
+                    "top_priorities": [],
+                    "active_constraints": [],
+                    "stance_summary": "Ready to continue issue 214 work.",
+                    "negative_decisions": [],
+                    "session_trajectory": [],
+                    "rationale_entries": [],
+                },
+            },
+            "common_mistakes": [
+                "Using the deprecated hook spelling pre_compaction_handoff.",
+                "Sending session_end_snapshot with fields outside the closed field set in this issue.",
+                "Calling handoff creation before the local continuity step completes.",
+            ],
+            "correction_hints": [
+                "Use pre_compaction_or_handoff exactly.",
+                "Use only open_loops, top_priorities, active_constraints, stance_summary, negative_decisions, session_trajectory, and rationale_entries in session_end_snapshot.",
+                "For a real inter-agent handoff, call coordination.handoff_create only after the local continuity step completes.",
+            ],
+        },
+    ],
+}
+
+_ERRORS = {
+    "validation": {
+        "kind": "error",
+        "id": "validation",
+        "purpose": "Explain how to correct a contract-validation failure.",
+        "when_to_use": [
+            "Use when a request failed contract validation.",
+        ],
+        "common_mistakes": [
+            "Guessing field names or allowed values from the error detail string alone.",
+        ],
+        "correction_hints": [
+            "Inspect validation_hints and correct the named field directly.",
+        ],
+    },
+    "tool_not_found": {
+        "kind": "error",
+        "id": "tool_not_found",
+        "purpose": "Explain the meaning of the tool_not_found error-guide target.",
+        "when_to_use": [
+            "Use when reading help about the tool_not_found error class itself.",
+        ],
+        "common_mistakes": [
+            "Treating tool_not_found as the rejection contract for unsupported tool names on the help surface.",
+        ],
+        "correction_hints": [
+            "For unsupported tool names on the help surface, use the validation rejection contract defined in this issue.",
+        ],
+    },
+    "unknown_help_topic": {
+        "kind": "error",
+        "id": "unknown_help_topic",
+        "purpose": "Explain the meaning of the unknown_help_topic error-guide target.",
+        "when_to_use": [
+            "Use when reading help about the unknown_help_topic error class itself.",
+        ],
+        "common_mistakes": [
+            "Treating unknown_help_topic as the rejection contract for unsupported topic IDs on the help surface.",
+        ],
+        "correction_hints": [
+            "For unsupported topic IDs on the help surface, use the validation rejection contract defined in this issue.",
+        ],
+    },
+}
+
+
+def _copy(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return a defensive deep copy of a frozen help payload."""
+    return deepcopy(payload)
+
+
+def _validation_error(
+    *,
+    field: str,
+    detail: str,
+    allowed_values: list[str],
+    correction_hint: str,
+) -> JSONResponse:
+    """Build the exact slice-1 HTTP validation error body."""
+    return JSONResponse(
+        status_code=400,
+        content={
+            "error": {
+                "code": "validation",
+                "detail": detail,
+                "validation_hints": [
+                    {
+                        "field": field,
+                        "area": "request.path",
+                        "reason": "unsupported_value",
+                        "limit": None,
+                        "allowed_values": allowed_values,
+                        "correction_hint": correction_hint,
+                    }
+                ],
+            }
+        },
+    )
+
+
+def help_root_payload() -> dict[str, Any]:
+    """Return the exact slice-1 HTTP help root body."""
+    return _copy(_ROOT_BODY)
+
+
+def help_tool_payload(name: str) -> dict[str, Any] | JSONResponse:
+    """Return the exact tool help body or the exact unsupported-tool validation error."""
+    payload = _TOOLS.get(name)
+    if payload is not None:
+        return _copy(payload)
+    return _validation_error(
+        field="name",
+        detail="Unsupported tool name.",
+        allowed_values=list(_TOOL_IDS),
+        correction_hint="Use one of: continuity.read, continuity.upsert, context.retrieve.",
+    )
+
+
+def help_topic_payload(topic_id: str) -> dict[str, Any] | JSONResponse:
+    """Return the exact topic help body or the exact unsupported-topic validation error."""
+    payload = _TOPICS.get(topic_id)
+    if payload is not None:
+        return _copy(payload)
+    return _validation_error(
+        field="id",
+        detail="Unsupported topic id.",
+        allowed_values=list(_TOPIC_IDS),
+        correction_hint="Use one of: continuity.read.startup_view, continuity.read.trust_signals, continuity.upsert.session_end_snapshot.",
+    )
+
+
+def help_hooks_payload() -> dict[str, Any]:
+    """Return the exact slice-1 HTTP hook guidance body."""
+    return _copy(_HOOKS)
+
+
+def help_error_payload(code: str) -> dict[str, Any] | JSONResponse:
+    """Return the exact error help body or the exact unsupported-error validation error."""
+    payload = _ERRORS.get(code)
+    if payload is not None:
+        return _copy(payload)
+    return _validation_error(
+        field="code",
+        detail="Unsupported error code.",
+        allowed_values=list(_ERROR_CODES),
+        correction_hint="Use one of: validation, tool_not_found, unknown_help_topic.",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -207,6 +207,13 @@ from .tasks import (
     tasks_query_service,
     tasks_update_service,
 )
+from .help import (
+    help_error_payload,
+    help_hooks_payload,
+    help_root_payload,
+    help_tool_payload,
+    help_topic_payload,
+)
 from .ui import build_ui_router
 
 _log = logging.getLogger(__name__)
@@ -574,6 +581,36 @@ def contracts() -> dict:
     """Return contract version metadata and compatibility policy."""
     settings = get_settings()
     return contracts_payload(contract_version=settings.contract_version, tools=_tool_catalog())
+
+
+@app.get("/v1/help")
+def help_root() -> dict:
+    """Return the exact machine-facing HTTP help root body for issue #214 slice 1."""
+    return help_root_payload()
+
+
+@app.get("/v1/help/tools/{name}")
+def help_tool(name: str) -> Any:
+    """Return the exact supported tool-help body or the exact slice-1 validation error."""
+    return help_tool_payload(name)
+
+
+@app.get("/v1/help/topics/{id}")
+def help_topic(id: str) -> Any:
+    """Return the exact supported topic-help body or the exact slice-1 validation error."""
+    return help_topic_payload(id)
+
+
+@app.get("/v1/help/hooks")
+def help_hooks() -> dict:
+    """Return the exact hook guidance body for issue #214 slice 1."""
+    return help_hooks_payload()
+
+
+@app.get("/v1/help/errors/{code}")
+def help_error(code: str) -> Any:
+    """Return the exact supported error-help body or the exact slice-1 validation error."""
+    return help_error_payload(code)
 
 
 @app.get("/v1/governance/policy")

--- a/app/main.py
+++ b/app/main.py
@@ -278,11 +278,11 @@ if get_settings().ui_enabled:
 
 @app.middleware("http")
 async def _cache_raw_json_body(request: FastAPIRequest, call_next):  # type: ignore[no-untyped-def]
-    """Cache the raw JSON body on request.state for preserve-mode upsert.
+    """Reject forbidden help aliases and cache preserve-mode upsert bodies.
 
-    Only activates for the continuity upsert endpoint when the body
-    contains ``"merge_mode": "preserve"``.  All other requests pass
-    through untouched.
+    Returns a direct 404 for forbidden trailing-slash help aliases. For
+    POST /v1/continuity/upsert, caches the raw JSON body only when
+    ``merge_mode`` is ``"preserve"``.
     """
     if is_forbidden_help_alias_path(request.url.path):
         return JSONResponse(status_code=404, content={"detail": "Not Found"})

--- a/app/main.py
+++ b/app/main.py
@@ -213,6 +213,7 @@ from .help import (
     help_root_payload,
     help_tool_payload,
     help_topic_payload,
+    is_forbidden_help_alias_path,
 )
 from .ui import build_ui_router
 
@@ -283,6 +284,9 @@ async def _cache_raw_json_body(request: FastAPIRequest, call_next):  # type: ign
     contains ``"merge_mode": "preserve"``.  All other requests pass
     through untouched.
     """
+    if is_forbidden_help_alias_path(request.url.path):
+        return JSONResponse(status_code=404, content={"detail": "Not Found"})
+
     if request.url.path.endswith("/v1/continuity/upsert") and request.method == "POST":
         body_bytes = await request.body()
         try:

--- a/tests/test_help_214_slice1.py
+++ b/tests/test_help_214_slice1.py
@@ -464,6 +464,12 @@ class TestHelp214Slice1Routes(HelpHttpTestCase):
         self.assertNotIn("location", response.headers)
         self.assertEqual(response.json(), {"detail": "Not Found"})
 
+    def test_non_help_trailing_slash_paths_keep_existing_redirects(self) -> None:
+        """The help-alias guard must not intercept unrelated slash redirects."""
+        response = self.client.get("/v1/capabilities/", follow_redirects=False)
+        self.assertEqual(response.status_code, 307)
+        self.assertEqual(response.headers["location"], "http://testserver/v1/capabilities")
+
 
 class TestHelp214Slice1SuccessBodies(HelpHttpTestCase):
     """Successful slice-1 help responses must match the hardened issue body exactly."""

--- a/tests/test_help_214_slice1.py
+++ b/tests/test_help_214_slice1.py
@@ -1,0 +1,582 @@
+"""HTTP help baseline contract tests for issue #214 slice 1."""
+
+import json
+import unittest
+
+from starlette.responses import JSONResponse
+
+from app.main import (
+    app,
+    help_error,
+    help_hooks,
+    help_root,
+    help_tool,
+    help_topic,
+)
+
+
+EXPECTED_ROOT = {
+    "http_endpoints": [
+        "GET /v1/help",
+        "GET /v1/help/tools/{name}",
+        "GET /v1/help/topics/{id}",
+        "GET /v1/help/hooks",
+        "GET /v1/help/errors/{code}",
+    ],
+    "mcp_tools": [
+        "system.help",
+        "system.tool_usage",
+        "system.topic_help",
+        "system.hook_guide",
+        "system.error_guide",
+    ],
+    "tool_topics": [
+        "continuity.read",
+        "continuity.upsert",
+        "context.retrieve",
+    ],
+    "non_tool_topics": [
+        "continuity.read.startup_view",
+        "continuity.read.trust_signals",
+        "continuity.upsert.session_end_snapshot",
+    ],
+    "hook_ids": [
+        "startup",
+        "pre_prompt",
+        "post_prompt",
+        "pre_compaction_or_handoff",
+    ],
+    "errors": [
+        "validation",
+        "tool_not_found",
+        "unknown_help_topic",
+    ],
+}
+
+EXPECTED_TOOLS = {
+    "continuity.read": {
+        "kind": "tool",
+        "id": "continuity.read",
+        "purpose": "Read continuity state for a subject.",
+        "when_to_use": [
+            "Use when the runtime needs persisted orientation for a subject.",
+            "Use at session start when continuity is needed before prompting.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "view": "startup",
+            "allow_fallback": True,
+        },
+        "common_mistakes": [
+            "Using a view value that is not defined by the continuity.read contract.",
+            "Omitting subject_kind or subject_id.",
+        ],
+        "correction_hints": [
+            "Use view: startup and allow_fallback: true for startup continuity guidance.",
+            "Provide both subject_kind and subject_id.",
+        ],
+    },
+    "continuity.upsert": {
+        "kind": "tool",
+        "id": "continuity.upsert",
+        "purpose": "Create or update continuity state for a subject.",
+        "when_to_use": [
+            "Use when the runtime needs to persist an updated continuity capsule.",
+            "Use at session end when storing a bounded snapshot for the next startup read.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [
+            "POST /v1/continuity/upsert",
+            "continuity.upsert",
+        ],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "capsule": {
+                "updated_at": "2026-04-21T12:00:00Z",
+                "open_loops": [],
+                "top_priorities": [],
+                "active_constraints": [],
+                "stance_summary": "Ready to continue issue 214 work.",
+            },
+        },
+        "common_mistakes": [
+            "Sending a capsule without updated_at.",
+            "Sending session_end_snapshot with fields outside the closed field set in this issue.",
+        ],
+        "correction_hints": [
+            "Include updated_at in the capsule using an explicit UTC timestamp.",
+            "Use only the session_end_snapshot fields closed by this issue.",
+        ],
+    },
+    "context.retrieve": {
+        "kind": "tool",
+        "id": "context.retrieve",
+        "purpose": "Retrieve a bounded context package for a task, thread, or subject.",
+        "when_to_use": [
+            "Use when the runtime needs a compact context package instead of a raw continuity capsule.",
+            "Use before prompting when context retrieval is the contract-defined entrypoint.",
+        ],
+        "read_operations": [
+            "POST /v1/context/retrieve",
+            "context.retrieve",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "task": "Address determinism findings on issue #214 only.",
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "continuity_mode": "required",
+        },
+        "common_mistakes": [
+            "Using continuity.read fields as if they were context.retrieve fields.",
+            "Persisting prompt text, retrieved snippets, or transcript material through context.retrieve.",
+        ],
+        "correction_hints": [
+            "Use exactly task, subject_kind, subject_id, and continuity_mode in the minimal payload shape defined by this issue.",
+            "Keep context.retrieve read-only and do not persist prompt or retrieval transcript material.",
+        ],
+    },
+}
+
+EXPECTED_TOPICS = {
+    "continuity.read.startup_view": {
+        "kind": "topic",
+        "id": "continuity.read.startup_view",
+        "purpose": "Explain the startup continuity view used to re-establish orientation.",
+        "when_to_use": [
+            "Use when selecting the startup view for continuity.read.",
+            "Use when a runtime needs startup-oriented continuity guidance rather than a full raw capsule.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "view": "startup",
+            "allow_fallback": True,
+        },
+        "common_mistakes": [
+            "Using startup_view as if it were a literal request value.",
+            "Disabling allow_fallback when degraded startup continuity is acceptable.",
+        ],
+        "correction_hints": [
+            "Use view: startup in the request payload.",
+            "Set allow_fallback to true when fallback continuity is acceptable.",
+        ],
+    },
+    "continuity.read.trust_signals": {
+        "kind": "topic",
+        "id": "continuity.read.trust_signals",
+        "purpose": "Explain trust-oriented continuity signals surfaced by continuity.read.",
+        "when_to_use": [
+            "Use when interpreting trust signals returned with a continuity read.",
+            "Use when a caller needs to distinguish healthy continuity from degraded continuity.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "view": "startup",
+            "allow_fallback": True,
+        },
+        "common_mistakes": [
+            "Treating trust signals as a separate request field.",
+            "Ignoring degraded trust signals when choosing the next runtime action.",
+        ],
+        "correction_hints": [
+            "Read trust signals from the continuity.read response rather than inventing a request field.",
+            "Use degraded trust signals to trigger a cautious or recovery-oriented next step.",
+        ],
+    },
+    "continuity.upsert.session_end_snapshot": {
+        "kind": "topic",
+        "id": "continuity.upsert.session_end_snapshot",
+        "purpose": "Explain the bounded session_end_snapshot helper for continuity.upsert.",
+        "when_to_use": [
+            "Use when persisting a startup-focused summary at session end.",
+            "Use when the runtime needs to update startup-critical continuity fields without rebuilding the full capsule.",
+        ],
+        "read_operations": [
+            "POST /v1/continuity/read",
+            "continuity.read",
+        ],
+        "write_operations": [
+            "POST /v1/continuity/upsert",
+            "continuity.upsert",
+        ],
+        "minimal_payload": {
+            "subject_kind": "thread",
+            "subject_id": "issue-214",
+            "capsule": {
+                "updated_at": "2026-04-21T12:00:00Z",
+                "open_loops": [],
+                "top_priorities": [],
+                "active_constraints": [],
+                "stance_summary": "Ready to continue issue 214 work.",
+            },
+            "session_end_snapshot": {
+                "open_loops": [],
+                "top_priorities": [],
+                "active_constraints": [],
+                "stance_summary": "Ready to continue issue 214 work.",
+                "negative_decisions": [],
+                "session_trajectory": [],
+                "rationale_entries": [],
+            },
+        },
+        "common_mistakes": [
+            "Sending session_end_snapshot without a base capsule.",
+            "Sending fields in session_end_snapshot that are outside the closed field set in this issue.",
+        ],
+        "correction_hints": [
+            "Include the base capsule and then provide session_end_snapshot as a bounded helper.",
+            "Use only open_loops, top_priorities, active_constraints, stance_summary, negative_decisions, session_trajectory, and rationale_entries in session_end_snapshot.",
+        ],
+    },
+}
+
+EXPECTED_HOOKS = {
+    "hooks": [
+        {
+            "id": "startup",
+            "purpose": "Re-establish orientation at session start or agent re-entry.",
+            "when_to_use": [
+                "Use when a runtime is about to begin work and needs startup continuity guidance.",
+            ],
+            "read_operations": [
+                "POST /v1/continuity/read",
+                "continuity.read",
+            ],
+            "write_operations": [],
+            "minimal_payload": {
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "view": "startup",
+                "allow_fallback": True,
+            },
+            "common_mistakes": [
+                "Using a hook ID that is not one of the four canonical hook IDs in this issue.",
+            ],
+            "correction_hints": [
+                "Use startup exactly for the startup hook.",
+            ],
+        },
+        {
+            "id": "pre_prompt",
+            "purpose": "Retrieve bounded working context before a major work step.",
+            "when_to_use": [
+                "Use when the runtime is about to start a major work step and needs bounded retrieval.",
+            ],
+            "read_operations": [
+                "POST /v1/context/retrieve",
+                "context.retrieve",
+            ],
+            "write_operations": [],
+            "minimal_payload": {
+                "task": "Address determinism findings on issue #214 only.",
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "continuity_mode": "required",
+            },
+            "common_mistakes": [
+                "Using continuity.read fields as if pre_prompt were bound to continuity.read.",
+                "Persisting prompt text, retrieved snippets, or transcript material through pre_prompt.",
+            ],
+            "correction_hints": [
+                "Use exactly task, subject_kind, subject_id, and continuity_mode in the minimal payload shape defined by this issue.",
+                "Keep pre_prompt read-only and do not persist prompt or retrieval transcript material.",
+            ],
+        },
+        {
+            "id": "post_prompt",
+            "purpose": "Persist durable orientation changes caused by the completed work step.",
+            "when_to_use": [
+                "Use when a completed work step changed durable continuity state that should persist.",
+            ],
+            "read_operations": [],
+            "write_operations": [
+                "POST /v1/continuity/upsert",
+                "continuity.upsert",
+            ],
+            "minimal_payload": {
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "capsule": {
+                    "updated_at": "2026-04-21T12:00:00Z",
+                    "open_loops": [],
+                    "top_priorities": [],
+                    "active_constraints": [],
+                    "stance_summary": "Ready to continue issue 214 work.",
+                },
+            },
+            "common_mistakes": [
+                "Treating post_prompt as read-oriented guidance.",
+                "Using post_prompt as an interaction log or prompt/response summary sink.",
+            ],
+            "correction_hints": [
+                "Use continuity.upsert only when a completed work step produced durable orientation state that should persist.",
+                "Keep post_prompt focused on durable continuity rather than transcript material.",
+            ],
+        },
+        {
+            "id": "pre_compaction_or_handoff",
+            "purpose": "Persist a bounded savepoint immediately before context loss, compaction, or a real inter-agent handoff boundary.",
+            "when_to_use": [
+                "Use when a runtime is about to compact local context or cross a real inter-agent handoff boundary.",
+            ],
+            "read_operations": [],
+            "write_operations": [
+                "POST /v1/continuity/upsert",
+                "continuity.upsert",
+            ],
+            "additional_operations_for_real_handoff": [
+                "POST /v1/coordination/handoff/create",
+                "coordination.handoff_create",
+            ],
+            "minimal_payload": {
+                "subject_kind": "thread",
+                "subject_id": "issue-214",
+                "capsule": {
+                    "updated_at": "2026-04-21T12:00:00Z",
+                    "open_loops": [],
+                    "top_priorities": [],
+                    "active_constraints": [],
+                    "stance_summary": "Ready to continue issue 214 work.",
+                },
+                "session_end_snapshot": {
+                    "open_loops": [],
+                    "top_priorities": [],
+                    "active_constraints": [],
+                    "stance_summary": "Ready to continue issue 214 work.",
+                    "negative_decisions": [],
+                    "session_trajectory": [],
+                    "rationale_entries": [],
+                },
+            },
+            "common_mistakes": [
+                "Using the deprecated hook spelling pre_compaction_handoff.",
+                "Sending session_end_snapshot with fields outside the closed field set in this issue.",
+                "Calling handoff creation before the local continuity step completes.",
+            ],
+            "correction_hints": [
+                "Use pre_compaction_or_handoff exactly.",
+                "Use only open_loops, top_priorities, active_constraints, stance_summary, negative_decisions, session_trajectory, and rationale_entries in session_end_snapshot.",
+                "For a real inter-agent handoff, call coordination.handoff_create only after the local continuity step completes.",
+            ],
+        },
+    ],
+}
+
+EXPECTED_ERRORS = {
+    "validation": {
+        "kind": "error",
+        "id": "validation",
+        "purpose": "Explain how to correct a contract-validation failure.",
+        "when_to_use": [
+            "Use when a request failed contract validation.",
+        ],
+        "common_mistakes": [
+            "Guessing field names or allowed values from the error detail string alone.",
+        ],
+        "correction_hints": [
+            "Inspect validation_hints and correct the named field directly.",
+        ],
+    },
+    "tool_not_found": {
+        "kind": "error",
+        "id": "tool_not_found",
+        "purpose": "Explain the meaning of the tool_not_found error-guide target.",
+        "when_to_use": [
+            "Use when reading help about the tool_not_found error class itself.",
+        ],
+        "common_mistakes": [
+            "Treating tool_not_found as the rejection contract for unsupported tool names on the help surface.",
+        ],
+        "correction_hints": [
+            "For unsupported tool names on the help surface, use the validation rejection contract defined in this issue.",
+        ],
+    },
+    "unknown_help_topic": {
+        "kind": "error",
+        "id": "unknown_help_topic",
+        "purpose": "Explain the meaning of the unknown_help_topic error-guide target.",
+        "when_to_use": [
+            "Use when reading help about the unknown_help_topic error class itself.",
+        ],
+        "common_mistakes": [
+            "Treating unknown_help_topic as the rejection contract for unsupported topic IDs on the help surface.",
+        ],
+        "correction_hints": [
+            "For unsupported topic IDs on the help surface, use the validation rejection contract defined in this issue.",
+        ],
+    },
+}
+
+
+def _json_response_body(response: JSONResponse) -> dict:
+    """Decode a JSONResponse body into a dict."""
+    return json.loads(response.body.decode("utf-8"))
+
+
+class TestHelp214Slice1Routes(unittest.TestCase):
+    """The HTTP help surface is closed to the five slice-1 routes."""
+
+    def test_help_routes_are_exact(self) -> None:
+        """Only the exact issue-defined /v1/help routes are registered."""
+        help_routes = {
+            (frozenset(route.methods), route.path)
+            for route in app.routes
+            if route.path.startswith("/v1/help")
+        }
+        self.assertEqual(
+            help_routes,
+            {
+                (frozenset({"GET"}), "/v1/help"),
+                (frozenset({"GET"}), "/v1/help/tools/{name}"),
+                (frozenset({"GET"}), "/v1/help/topics/{id}"),
+                (frozenset({"GET"}), "/v1/help/hooks"),
+                (frozenset({"GET"}), "/v1/help/errors/{code}"),
+            },
+        )
+
+
+class TestHelp214Slice1SuccessBodies(unittest.TestCase):
+    """Successful slice-1 help responses must match the hardened issue body exactly."""
+
+    def test_root_body(self) -> None:
+        """GET /v1/help returns the exact closed root body."""
+        self.assertEqual(help_root(), EXPECTED_ROOT)
+
+    def test_tool_bodies(self) -> None:
+        """Each supported tool target returns its exact closed body."""
+        for name, expected in EXPECTED_TOOLS.items():
+            with self.subTest(name=name):
+                self.assertEqual(help_tool(name), expected)
+
+    def test_topic_bodies(self) -> None:
+        """Each supported topic target returns its exact closed body."""
+        for topic_id, expected in EXPECTED_TOPICS.items():
+            with self.subTest(topic_id=topic_id):
+                self.assertEqual(help_topic(topic_id), expected)
+
+    def test_hooks_body(self) -> None:
+        """GET /v1/help/hooks returns the exact closed hook map."""
+        self.assertEqual(help_hooks(), EXPECTED_HOOKS)
+
+    def test_error_bodies(self) -> None:
+        """Each supported error target returns its exact closed body."""
+        for code, expected in EXPECTED_ERRORS.items():
+            with self.subTest(code=code):
+                self.assertEqual(help_error(code), expected)
+
+
+class TestHelp214Slice1Validation(unittest.TestCase):
+    """Unsupported help targets are validation failures, not not-found lookups."""
+
+    def test_unsupported_tool_name_returns_400_validation_body(self) -> None:
+        """Unsupported tool names use the exact validation contract."""
+        response = help_tool("memory.write")
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            _json_response_body(response),
+            {
+                "error": {
+                    "code": "validation",
+                    "detail": "Unsupported tool name.",
+                    "validation_hints": [
+                        {
+                            "field": "name",
+                            "area": "request.path",
+                            "reason": "unsupported_value",
+                            "limit": None,
+                            "allowed_values": [
+                                "continuity.read",
+                                "continuity.upsert",
+                                "context.retrieve",
+                            ],
+                            "correction_hint": "Use one of: continuity.read, continuity.upsert, context.retrieve.",
+                        }
+                    ],
+                }
+            },
+        )
+
+    def test_unsupported_topic_id_returns_400_validation_body(self) -> None:
+        """Unsupported topic ids use the exact validation contract."""
+        response = help_topic("continuity.read.startup")
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            _json_response_body(response),
+            {
+                "error": {
+                    "code": "validation",
+                    "detail": "Unsupported topic id.",
+                    "validation_hints": [
+                        {
+                            "field": "id",
+                            "area": "request.path",
+                            "reason": "unsupported_value",
+                            "limit": None,
+                            "allowed_values": [
+                                "continuity.read.startup_view",
+                                "continuity.read.trust_signals",
+                                "continuity.upsert.session_end_snapshot",
+                            ],
+                            "correction_hint": "Use one of: continuity.read.startup_view, continuity.read.trust_signals, continuity.upsert.session_end_snapshot.",
+                        }
+                    ],
+                }
+            },
+        )
+
+    def test_unsupported_error_code_returns_400_validation_body(self) -> None:
+        """Unsupported error codes use the exact validation contract."""
+        response = help_error("not_found")
+        self.assertIsInstance(response, JSONResponse)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            _json_response_body(response),
+            {
+                "error": {
+                    "code": "validation",
+                    "detail": "Unsupported error code.",
+                    "validation_hints": [
+                        {
+                            "field": "code",
+                            "area": "request.path",
+                            "reason": "unsupported_value",
+                            "limit": None,
+                            "allowed_values": [
+                                "validation",
+                                "tool_not_found",
+                                "unknown_help_topic",
+                            ],
+                            "correction_hint": "Use one of: validation, tool_not_found, unknown_help_topic.",
+                        }
+                    ],
+                }
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_help_214_slice1.py
+++ b/tests/test_help_214_slice1.py
@@ -1,18 +1,10 @@
 """HTTP help baseline contract tests for issue #214 slice 1."""
 
-import json
 import unittest
 
-from starlette.responses import JSONResponse
+from fastapi.testclient import TestClient
 
-from app.main import (
-    app,
-    help_error,
-    help_hooks,
-    help_root,
-    help_tool,
-    help_topic,
-)
+from app.main import app
 
 
 EXPECTED_ROOT = {
@@ -429,13 +421,22 @@ EXPECTED_ERRORS = {
     },
 }
 
+class HelpHttpTestCase(unittest.TestCase):
+    """Share a real HTTP client for the slice-1 help contract tests."""
 
-def _json_response_body(response: JSONResponse) -> dict:
-    """Decode a JSONResponse body into a dict."""
-    return json.loads(response.body.decode("utf-8"))
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Start a real client so routing assertions exercise FastAPI itself."""
+        cls._client_context = TestClient(app)
+        cls.client = cls._client_context.__enter__()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Close the shared client after the HTTP contract checks finish."""
+        cls._client_context.__exit__(None, None, None)
 
 
-class TestHelp214Slice1Routes(unittest.TestCase):
+class TestHelp214Slice1Routes(HelpHttpTestCase):
     """The HTTP help surface is closed to the five slice-1 routes."""
 
     def test_help_routes_are_exact(self) -> None:
@@ -456,47 +457,78 @@ class TestHelp214Slice1Routes(unittest.TestCase):
             },
         )
 
+    def test_alternate_topic_routing_path_is_not_exposed(self) -> None:
+        """Only the canonical single-segment topic path is live over HTTP."""
+        response = self.client.get("/v1/help/topics/continuity.read/startup_view", follow_redirects=False)
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn("location", response.headers)
+        self.assertEqual(response.json(), {"detail": "Not Found"})
 
-class TestHelp214Slice1SuccessBodies(unittest.TestCase):
+
+class TestHelp214Slice1SuccessBodies(HelpHttpTestCase):
     """Successful slice-1 help responses must match the hardened issue body exactly."""
 
     def test_root_body(self) -> None:
         """GET /v1/help returns the exact closed root body."""
-        self.assertEqual(help_root(), EXPECTED_ROOT)
+        response = self.client.get("/v1/help")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), EXPECTED_ROOT)
 
     def test_tool_bodies(self) -> None:
         """Each supported tool target returns its exact closed body."""
         for name, expected in EXPECTED_TOOLS.items():
             with self.subTest(name=name):
-                self.assertEqual(help_tool(name), expected)
+                response = self.client.get(f"/v1/help/tools/{name}")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), expected)
 
     def test_topic_bodies(self) -> None:
         """Each supported topic target returns its exact closed body."""
         for topic_id, expected in EXPECTED_TOPICS.items():
             with self.subTest(topic_id=topic_id):
-                self.assertEqual(help_topic(topic_id), expected)
+                response = self.client.get(f"/v1/help/topics/{topic_id}")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), expected)
 
     def test_hooks_body(self) -> None:
         """GET /v1/help/hooks returns the exact closed hook map."""
-        self.assertEqual(help_hooks(), EXPECTED_HOOKS)
+        response = self.client.get("/v1/help/hooks")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), EXPECTED_HOOKS)
 
     def test_error_bodies(self) -> None:
         """Each supported error target returns its exact closed body."""
         for code, expected in EXPECTED_ERRORS.items():
             with self.subTest(code=code):
-                self.assertEqual(help_error(code), expected)
+                response = self.client.get(f"/v1/help/errors/{code}")
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json(), expected)
+
+    def test_slash_suffixed_variants_do_not_redirect_or_succeed(self) -> None:
+        """Slash aliases must fail directly so the help surface stays exact."""
+        for path in (
+            "/v1/help/",
+            "/v1/help/tools/continuity.read/",
+            "/v1/help/topics/continuity.read.startup_view/",
+            "/v1/help/hooks/",
+            "/v1/help/errors/validation/",
+        ):
+            with self.subTest(path=path):
+                response = self.client.get(path, follow_redirects=False)
+                self.assertEqual(response.status_code, 404)
+                self.assertNotIn("location", response.headers)
+                self.assertEqual(response.json(), {"detail": "Not Found"})
 
 
-class TestHelp214Slice1Validation(unittest.TestCase):
+class TestHelp214Slice1Validation(HelpHttpTestCase):
     """Unsupported help targets are validation failures, not not-found lookups."""
 
     def test_unsupported_tool_name_returns_400_validation_body(self) -> None:
         """Unsupported tool names use the exact validation contract."""
-        response = help_tool("memory.write")
-        self.assertIsInstance(response, JSONResponse)
+        response = self.client.get("/v1/help/tools/memory.write", follow_redirects=False)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            _json_response_body(response),
+            response.json(),
             {
                 "error": {
                     "code": "validation",
@@ -521,11 +553,10 @@ class TestHelp214Slice1Validation(unittest.TestCase):
 
     def test_unsupported_topic_id_returns_400_validation_body(self) -> None:
         """Unsupported topic ids use the exact validation contract."""
-        response = help_topic("continuity.read.startup")
-        self.assertIsInstance(response, JSONResponse)
+        response = self.client.get("/v1/help/topics/continuity.read.startup", follow_redirects=False)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            _json_response_body(response),
+            response.json(),
             {
                 "error": {
                     "code": "validation",
@@ -550,11 +581,10 @@ class TestHelp214Slice1Validation(unittest.TestCase):
 
     def test_unsupported_error_code_returns_400_validation_body(self) -> None:
         """Unsupported error codes use the exact validation contract."""
-        response = help_error("not_found")
-        self.assertIsInstance(response, JSONResponse)
+        response = self.client.get("/v1/help/errors/not_found", follow_redirects=False)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
-            _json_response_body(response),
+            response.json(),
             {
                 "error": {
                     "code": "validation",


### PR DESCRIPTION
Refs #214

## Summary
- implement `#214` slice 1 only: the HTTP integrated help baseline
- add the exact closed HTTP help routes for `/v1/help`, `/v1/help/tools/{name}`, `/v1/help/topics/{id}`, `/v1/help/hooks`, and `/v1/help/errors/{code}`
- return the exact machine-facing response bodies for the supported slice-1 help targets
- return the exact HTTP 400 validation bodies for unsupported tool, topic, and error targets
- close forbidden slash-suffixed help aliases so they fail directly instead of redirecting
- close the alternate topic-routing path so only the canonical single-segment topic path is exposed
- keep scope bounded to HTTP slice 1 only with no MCP parity yet and no broader help-system work

## Verification
- `./.venv/bin/python -m unittest tests.test_help_214_slice1 -v`
- `./.venv/bin/python -m ruff check app tests tools`
