### PR TITLE
Refs #217: related_documents slice 1

### DIFF
--- a/app/continuity/constants.py
+++ b/app/continuity/constants.py
@@ -99,6 +99,7 @@ CONTINUITY_COMPARE_NESTED_ORDERS: dict[str, list[str]] = {
         "trailing_notes",
         "curiosity_queue",
         "rationale_entries",
+        "related_documents",
         "relationship_model",
         "retrieval_hints",
     ],
@@ -209,6 +210,7 @@ PRESERVE_OPTIONAL_LIST_CONTINUITY_FIELDS: frozenset[str] = frozenset({
     "curiosity_queue",
     "negative_decisions",
     "rationale_entries",
+    "related_documents",
 })
 # Optional object fields: absent → preserve; null → clear to None.
 PRESERVE_OPTIONAL_OBJECT_CONTINUITY_FIELDS: frozenset[str] = frozenset({

--- a/app/continuity/context_state.py
+++ b/app/continuity/context_state.py
@@ -44,8 +44,8 @@ from app.continuity.paths import (
     continuity_rel_path,
 )
 from app.continuity.persistence import (
-    _load_capsule,
-    _load_fallback_snapshot,
+    _load_capsule_with_warnings,
+    _load_fallback_snapshot_with_warnings,
 )
 from app.continuity.retrieval import (
     _format_selector,
@@ -108,7 +108,12 @@ def _load_selectors_with_fallback(
             raise
         source_state = "active"
         try:
-            capsule = _load_capsule(repo_root, rel, expected_subject=(kind, subject_id))
+            capsule, related_document_warnings = _load_capsule_with_warnings(
+                repo_root,
+                rel,
+                expected_subject=(kind, subject_id),
+            )
+            recovery_warnings.extend(related_document_warnings)
         except HTTPException as exc:
             selector_label = _format_selector(kind, subject_id)
             if exc.status_code == 404:
@@ -135,8 +140,13 @@ def _load_selectors_with_fallback(
                     continue
                 raise
             try:
-                capsule = _load_fallback_snapshot(repo_root, fallback_rel, expected_subject=(kind, subject_id))
+                capsule, related_document_warnings = _load_fallback_snapshot_with_warnings(
+                    repo_root,
+                    fallback_rel,
+                    expected_subject=(kind, subject_id),
+                )
                 recovery_warnings.append(_qualify_warning(CONTINUITY_WARNING_FALLBACK_USED, kind, subject_id, multi_mode=multi_warning_mode))
+                recovery_warnings.extend(related_document_warnings)
                 fallback_used = True
                 source_state = "fallback"
             except HTTPException as fallback_exc:

--- a/app/continuity/persistence.py
+++ b/app/continuity/persistence.py
@@ -23,7 +23,11 @@ from app.continuity.paths import (
     continuity_fallback_rel_path,
     continuity_rel_path,
 )
-from app.continuity.validation import _require_utc_timestamp, _upgrade_legacy_structured_entry_timestamps
+from app.continuity.validation import (
+    _require_utc_timestamp,
+    _sanitize_related_documents_on_read,
+    _upgrade_legacy_structured_entry_timestamps,
+)
 from app.git_locking import repository_mutation_lock
 from app.git_manager import GitManager
 from app.git_safety import try_unstage_paths
@@ -138,6 +142,12 @@ def _restore_failed_retention_state(path: Path, old_bytes: bytes | None, exc: Ex
 
 def _load_fallback_envelope_payload(repo_root: Path, rel: str) -> dict[str, Any]:
     """Load and validate a fallback snapshot envelope payload."""
+    payload, _warnings = _load_fallback_envelope_payload_with_warnings(repo_root, rel)
+    return payload
+
+
+def _load_fallback_envelope_payload_with_warnings(repo_root: Path, rel: str) -> tuple[dict[str, Any], list[str]]:
+    """Load and validate a fallback snapshot envelope payload plus recovery warnings."""
     path = safe_path(repo_root, rel)
     if not path.exists() or not path.is_file():
         raise HTTPException(status_code=404, detail="Continuity fallback snapshot not found")
@@ -152,13 +162,12 @@ def _load_fallback_envelope_payload(repo_root: Path, rel: str) -> dict[str, Any]
     nested = payload.get("capsule")
     if not isinstance(nested, dict):
         raise HTTPException(status_code=400, detail="Invalid continuity fallback snapshot capsule")
+    nested, warnings = _sanitize_related_documents_on_read(_upgrade_legacy_structured_entry_timestamps(nested))
     try:
-        payload["capsule"] = ContinuityCapsule.model_validate(
-            _upgrade_legacy_structured_entry_timestamps(nested)
-        ).model_dump(mode="json", exclude_none=True)
+        payload["capsule"] = ContinuityCapsule.model_validate(nested).model_dump(mode="json", exclude_none=True)
     except ValidationError as e:
         raise HTTPException(status_code=400, detail=f"Invalid continuity fallback snapshot capsule: {e}") from e
-    return payload
+    return payload, warnings
 
 
 def _persist_fallback_snapshot(
@@ -211,14 +220,25 @@ def _delete_commit_message(subject_kind: str, subject_id: str, reason: str) -> s
 
 def _load_fallback_snapshot(repo_root: Path, rel: str, *, expected_subject: tuple[str, str]) -> dict[str, Any]:
     """Load and validate one fallback snapshot envelope, returning the nested capsule."""
-    payload = _load_fallback_envelope_payload(repo_root, rel)
+    capsule, _warnings = _load_fallback_snapshot_with_warnings(repo_root, rel, expected_subject=expected_subject)
+    return capsule
+
+
+def _load_fallback_snapshot_with_warnings(
+    repo_root: Path,
+    rel: str,
+    *,
+    expected_subject: tuple[str, str],
+) -> tuple[dict[str, Any], list[str]]:
+    """Load a fallback snapshot and return any degraded related_documents warnings."""
+    payload, warnings = _load_fallback_envelope_payload_with_warnings(repo_root, rel)
     capsule = payload["capsule"]
     expected_kind, expected_id = expected_subject
     capsule_kind = str(capsule.get("subject_kind") or "")
     capsule_subject_id = str(capsule.get("subject_id") or "")
     if capsule_kind != expected_kind or _normalize_subject_id(capsule_subject_id) != _normalize_subject_id(expected_id):
         raise HTTPException(status_code=400, detail="Continuity fallback snapshot subject does not match requested subject")
-    return capsule
+    return capsule, warnings
 
 
 def _load_archive_envelope(repo_root: Path, rel: str) -> dict[str, Any]:
@@ -243,10 +263,9 @@ def _load_archive_envelope(repo_root: Path, rel: str) -> dict[str, Any]:
     capsule = payload.get("capsule")
     if not isinstance(capsule, dict):
         raise HTTPException(status_code=400, detail="Invalid continuity archive envelope capsule")
+    capsule, _warnings = _sanitize_related_documents_on_read(_upgrade_legacy_structured_entry_timestamps(capsule))
     try:
-        payload["capsule"] = ContinuityCapsule.model_validate(
-            _upgrade_legacy_structured_entry_timestamps(capsule)
-        ).model_dump(mode="json", exclude_none=True)
+        payload["capsule"] = ContinuityCapsule.model_validate(capsule).model_dump(mode="json", exclude_none=True)
     except ValidationError as e:
         raise HTTPException(status_code=400, detail=f"Invalid continuity archive envelope capsule: {e}") from e
     return payload
@@ -254,21 +273,31 @@ def _load_archive_envelope(repo_root: Path, rel: str) -> dict[str, Any]:
 
 def _load_capsule(repo_root: Path, rel: str, *, expected_subject: tuple[str, str] | None = None) -> dict[str, Any]:
     """Load one capsule from disk and enforce optional subject matching."""
+    capsule, _warnings = _load_capsule_with_warnings(repo_root, rel, expected_subject=expected_subject)
+    return capsule
+
+
+def _load_capsule_with_warnings(
+    repo_root: Path,
+    rel: str,
+    *,
+    expected_subject: tuple[str, str] | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Load one capsule from disk and return any degraded related_documents warnings."""
     path = safe_path(repo_root, rel)
     if not path.exists() or not path.is_file():
         raise HTTPException(status_code=404, detail="Continuity capsule not found")
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-        capsule = ContinuityCapsule.model_validate(
-            _upgrade_legacy_structured_entry_timestamps(payload)
-        ).model_dump(mode="json", exclude_none=True)
+        payload, warnings = _sanitize_related_documents_on_read(_upgrade_legacy_structured_entry_timestamps(payload))
+        capsule = ContinuityCapsule.model_validate(payload).model_dump(mode="json", exclude_none=True)
         if expected_subject is not None:
             expected_kind, expected_id = expected_subject
             capsule_kind = str(capsule.get("subject_kind") or "")
             capsule_subject_id = str(capsule.get("subject_id") or "")
             if capsule_kind != expected_kind or _normalize_subject_id(capsule_subject_id) != _normalize_subject_id(expected_id):
                 raise HTTPException(status_code=400, detail="Continuity capsule subject does not match requested subject")
-        return capsule
+        return capsule, warnings
     except json.JSONDecodeError as e:
         raise HTTPException(status_code=400, detail=f"Invalid continuity capsule JSON: {e}") from e
     except ValidationError as e:

--- a/app/continuity/service.py
+++ b/app/continuity/service.py
@@ -113,9 +113,10 @@ from app.continuity.compare import (
 from app.continuity.persistence import (
     _delete_commit_message,
     _load_archive_envelope,
+    _load_capsule_with_warnings,
     _load_capsule,
     _load_fallback_envelope_payload,
-    _load_fallback_snapshot,
+    _load_fallback_snapshot_with_warnings,
     _persist_active_capsule,
     _persist_fallback_snapshot,
     _reject_stale_or_conflicting_write,
@@ -489,6 +490,8 @@ def continuity_upsert_service(
 ) -> dict[str, Any]:
     """Validate and persist one continuity capsule with commit-on-change behavior."""
     auth.require("write:projects")
+    if "related_documents" in req.capsule.continuity.model_fields_set and req.capsule.continuity.related_documents is None:
+        raise HTTPException(status_code=400, detail="Invalid value type in continuity.related_documents[]")
     capsule = _strip_verification_fields_for_upsert(req.capsule)
     if capsule.subject_kind != req.subject_kind or capsule.subject_id != req.subject_id:
         raise HTTPException(status_code=400, detail="Capsule subject does not match request subject")
@@ -1116,7 +1119,12 @@ def continuity_read_service(
     fallback_rel = continuity_fallback_rel_path(req.subject_kind, req.subject_id)
     recovery_warnings: list[str] = []
     try:
-        capsule = _load_capsule(repo_root, rel, expected_subject=(req.subject_kind, req.subject_id))
+        capsule, related_document_warnings = _load_capsule_with_warnings(
+            repo_root,
+            rel,
+            expected_subject=(req.subject_kind, req.subject_id),
+        )
+        recovery_warnings.extend(related_document_warnings)
         out = {
             "ok": True,
             "path": rel,
@@ -1138,8 +1146,13 @@ def continuity_read_service(
             raise
         auth.require_read_path(fallback_rel)
         try:
-            capsule = _load_fallback_snapshot(repo_root, fallback_rel, expected_subject=(req.subject_kind, req.subject_id))
+            capsule, related_document_warnings = _load_fallback_snapshot_with_warnings(
+                repo_root,
+                fallback_rel,
+                expected_subject=(req.subject_kind, req.subject_id),
+            )
             recovery_warnings.append(CONTINUITY_WARNING_FALLBACK_USED)
+            recovery_warnings.extend(related_document_warnings)
             out = {
                 "ok": True,
                 "path": rel,

--- a/app/continuity/validation.py
+++ b/app/continuity/validation.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import copy
+import posixpath
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -30,6 +32,19 @@ from app.timestamps import format_iso, parse_iso as _parse_iso
 
 
 _LEGACY_TIMESTAMP_FLOOR = "1970-01-01T00:00:00Z"
+_RELATED_DOCUMENTS_ALLOWED_KEYS = frozenset({"path", "kind", "label", "relevance"})
+_RELATED_DOCUMENTS_REQUIRED_KEYS = ("path", "kind", "label")
+_RELATED_DOCUMENTS_KEY_ORDER = ("path", "kind", "label", "relevance")
+_RELATED_DOCUMENTS_RESERVED_KEYS = frozenset({"content", "body", "text", "excerpt", "markdown", "html", "payload"})
+_RELATED_DOCUMENTS_RELEVANCE = frozenset({"primary", "supporting", "background"})
+_RELATED_DOCUMENTS_PATH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+_RELATED_DOCUMENTS_KIND_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_RELATED_DOCUMENTS_PATH_MAX = 240
+_RELATED_DOCUMENTS_KIND_MAX = 32
+_RELATED_DOCUMENTS_LABEL_MAX = 120
+_RELATED_DOCUMENTS_RELEVANCE_MAX = 32
+_RELATED_DOCUMENTS_MAX_ENTRIES = 8
+_MISSING = object()
 
 
 def _upgrade_legacy_structured_entry_timestamps(payload: dict[str, Any]) -> dict[str, Any]:
@@ -122,6 +137,256 @@ def _validate_repo_relative_paths(repo_root: Path, paths: list[str], field_name:
             safe_path(repo_root, rel)
         except StorageError as e:
             raise HTTPException(status_code=400, detail=f"Invalid repo-relative path in {field_name}: {e}") from e
+
+
+def _contains_reserved_related_documents_key(value: Any) -> bool:
+    """Return True when any reserved embedded-content key exists recursively."""
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key in _RELATED_DOCUMENTS_RESERVED_KEYS:
+                return True
+            if _contains_reserved_related_documents_key(nested):
+                return True
+        return False
+    if isinstance(value, list):
+        return any(_contains_reserved_related_documents_key(item) for item in value)
+    return False
+
+
+def _is_valid_related_document_path(value: str) -> bool:
+    """Apply the lexical-only #217 path rules for related_documents[].path."""
+    if not _RELATED_DOCUMENTS_PATH_RE.match(value):
+        return False
+    if value.startswith("/") or ".." in value:
+        return False
+    normalized = posixpath.normpath(value)
+    if normalized == ".." or normalized.startswith("../") or normalized.startswith("/"):
+        return False
+    return True
+
+
+def _related_documents_failure_key(category: int, *parts: int) -> tuple[int, ...]:
+    """Build a sortable precedence key for one related_documents failure."""
+    return (category, *parts)
+
+
+def _iter_related_documents_failures(value: Any) -> list[tuple[tuple[int, ...], str]]:
+    """Return all deterministic write-time validation failures for related_documents."""
+    failures: list[tuple[tuple[int, ...], str]] = []
+
+    if _contains_reserved_related_documents_key(value):
+        failures.append(
+            (
+                _related_documents_failure_key(1),
+                "Embedded content is not allowed in continuity.related_documents[]",
+            )
+        )
+
+    if not isinstance(value, list):
+        failures.append(
+            (
+                _related_documents_failure_key(3, -1),
+                "Invalid value type in continuity.related_documents[]",
+            )
+        )
+        return failures
+
+    if len(value) > _RELATED_DOCUMENTS_MAX_ENTRIES:
+        failures.append(
+            (
+                _related_documents_failure_key(11),
+                "Too many entries in continuity.related_documents",
+            )
+        )
+
+    seen_duplicates: dict[tuple[str, str, str, object], int] = {}
+
+    for entry_index, entry in enumerate(value):
+        if not isinstance(entry, dict):
+            failures.append(
+                (
+                    _related_documents_failure_key(3, entry_index, len(_RELATED_DOCUMENTS_KEY_ORDER)),
+                    "Invalid value type in continuity.related_documents[]",
+                )
+            )
+            continue
+
+        unknown_keys = sorted(key for key in entry if key not in _RELATED_DOCUMENTS_ALLOWED_KEYS and key not in _RELATED_DOCUMENTS_RESERVED_KEYS)
+        if unknown_keys:
+            failures.append(
+                (
+                    _related_documents_failure_key(2, entry_index, 0),
+                    "Unknown key in continuity.related_documents[]",
+                )
+            )
+
+        for key_rank, key_name in enumerate(_RELATED_DOCUMENTS_REQUIRED_KEYS):
+            if key_name not in entry:
+                failures.append(
+                    (
+                        _related_documents_failure_key(4, entry_index, key_rank),
+                        "Missing required key in continuity.related_documents[]",
+                    )
+                )
+
+        candidate_for_duplicate = True
+        duplicate_parts: list[str] = []
+
+        for key_rank, key_name in enumerate(_RELATED_DOCUMENTS_KEY_ORDER):
+            raw = entry.get(key_name, _MISSING)
+            if raw is _MISSING:
+                if key_name == "relevance":
+                    duplicate_parts.append("")
+                else:
+                    candidate_for_duplicate = False
+                continue
+
+            if not isinstance(raw, str):
+                failures.append(
+                    (
+                        _related_documents_failure_key(3, entry_index, key_rank),
+                        "Invalid value type in continuity.related_documents[]",
+                    )
+                )
+                candidate_for_duplicate = False
+                continue
+
+            if raw == "":
+                failures.append(
+                    (
+                        _related_documents_failure_key(7, entry_index, key_rank),
+                        "Value too short in continuity.related_documents[]",
+                    )
+                )
+                candidate_for_duplicate = False
+                continue
+
+            if raw != raw.strip() or raw.strip() == "":
+                failures.append(
+                    (
+                        _related_documents_failure_key(8, entry_index, key_rank),
+                        "Leading or trailing whitespace is not allowed in continuity.related_documents[]",
+                    )
+                )
+                candidate_for_duplicate = False
+                continue
+
+            if key_name == "path":
+                if len(raw) > _RELATED_DOCUMENTS_PATH_MAX:
+                    failures.append(
+                        (
+                            _related_documents_failure_key(9, entry_index, key_rank),
+                            "Value too long in continuity.related_documents[].path",
+                        )
+                    )
+                    candidate_for_duplicate = False
+                elif not _is_valid_related_document_path(raw):
+                    failures.append(
+                        (
+                            _related_documents_failure_key(5, entry_index, key_rank),
+                            "Invalid path in continuity.related_documents[].path",
+                        )
+                    )
+                    candidate_for_duplicate = False
+            elif key_name == "kind":
+                if len(raw) > _RELATED_DOCUMENTS_KIND_MAX:
+                    failures.append(
+                        (
+                            _related_documents_failure_key(9, entry_index, key_rank),
+                            "Value too long in continuity.related_documents[].kind",
+                        )
+                    )
+                    candidate_for_duplicate = False
+                elif not _RELATED_DOCUMENTS_KIND_RE.match(raw):
+                    failures.append(
+                        (
+                            _related_documents_failure_key(6, entry_index, key_rank),
+                            "Invalid kind format in continuity.related_documents[]",
+                        )
+                    )
+                    candidate_for_duplicate = False
+            elif key_name == "label":
+                if len(raw) > _RELATED_DOCUMENTS_LABEL_MAX:
+                    failures.append(
+                        (
+                            _related_documents_failure_key(9, entry_index, key_rank),
+                            "Value too long in continuity.related_documents[].label",
+                        )
+                    )
+                    candidate_for_duplicate = False
+            elif key_name == "relevance":
+                if len(raw) > _RELATED_DOCUMENTS_RELEVANCE_MAX:
+                    failures.append(
+                        (
+                            _related_documents_failure_key(9, entry_index, key_rank),
+                            "Value too long in continuity.related_documents[].relevance",
+                        )
+                    )
+                    candidate_for_duplicate = False
+                elif raw not in _RELATED_DOCUMENTS_RELEVANCE:
+                    failures.append(
+                        (
+                            _related_documents_failure_key(6, entry_index, key_rank),
+                            "Invalid relevance in continuity.related_documents[]",
+                        )
+                    )
+                    candidate_for_duplicate = False
+
+            duplicate_parts.append(raw)
+
+        if candidate_for_duplicate:
+            duplicate_key = (
+                duplicate_parts[0],
+                duplicate_parts[1],
+                duplicate_parts[2],
+                _MISSING if "relevance" not in entry else duplicate_parts[3],
+            )
+            first_index = seen_duplicates.get(duplicate_key)
+            if first_index is None:
+                seen_duplicates[duplicate_key] = entry_index
+            else:
+                failures.append(
+                    (
+                        _related_documents_failure_key(10, entry_index, first_index),
+                        "Duplicate related_documents entry",
+                    )
+                )
+
+    return failures
+
+
+def _validate_related_documents_on_write(value: Any, *, field_present: bool) -> Any:
+    """Validate raw related_documents input and return the original value on success."""
+    if not field_present:
+        return None
+    failures = _iter_related_documents_failures(value)
+    if failures:
+        _sort_key, detail = min(failures, key=lambda item: item[0])
+        raise HTTPException(status_code=400, detail=detail)
+    if value is None:
+        raise HTTPException(status_code=400, detail="Invalid value type in continuity.related_documents[]")
+    return value
+
+
+def _sanitize_related_documents_on_read(payload: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Omit malformed stored related_documents and return any degraded-read warnings."""
+    continuity = payload.get("continuity")
+    if not isinstance(continuity, dict) or "related_documents" not in continuity:
+        return payload, []
+    value = continuity.get("related_documents")
+    if not _iter_related_documents_failures(value):
+        return payload, []
+
+    warning = (
+        "related_documents_omitted_non_metadata"
+        if _contains_reserved_related_documents_key(value)
+        else "related_documents_omitted_invalid"
+    )
+    sanitized = copy.deepcopy(payload)
+    sanitized_continuity = sanitized.get("continuity")
+    if isinstance(sanitized_continuity, dict):
+        sanitized_continuity.pop("related_documents", None)
+    return sanitized, [warning]
 
 
 def _validate_low_commitment_fields(capsule: ContinuityCapsule) -> None:
@@ -364,6 +629,11 @@ def _validate_capsule(repo_root: Path, capsule: ContinuityCapsule) -> tuple[dict
                         status_code=400,
                         detail=f"rationale_entries[].supersedes references tag '{entry.supersedes}' which does not exist with status 'superseded'",
                     )
+    if capsule.continuity.related_documents is not None:
+        capsule.continuity.related_documents = _validate_related_documents_on_write(
+            capsule.continuity.related_documents,
+            field_present=True,
+        )
     _validate_thread_descriptor(capsule)
     payload = capsule.model_dump(mode="json", exclude_none=True)
     canonical = canonical_json(payload)

--- a/app/models.py
+++ b/app/models.py
@@ -753,6 +753,7 @@ class ContinuityState(BaseModel):
     trailing_notes: List[str] = Field(default_factory=list, max_length=3)
     curiosity_queue: List[str] = Field(default_factory=list, max_length=5)
     rationale_entries: List[RationaleEntry] = Field(default_factory=list, max_length=6)
+    related_documents: Any | None = None
     relationship_model: Optional[ContinuityRelationshipModel] = None
     retrieval_hints: Optional[ContinuityRetrievalHints] = None
 

--- a/app/models.py
+++ b/app/models.py
@@ -4,10 +4,48 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, model_validator
+from pydantic.json_schema import SkipJsonSchema
 
 
 PeerId = Annotated[str, Field(min_length=1, max_length=200)]
+
+_RELATED_DOCUMENTS_RELEVANCE = ("primary", "supporting", "background")
+_RELATED_DOCUMENTS_SCHEMA = {
+    "type": "array",
+    "maxItems": 8,
+    "items": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 240,
+                "pattern": r"^[A-Za-z0-9._/-]+$",
+            },
+            "kind": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 32,
+                "pattern": r"^[a-z][a-z0-9_]*$",
+            },
+            "label": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 120,
+            },
+            "relevance": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 32,
+                "enum": list(_RELATED_DOCUMENTS_RELEVANCE),
+            },
+        },
+        "required": ["path", "kind", "label"],
+        "additionalProperties": False,
+    },
+}
+RelatedDocumentsSchemaField = Annotated[Any, WithJsonSchema(_RELATED_DOCUMENTS_SCHEMA)]
 
 
 class WriteRequest(BaseModel):
@@ -753,7 +791,7 @@ class ContinuityState(BaseModel):
     trailing_notes: List[str] = Field(default_factory=list, max_length=3)
     curiosity_queue: List[str] = Field(default_factory=list, max_length=5)
     rationale_entries: List[RationaleEntry] = Field(default_factory=list, max_length=6)
-    related_documents: Any | None = None
+    related_documents: RelatedDocumentsSchemaField | SkipJsonSchema[None] = None
     relationship_model: Optional[ContinuityRelationshipModel] = None
     retrieval_hints: Optional[ContinuityRetrievalHints] = None
 

--- a/app/models.py
+++ b/app/models.py
@@ -22,6 +22,12 @@ _RELATED_DOCUMENTS_SCHEMA = {
                 "minLength": 1,
                 "maxLength": 240,
                 "pattern": r"^[A-Za-z0-9._/-]+$",
+                "description": (
+                    "Repo-relative lexical path only. Must not start with '/'; "
+                    "must not contain '..'; '/' is the only allowed separator; "
+                    "normalization is lexical-only; and the lexically normalized "
+                    "path must remain under the repo root."
+                ),
             },
             "kind": {
                 "type": "string",

--- a/tests/test_continuity_176_preserve.py
+++ b/tests/test_continuity_176_preserve.py
@@ -355,6 +355,39 @@ class TestPreserveOptionalListFields(unittest.TestCase):
             self.assertEqual(stored_decision["created_at"], _STORED_TS)
             self.assertEqual(stored_decision["updated_at"], _STORED_TS)
 
+    def test_absent_preserves_stored_related_documents(self) -> None:
+        """When related_documents is absent from raw JSON, preserve mode keeps the stored list."""
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td)
+            stored = _base_capsule()
+            stored["continuity"]["related_documents"] = [
+                {
+                    "path": "docs/stored-spec.md",
+                    "kind": "spec",
+                    "label": "Stored spec",
+                    "relevance": "primary",
+                }
+            ]
+            _seed_capsule(repo, stored)
+            cap = _incoming_capsule()
+            raw_cap = dict(cap)
+            raw_cap["continuity"] = {
+                "top_priorities": [],
+                "active_concerns": [],
+                "active_constraints": [],
+                "open_loops": [],
+                "stance_summary": "New stance summary for the incoming capsule test",
+                "drift_signals": [],
+            }
+            raw = _build_raw_body(raw_cap)
+            out = _do_upsert(repo, cap, merge_mode="preserve", raw_body=raw)
+            self.assertTrue(out["ok"])
+            written = _read_stored(repo)
+            self.assertEqual(
+                written["continuity"]["related_documents"],
+                stored["continuity"]["related_documents"],
+            )
+
     def test_empty_list_overrides_to_empty(self) -> None:
         """Sending [] for an optional list field overrides to empty list."""
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_related_documents_217_slice1.py
+++ b/tests/test_related_documents_217_slice1.py
@@ -18,6 +18,8 @@ from app.continuity.service import continuity_read_service, continuity_upsert_se
 from app.models import ContinuityReadRequest, ContinuityUpsertRequest, ContextRetrieveRequest
 from tests.helpers import AllowAllAuthStub, SimpleGitManagerStub
 
+_MISSING = object()
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -34,7 +36,7 @@ def _settings(repo_root: Path) -> Settings:
     )
 
 
-def _base_capsule_payload(*, related_documents: object | None = None) -> dict:
+def _base_capsule_payload(*, related_documents: object = _MISSING) -> dict:
     now = _now_iso()
     continuity: dict[str, object] = {
         "top_priorities": ["ship #217 slice"],
@@ -44,7 +46,7 @@ def _base_capsule_payload(*, related_documents: object | None = None) -> dict:
         "stance_summary": "Implement the bounded runtime slice without changing unrelated semantics.",
         "drift_signals": [],
     }
-    if related_documents is not None:
+    if related_documents is not _MISSING:
         continuity["related_documents"] = related_documents
     return {
         "schema_version": "1.0",
@@ -229,6 +231,11 @@ class TestRelatedDocuments217Slice1(unittest.TestCase):
             (
                 "wrong top-level type",
                 {"path": "docs/payload-reference.md"},
+                "Invalid value type in continuity.related_documents[]",
+            ),
+            (
+                "explicit null",
+                None,
                 "Invalid value type in continuity.related_documents[]",
             ),
             (
@@ -497,6 +504,12 @@ class TestRelatedDocuments217Slice1(unittest.TestCase):
                     "minLength": 1,
                     "maxLength": 240,
                     "pattern": r"^[A-Za-z0-9._/-]+$",
+                    "description": (
+                        "Repo-relative lexical path only. Must not start with '/'; "
+                        "must not contain '..'; '/' is the only allowed separator; "
+                        "normalization is lexical-only; and the lexically normalized "
+                        "path must remain under the repo root."
+                    ),
                 },
                 "kind": {
                     "type": "string",

--- a/tests/test_related_documents_217_slice1.py
+++ b/tests/test_related_documents_217_slice1.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import HTTPException
 
+from app.main import discovery_tools
 from app.config import Settings
 from app.context import context_retrieve_service
 from app.continuity.service import continuity_read_service, continuity_upsert_service
@@ -113,6 +115,15 @@ class TestRelatedDocuments217Slice1(unittest.TestCase):
             audit=lambda *_args, **_kwargs: None,
         )
 
+    def _assert_upsert_detail(self, related_documents: object, expected_detail: str) -> None:
+        payload = _base_capsule_payload(related_documents=related_documents)
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, expected_detail)
+
     def test_upsert_persists_valid_related_documents(self) -> None:
         payload = _base_capsule_payload(
             related_documents=[
@@ -130,7 +141,7 @@ class TestRelatedDocuments217Slice1(unittest.TestCase):
         stored = continuity_read_service(
             repo_root=self.repo_root,
             auth=self.auth,
-            req=ContinuityReadRequest(subject_kind="user", subject_id="stef"),
+            req=ContinuityReadRequest(subject_kind="user", subject_id="stef", allow_fallback=True),
             now=datetime.now(timezone.utc),
             audit=lambda *_args, **_kwargs: None,
         )
@@ -173,73 +184,116 @@ class TestRelatedDocuments217Slice1(unittest.TestCase):
         self.assertEqual(ctx.exception.status_code, 400)
         self.assertEqual(ctx.exception.detail, "Invalid path in continuity.related_documents[].path")
 
-    def test_upsert_rejects_whitespace_only_label_with_whitespace_detail(self) -> None:
-        payload = _base_capsule_payload(
-            related_documents=[_related_document(label="   ")]
-        )
-
-        with self.assertRaises(HTTPException) as ctx:
-            self._upsert(payload)
-
-        self.assertEqual(ctx.exception.status_code, 400)
-        self.assertEqual(
-            ctx.exception.detail,
-            "Leading or trailing whitespace is not allowed in continuity.related_documents[]",
-        )
-
-    def test_upsert_rejects_non_list_related_documents_with_invalid_type_detail(self) -> None:
-        payload = _base_capsule_payload(
-            related_documents={"path": "docs/payload-reference.md"}
-        )
-
-        with self.assertRaises(HTTPException) as ctx:
-            self._upsert(payload)
-
-        self.assertEqual(ctx.exception.status_code, 400)
-        self.assertEqual(ctx.exception.detail, "Invalid value type in continuity.related_documents[]")
-
-    def test_upsert_rejects_invalid_kind_and_relevance_with_kind_precedence(self) -> None:
-        payload = _base_capsule_payload(
-            related_documents=[
-                _related_document(
-                    kind="Spec",
-                    relevance="secondary",
-                )
-            ]
-        )
-
-        with self.assertRaises(HTTPException) as ctx:
-            self._upsert(payload)
-
-        self.assertEqual(ctx.exception.status_code, 400)
-        self.assertEqual(ctx.exception.detail, "Invalid kind format in continuity.related_documents[]")
-
-    def test_upsert_rejects_duplicate_entries_when_relevance_omitted_on_both(self) -> None:
+    def test_upsert_rejects_named_invalid_related_documents_classes(self) -> None:
+        over_count = [
+            _related_document(path=f"docs/spec-{index}.md", label=f"Spec {index}")
+            for index in range(9)
+        ]
         duplicate = _related_document(relevance=None)
-        payload = _base_capsule_payload(related_documents=[duplicate, dict(duplicate)])
-
-        with self.assertRaises(HTTPException) as ctx:
-            self._upsert(payload)
-
-        self.assertEqual(ctx.exception.status_code, 400)
-        self.assertEqual(ctx.exception.detail, "Duplicate related_documents entry")
-
-    def test_upsert_rejects_more_than_eight_related_documents(self) -> None:
-        payload = _base_capsule_payload(
-            related_documents=[
-                _related_document(
-                    path=f"docs/spec-{index}.md",
-                    label=f"Spec {index}",
-                )
-                for index in range(9)
-            ]
+        cases: Sequence[tuple[str, object, str]] = (
+            (
+                "missing required key",
+                [{"kind": "spec", "label": "Spec"}],
+                "Missing required key in continuity.related_documents[]",
+            ),
+            (
+                "unknown key",
+                [{"path": "docs/spec.md", "kind": "spec", "label": "Spec", "note": "unexpected"}],
+                "Unknown key in continuity.related_documents[]",
+            ),
+            (
+                "whitespace-only string",
+                [_related_document(label="   ")],
+                "Leading or trailing whitespace is not allowed in continuity.related_documents[]",
+            ),
+            (
+                "leading/trailing whitespace",
+                [_related_document(label=" Spec ")],
+                "Leading or trailing whitespace is not allowed in continuity.related_documents[]",
+            ),
+            (
+                "empty string",
+                [_related_document(label="")],
+                "Value too short in continuity.related_documents[]",
+            ),
+            (
+                "invalid relevance alone",
+                [_related_document(relevance="secondary")],
+                "Invalid relevance in continuity.related_documents[]",
+            ),
+            (
+                "invalid kind format alone",
+                [_related_document(kind="Spec")],
+                "Invalid kind format in continuity.related_documents[]",
+            ),
+            (
+                "wrong top-level type",
+                {"path": "docs/payload-reference.md"},
+                "Invalid value type in continuity.related_documents[]",
+            ),
+            (
+                "wrong entry type",
+                ["docs/spec.md"],
+                "Invalid value type in continuity.related_documents[]",
+            ),
+            (
+                "over-count",
+                over_count,
+                "Too many entries in continuity.related_documents",
+            ),
+            (
+                "over-length path",
+                [_related_document(path=f"docs/{'a' * 236}")],
+                "Value too long in continuity.related_documents[].path",
+            ),
+            (
+                "over-length kind",
+                [_related_document(kind="a" * 33)],
+                "Value too long in continuity.related_documents[].kind",
+            ),
+            (
+                "over-length label",
+                [_related_document(label="x" * 121)],
+                "Value too long in continuity.related_documents[].label",
+            ),
+            (
+                "over-length relevance",
+                [_related_document(relevance="a" * 33)],
+                "Value too long in continuity.related_documents[].relevance",
+            ),
+            (
+                "duplicate with omitted relevance equality",
+                [duplicate, dict(duplicate)],
+                "Duplicate related_documents entry",
+            ),
+            (
+                "invalid path with ..",
+                [_related_document(path="docs/../spec.md")],
+                "Invalid path in continuity.related_documents[].path",
+            ),
+            (
+                "invalid path with backslash",
+                [_related_document(path=r"docs\\spec.md")],
+                "Invalid path in continuity.related_documents[].path",
+            ),
         )
 
-        with self.assertRaises(HTTPException) as ctx:
-            self._upsert(payload)
+        for name, related_documents, expected_detail in cases:
+            with self.subTest(name=name):
+                self._assert_upsert_detail(related_documents, expected_detail)
 
-        self.assertEqual(ctx.exception.status_code, 400)
-        self.assertEqual(ctx.exception.detail, "Too many entries in continuity.related_documents")
+    def test_upsert_rejects_reserved_embedded_content_key_alone(self) -> None:
+        self._assert_upsert_detail(
+            [
+                {
+                    "path": "docs/spec.md",
+                    "kind": "spec",
+                    "label": "Spec",
+                    "content": "forbidden",
+                }
+            ],
+            "Embedded content is not allowed in continuity.related_documents[]",
+        )
 
     def test_read_omits_invalid_related_documents_with_non_metadata_warning(self) -> None:
         payload = _base_capsule_payload(
@@ -294,3 +348,172 @@ class TestRelatedDocuments217Slice1(unittest.TestCase):
         self.assertIn("related_documents_omitted_invalid", continuity_state["recovery_warnings"])
         capsule = continuity_state["capsules"][0]
         self.assertNotIn("related_documents", capsule["continuity"])
+
+    def test_read_omits_nested_reserved_key_with_non_metadata_warning(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "spec",
+                    "label": "Spec",
+                    "payload": {"meta": {"nested": {"body": "forbidden"}}},
+                }
+            ]
+        )
+        _write_active_capsule(self.repo_root, payload)
+
+        out = continuity_read_service(
+            repo_root=self.repo_root,
+            auth=self.auth,
+            req=ContinuityReadRequest(subject_kind="user", subject_id="stef", allow_fallback=True),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(out["recovery_warnings"], ["related_documents_omitted_non_metadata"])
+        self.assertNotIn("related_documents", out["capsule"]["continuity"])
+
+    def test_read_emits_exactly_one_warning_for_multiple_invalid_classes(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                {
+                    "path": "docs/../spec.md",
+                    "kind": "Spec",
+                    "label": "Spec",
+                    "note": "unexpected",
+                }
+            ]
+        )
+        _write_active_capsule(self.repo_root, payload)
+
+        out = continuity_read_service(
+            repo_root=self.repo_root,
+            auth=self.auth,
+            req=ContinuityReadRequest(subject_kind="user", subject_id="stef", allow_fallback=True),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(out["recovery_warnings"], ["related_documents_omitted_invalid"])
+        self.assertNotIn("related_documents", out["capsule"]["continuity"])
+
+    def test_read_appends_related_documents_warning_to_existing_recovery_warnings(self) -> None:
+        fallback_payload = _base_capsule_payload(
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "Spec",
+                    "label": "Spec",
+                }
+            ]
+        )
+        fallback_target = self.repo_root / "memory" / "continuity" / "fallback"
+        fallback_target.mkdir(parents=True, exist_ok=True)
+        (fallback_target / "user-stef.json").write_text(
+            json.dumps(
+                {
+                    "schema_type": "continuity_fallback_snapshot",
+                    "schema_version": "1.1",
+                    "captured_at": fallback_payload["updated_at"],
+                    "source_path": "memory/continuity/user-stef.json",
+                    "verification_status": "unverified",
+                    "health_status": "healthy",
+                    "capsule": fallback_payload,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        out = continuity_read_service(
+            repo_root=self.repo_root,
+            auth=self.auth,
+            req=ContinuityReadRequest(
+                subject_kind="user",
+                subject_id="stef",
+                allow_fallback=True,
+            ),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(
+            out["recovery_warnings"],
+            [
+                "continuity_active_missing",
+                "continuity_fallback_used",
+                "related_documents_omitted_invalid",
+            ],
+        )
+        self.assertEqual(out["source_state"], "fallback")
+        self.assertNotIn("related_documents", out["capsule"]["continuity"])
+
+    def test_read_prefers_reserved_key_warning_over_generic_invalidity(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                {
+                    "path": "docs/../spec.md",
+                    "kind": "Spec",
+                    "label": "Spec",
+                    "payload": {"nested": {"body": "forbidden"}},
+                }
+            ]
+        )
+        _write_active_capsule(self.repo_root, payload)
+
+        out = continuity_read_service(
+            repo_root=self.repo_root,
+            auth=self.auth,
+            req=ContinuityReadRequest(subject_kind="user", subject_id="stef"),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(out["recovery_warnings"], ["related_documents_omitted_non_metadata"])
+        self.assertNotIn("related_documents", out["capsule"]["continuity"])
+
+    def test_public_schema_exposes_bounded_related_documents_contract(self) -> None:
+        payload = discovery_tools()
+        by_name = {tool["name"]: tool for tool in payload["tools"]}
+        schema = by_name["continuity.upsert"]["input_schema"]
+        continuity_ref = schema["$defs"]["ContinuityCapsule"]["properties"]["continuity"]["$ref"]
+        continuity_schema = schema["$defs"][continuity_ref.split("/")[-1]]
+        related_documents = continuity_schema["properties"]["related_documents"]
+
+        self.assertNotIn("related_documents", continuity_schema.get("required", []))
+        self.assertEqual(related_documents["type"], "array")
+        self.assertEqual(related_documents["maxItems"], 8)
+        self.assertNotIn("anyOf", related_documents)
+
+        items = related_documents["items"]
+        self.assertEqual(items["type"], "object")
+        self.assertEqual(items["required"], ["path", "kind", "label"])
+        self.assertFalse(items["additionalProperties"])
+        self.assertEqual(sorted(items["properties"]), ["kind", "label", "path", "relevance"])
+        self.assertEqual(
+            items["properties"],
+            {
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 240,
+                    "pattern": r"^[A-Za-z0-9._/-]+$",
+                },
+                "kind": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 32,
+                    "pattern": r"^[a-z][a-z0-9_]*$",
+                },
+                "label": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 120,
+                },
+                "relevance": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 32,
+                    "enum": ["primary", "supporting", "background"],
+                },
+            },
+        )

--- a/tests/test_related_documents_217_slice1.py
+++ b/tests/test_related_documents_217_slice1.py
@@ -1,0 +1,296 @@
+"""Tests for #217 slice 1: related_documents runtime validation and degradation."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from app.config import Settings
+from app.context import context_retrieve_service
+from app.continuity.service import continuity_read_service, continuity_upsert_service
+from app.models import ContinuityReadRequest, ContinuityUpsertRequest, ContextRetrieveRequest
+from tests.helpers import AllowAllAuthStub, SimpleGitManagerStub
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _settings(repo_root: Path) -> Settings:
+    return Settings(
+        repo_root=repo_root,
+        auto_init_git=False,
+        git_author_name="n/a",
+        git_author_email="n/a",
+        tokens={},
+        audit_log_enabled=False,
+    )
+
+
+def _base_capsule_payload(*, related_documents: object | None = None) -> dict:
+    now = _now_iso()
+    continuity: dict[str, object] = {
+        "top_priorities": ["ship #217 slice"],
+        "active_concerns": ["keep runtime deterministic"],
+        "active_constraints": ["avoid broad schema churn"],
+        "open_loops": ["land related_documents support"],
+        "stance_summary": "Implement the bounded runtime slice without changing unrelated semantics.",
+        "drift_signals": [],
+    }
+    if related_documents is not None:
+        continuity["related_documents"] = related_documents
+    return {
+        "schema_version": "1.0",
+        "subject_kind": "user",
+        "subject_id": "stef",
+        "updated_at": now,
+        "verified_at": now,
+        "verification_kind": "self_review",
+        "source": {
+            "producer": "test-suite",
+            "update_reason": "manual",
+            "inputs": [],
+        },
+        "continuity": continuity,
+        "confidence": {"continuity": 0.9, "relationship_model": 0.0},
+    }
+
+
+def _related_document(
+    *,
+    path: str = "docs/payload-reference.md",
+    kind: str = "spec",
+    label: str = "Payload reference",
+    relevance: str | None = "primary",
+) -> dict[str, str]:
+    entry = {
+        "path": path,
+        "kind": kind,
+        "label": label,
+    }
+    if relevance is not None:
+        entry["relevance"] = relevance
+    return entry
+
+
+def _write_active_capsule(repo_root: Path, payload: dict) -> None:
+    target = repo_root / "memory" / "continuity"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "user-stef.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestRelatedDocuments217Slice1(unittest.TestCase):
+    """Exercise the bounded related_documents runtime slice."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(self.tempdir.name)
+        self.settings = _settings(self.repo_root)
+        self.auth = AllowAllAuthStub()
+        self.gm = SimpleGitManagerStub(self.repo_root)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _upsert(self, payload: dict) -> dict:
+        req = ContinuityUpsertRequest.model_validate(
+            {
+                "subject_kind": payload["subject_kind"],
+                "subject_id": payload["subject_id"],
+                "capsule": payload,
+            }
+        )
+        return continuity_upsert_service(
+            repo_root=self.repo_root,
+            gm=self.gm,
+            auth=self.auth,
+            req=req,
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+    def test_upsert_persists_valid_related_documents(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                _related_document(),
+                _related_document(
+                    path="memory/notes/continuity-audit.md",
+                    kind="analysis_note",
+                    label="Continuity audit notes",
+                    relevance="supporting",
+                ),
+            ]
+        )
+
+        result = self._upsert(payload)
+        stored = continuity_read_service(
+            repo_root=self.repo_root,
+            auth=self.auth,
+            req=ContinuityReadRequest(subject_kind="user", subject_id="stef"),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(stored["recovery_warnings"], [])
+        self.assertEqual(stored["capsule"]["continuity"]["related_documents"], payload["continuity"]["related_documents"])
+
+    def test_upsert_rejects_reserved_embedded_content_key_with_highest_precedence(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                {
+                    "path": "docs/../payload-reference.md",
+                    "kind": "spec",
+                    "label": "Bad path still loses to embedded content precedence",
+                    "content": "forbidden",
+                }
+            ]
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "Embedded content is not allowed in continuity.related_documents[]")
+
+    def test_upsert_rejects_invalid_path_before_over_length_label(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                _related_document(
+                    path="/docs/spec.md",
+                    label="x" * 121,
+                )
+            ]
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "Invalid path in continuity.related_documents[].path")
+
+    def test_upsert_rejects_whitespace_only_label_with_whitespace_detail(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[_related_document(label="   ")]
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(
+            ctx.exception.detail,
+            "Leading or trailing whitespace is not allowed in continuity.related_documents[]",
+        )
+
+    def test_upsert_rejects_non_list_related_documents_with_invalid_type_detail(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents={"path": "docs/payload-reference.md"}
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "Invalid value type in continuity.related_documents[]")
+
+    def test_upsert_rejects_invalid_kind_and_relevance_with_kind_precedence(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                _related_document(
+                    kind="Spec",
+                    relevance="secondary",
+                )
+            ]
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "Invalid kind format in continuity.related_documents[]")
+
+    def test_upsert_rejects_duplicate_entries_when_relevance_omitted_on_both(self) -> None:
+        duplicate = _related_document(relevance=None)
+        payload = _base_capsule_payload(related_documents=[duplicate, dict(duplicate)])
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "Duplicate related_documents entry")
+
+    def test_upsert_rejects_more_than_eight_related_documents(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                _related_document(
+                    path=f"docs/spec-{index}.md",
+                    label=f"Spec {index}",
+                )
+                for index in range(9)
+            ]
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._upsert(payload)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, "Too many entries in continuity.related_documents")
+
+    def test_read_omits_invalid_related_documents_with_non_metadata_warning(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "spec",
+                    "label": "Spec",
+                    "payload": {"body": "forbidden"},
+                }
+            ]
+        )
+        _write_active_capsule(self.repo_root, payload)
+
+        out = continuity_read_service(
+            repo_root=self.repo_root,
+            auth=self.auth,
+            req=ContinuityReadRequest(subject_kind="user", subject_id="stef", view="startup"),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(out["recovery_warnings"], ["related_documents_omitted_non_metadata"])
+        self.assertNotIn("related_documents", out["capsule"]["continuity"])
+        self.assertIn("startup_summary", out)
+
+    def test_context_retrieve_omits_invalid_related_documents_with_invalid_warning(self) -> None:
+        payload = _base_capsule_payload(
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "Spec",
+                    "label": "Spec",
+                }
+            ]
+        )
+        _write_active_capsule(self.repo_root, payload)
+
+        out = context_retrieve_service(
+            repo_root=self.repo_root,
+            auth=self.auth,
+            req=ContextRetrieveRequest(
+                task="Load continuity",
+                subject_kind="user",
+                subject_id="stef",
+            ),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        continuity_state = out["bundle"]["continuity_state"]
+        self.assertIn("related_documents_omitted_invalid", continuity_state["recovery_warnings"])
+        capsule = continuity_state["capsules"][0]
+        self.assertNotIn("related_documents", capsule["continuity"])


### PR DESCRIPTION
Refs #217

## Summary
This PR lands `#217` slice 1 only.

This slice covers:
- `related_documents` public field and exported schema surface
- exact write-time validation for the bounded `related_documents` contract
- exact duplicate/path/embedded-content handling
- exact degraded-read omission and warning behavior
- preserve-mode consistency for the field
- regression coverage for the bounded slice-1 contract
- no limit-rebalance work yet

## Verification
- `./.venv/bin/python -m unittest tests.test_related_documents_217_slice1 -v`
- `./.venv/bin/python -m unittest tests.test_continuity_176_preserve -v`
- `./.venv/bin/python -m ruff check app tests tools`
