### PR TITLE
continuity: complete #217 related_documents slice 2 persistence

### DIFF
--- a/app/continuity/persistence.py
+++ b/app/continuity/persistence.py
@@ -243,6 +243,12 @@ def _load_fallback_snapshot_with_warnings(
 
 def _load_archive_envelope(repo_root: Path, rel: str) -> dict[str, Any]:
     """Load and validate an archive envelope."""
+    payload, _warnings = _load_archive_envelope_with_warnings(repo_root, rel)
+    return payload
+
+
+def _load_archive_envelope_with_warnings(repo_root: Path, rel: str) -> tuple[dict[str, Any], list[str]]:
+    """Load and validate an archive envelope plus degraded related_documents warnings."""
     path = safe_path(repo_root, rel)
     if not path.exists() or not path.is_file():
         raise HTTPException(status_code=404, detail="Continuity archive envelope not found")
@@ -263,12 +269,12 @@ def _load_archive_envelope(repo_root: Path, rel: str) -> dict[str, Any]:
     capsule = payload.get("capsule")
     if not isinstance(capsule, dict):
         raise HTTPException(status_code=400, detail="Invalid continuity archive envelope capsule")
-    capsule, _warnings = _sanitize_related_documents_on_read(_upgrade_legacy_structured_entry_timestamps(capsule))
+    capsule, warnings = _sanitize_related_documents_on_read(_upgrade_legacy_structured_entry_timestamps(capsule))
     try:
         payload["capsule"] = ContinuityCapsule.model_validate(capsule).model_dump(mode="json", exclude_none=True)
     except ValidationError as e:
         raise HTTPException(status_code=400, detail=f"Invalid continuity archive envelope capsule: {e}") from e
-    return payload
+    return payload, warnings
 
 
 def _load_capsule(repo_root: Path, rel: str, *, expected_subject: tuple[str, str] | None = None) -> dict[str, Any]:

--- a/app/continuity/service.py
+++ b/app/continuity/service.py
@@ -2296,7 +2296,9 @@ def continuity_cold_rehydrate_service(
                 # before deleting cold files and committing. ---
                 if cold_payload_file.exists() or cold_stub_file.exists():
                     try:
-                        _check_envelope = _load_archive_envelope(repo_root, source_archive_path)
+                        _check_envelope, _related_document_warnings = _load_archive_envelope_with_warnings(
+                            repo_root, source_archive_path
+                        )
                         if _archive_rel_path_from_envelope(_check_envelope) == source_archive_path:
                             cold_payload_file.unlink(missing_ok=True)
                             cold_stub_file.unlink(missing_ok=True)
@@ -2330,6 +2332,9 @@ def continuity_cold_rehydrate_service(
                                         "Crash recovery completed on disk but git commit failed; state is not yet durable",
                                     ),
                                 )
+                            _rh_recovery_warning_codes = [
+                                warning["code"] for warning in _rh_warnings if isinstance(warning.get("code"), str)
+                            ]
                             return {
                                 "ok": True,
                                 "artifact_state": "archived",
@@ -2342,7 +2347,7 @@ def continuity_cold_rehydrate_service(
                                 "durable": _rh_recovery_committed,
                                 "latest_commit": gm.latest_commit(),
                                 "warnings": _rh_warnings,
-                                "recovery_warnings": _rh_warnings,
+                                "recovery_warnings": [*_rh_recovery_warning_codes, *_related_document_warnings],
                             }
                     except Exception:
                         _logger.warning(

--- a/app/continuity/service.py
+++ b/app/continuity/service.py
@@ -97,6 +97,7 @@ from app.continuity.validation import (
     _normalize_capsule_fields,
     _normalize_compare_payload,
     _require_utc_timestamp,
+    _sanitize_related_documents_on_read,
     _strip_service_managed_descriptor_fields,
     _strip_verification_fields_for_upsert,
     _upgrade_legacy_structured_entry_timestamps,
@@ -113,6 +114,7 @@ from app.continuity.compare import (
 from app.continuity.persistence import (
     _delete_commit_message,
     _load_archive_envelope,
+    _load_archive_envelope_with_warnings,
     _load_capsule_with_warnings,
     _load_capsule,
     _load_fallback_envelope_payload,
@@ -2150,7 +2152,7 @@ def continuity_cold_store_service(
 
     if not archive_path.exists() or not archive_path.is_file():
         raise HTTPException(status_code=404, detail="Continuity archive envelope not found")
-    envelope = _load_archive_envelope(repo_root, source_archive_path)
+    envelope, related_document_warnings = _load_archive_envelope_with_warnings(repo_root, source_archive_path)
     capsule = envelope["capsule"]
     with _continuity_subject_lock(
         repo_root=repo_root,
@@ -2167,7 +2169,7 @@ def continuity_cold_store_service(
             raise HTTPException(status_code=409, detail=f"Continuity archive envelope changed during cold-store: {exc.filename or exc}") from exc
 
         try:
-            envelope = _load_archive_envelope(repo_root, source_archive_path)
+            envelope, related_document_warnings = _load_archive_envelope_with_warnings(repo_root, source_archive_path)
             if _archive_rel_path_from_envelope(envelope) != source_archive_path:
                 raise HTTPException(status_code=400, detail="Continuity archive envelope identity does not match source_archive_path")
             # Crash recovery: if both archive and cold artifacts exist,
@@ -2246,7 +2248,7 @@ def continuity_cold_store_service(
         "durable": True,
         "latest_commit": gm.latest_commit(),
         "warnings": [],
-        "recovery_warnings": [],
+        "recovery_warnings": related_document_warnings,
     }
 
 
@@ -2359,7 +2361,9 @@ def continuity_cold_rehydrate_service(
             if payload.get("schema_version") not in CONTINUITY_SUPPORTED_ARCHIVE_SCHEMA_VERSIONS:
                 raise ValueError("wrong schema_version")
             raw_capsule = payload.get("capsule") or {}
-            upgraded_capsule = _upgrade_legacy_structured_entry_timestamps(raw_capsule)
+            upgraded_capsule, related_document_warnings = _sanitize_related_documents_on_read(
+                _upgrade_legacy_structured_entry_timestamps(raw_capsule)
+            )
             capsule = ContinuityCapsule.model_validate(
                 upgraded_capsule
             ).model_dump(mode="json", exclude_none=True)
@@ -2445,7 +2449,7 @@ def continuity_cold_rehydrate_service(
         "durable": True,
         "latest_commit": gm.latest_commit(),
         "warnings": [],
-        "recovery_warnings": [],
+        "recovery_warnings": related_document_warnings,
     }
 
 

--- a/tests/test_related_documents_217_slice2.py
+++ b/tests/test_related_documents_217_slice2.py
@@ -1,0 +1,160 @@
+"""Tests for #217 slice 2 persistence-path related_documents behavior."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from app.continuity.service import (
+    continuity_cold_rehydrate_service,
+    continuity_cold_store_service,
+)
+from app.models import ContinuityColdRehydrateRequest, ContinuityColdStoreRequest
+from tests.helpers import AllowAllAuthStub, SimpleGitManagerStub
+
+
+def _archive_rel(subject_id: str) -> str:
+    return f"memory/continuity/archive/user-{subject_id}-20260320T120000Z.json"
+
+
+def _archive_payload(*, subject_id: str, related_documents: object) -> dict[str, object]:
+    now_iso = "2026-03-20T12:00:00Z"
+    return {
+        "schema_type": "continuity_archive_envelope",
+        "schema_version": "1.0",
+        "archived_at": now_iso,
+        "archived_by": "peer-test",
+        "reason": "retention",
+        "active_path": f"memory/continuity/user-{subject_id}.json",
+        "capsule": {
+            "schema_version": "1.0",
+            "subject_kind": "user",
+            "subject_id": subject_id,
+            "updated_at": now_iso,
+            "verified_at": now_iso,
+            "verification_kind": "system_check",
+            "source": {
+                "producer": "test",
+                "update_reason": "manual",
+                "inputs": ["memory/core/identity.md"],
+            },
+            "continuity": {
+                "top_priorities": ["test priority"],
+                "active_constraints": ["test constraint"],
+                "active_concerns": ["test concern"],
+                "open_loops": ["test loop"],
+                "stance_summary": "Test stance.",
+                "drift_signals": ["test drift"],
+                "related_documents": related_documents,
+            },
+            "confidence": {"continuity": 0.9, "relationship_model": 0.0},
+            "freshness": {"freshness_class": "durable"},
+            "verification_state": {
+                "status": "system_confirmed",
+                "last_revalidated_at": now_iso,
+                "strongest_signal": "system_check",
+                "evidence_refs": ["memory/core/identity.md"],
+            },
+            "capsule_health": {
+                "status": "healthy",
+                "reasons": [],
+                "last_checked_at": now_iso,
+            },
+        },
+    }
+
+
+def _write_archive(repo_root: Path, *, subject_id: str, related_documents: object) -> str:
+    archive_rel = _archive_rel(subject_id)
+    archive_path = repo_root / archive_rel
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    archive_path.write_text(
+        json.dumps(_archive_payload(subject_id=subject_id, related_documents=related_documents)),
+        encoding="utf-8",
+    )
+    return archive_rel
+
+
+class TestRelatedDocuments217Slice2(unittest.TestCase):
+    """Exercise archive/cold persistence degradation for malformed related_documents."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(self.tempdir.name)
+        (self.repo_root / ".locks").mkdir()
+        self.auth = AllowAllAuthStub()
+        self.gm = SimpleGitManagerStub(self.repo_root)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_cold_store_surfaces_non_metadata_warning_for_malformed_archive_capsule(self) -> None:
+        archive_rel = _write_archive(
+            self.repo_root,
+            subject_id="alpha",
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "spec",
+                    "label": "Spec",
+                    "payload": {"nested": {"body": "forbidden"}},
+                }
+            ],
+        )
+
+        result = continuity_cold_store_service(
+            repo_root=self.repo_root,
+            gm=self.gm,
+            auth=self.auth,
+            req=ContinuityColdStoreRequest(source_archive_path=archive_rel),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["recovery_warnings"], ["related_documents_omitted_non_metadata"])
+
+    def test_cold_rehydrate_omits_invalid_related_documents_and_warns_once(self) -> None:
+        archive_rel = _write_archive(
+            self.repo_root,
+            subject_id="beta",
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "Spec",
+                    "label": "Spec",
+                }
+            ],
+        )
+
+        store_result = continuity_cold_store_service(
+            repo_root=self.repo_root,
+            gm=self.gm,
+            auth=self.auth,
+            req=ContinuityColdStoreRequest(source_archive_path=archive_rel),
+            audit=lambda *_args, **_kwargs: None,
+        )
+        cold_payload_path = self.repo_root / store_result["cold_storage_path"]
+        cold_payload = json.loads(gzip.decompress(cold_payload_path.read_bytes()).decode("utf-8"))
+
+        result = continuity_cold_rehydrate_service(
+            repo_root=self.repo_root,
+            gm=self.gm,
+            auth=self.auth,
+            req=ContinuityColdRehydrateRequest(source_archive_path=archive_rel),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        archive_path = self.repo_root / archive_rel
+        restored = json.loads(archive_path.read_text(encoding="utf-8"))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["recovery_warnings"], ["related_documents_omitted_invalid"])
+        self.assertNotIn("related_documents", restored["capsule"]["continuity"])
+        self.assertIn("related_documents", cold_payload["capsule"]["continuity"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_related_documents_217_slice2.py
+++ b/tests/test_related_documents_217_slice2.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from app.continuity.persistence import _load_archive_envelope_with_warnings
 from app.continuity.service import (
     continuity_cold_rehydrate_service,
     continuity_cold_store_service,
@@ -154,6 +155,62 @@ class TestRelatedDocuments217Slice2(unittest.TestCase):
         self.assertEqual(result["recovery_warnings"], ["related_documents_omitted_invalid"])
         self.assertNotIn("related_documents", restored["capsule"]["continuity"])
         self.assertIn("related_documents", cold_payload["capsule"]["continuity"])
+
+    def test_cold_rehydrate_crash_recovery_surfaces_related_documents_warning_once(self) -> None:
+        archive_rel = _write_archive(
+            self.repo_root,
+            subject_id="gamma",
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "Spec",
+                    "label": "Spec",
+                }
+            ],
+        )
+
+        store_result = continuity_cold_store_service(
+            repo_root=self.repo_root,
+            gm=self.gm,
+            auth=self.auth,
+            req=ContinuityColdStoreRequest(source_archive_path=archive_rel),
+            audit=lambda *_args, **_kwargs: None,
+        )
+        _write_archive(
+            self.repo_root,
+            subject_id="gamma",
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "Spec",
+                    "label": "Spec",
+                }
+            ],
+        )
+
+        result = continuity_cold_rehydrate_service(
+            repo_root=self.repo_root,
+            gm=self.gm,
+            auth=self.auth,
+            req=ContinuityColdRehydrateRequest(source_archive_path=archive_rel),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        restored, restored_warnings = _load_archive_envelope_with_warnings(self.repo_root, archive_rel)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["artifact_state"], "archived")
+        self.assertFalse((self.repo_root / store_result["cold_storage_path"]).exists())
+        self.assertFalse((self.repo_root / store_result["cold_stub_path"]).exists())
+        self.assertEqual(
+            result["recovery_warnings"],
+            [
+                "continuity_cold_rehydrate_crash_recovery",
+                "related_documents_omitted_invalid",
+            ],
+        )
+        self.assertEqual(restored_warnings, ["related_documents_omitted_invalid"])
+        self.assertNotIn("related_documents", restored["capsule"]["continuity"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- complete `related_documents` validation/persistence for `#217` slice 2 only
- preserve degraded-read omission behavior for malformed persisted `related_documents`
- enforce exact single-warning behavior with reserved-key precedence
- align cold-store, cold-rehydrate, and cold-rehydrate crash-recovery warning handling
- add regression coverage for the bounded slice-2 persistence/degraded-read surface
- no limit-rebalance work in this slice

## Why
The remaining slice-2 contradiction was in the continuity cold-rehydrate crash-recovery branch, which validated restored archives through a warning-dropping wrapper and could lose the required top-level `related_documents_omitted_*` degraded-read warning.

## Validation
- `./.venv/bin/python -m unittest tests.test_related_documents_217_slice2 -v`
- `./.venv/bin/python -m unittest tests.test_related_documents_217_slice1 -v`
- `./.venv/bin/python -m unittest tests.test_stage_d_cold_crash_recovery -v`
- `./.venv/bin/python -m ruff check app tests tools`

Refs #217
