### PR TITLE
Complete #217 hardened related_documents contract and continuity limit rebalance

### DIFF
--- a/app/continuity/constants.py
+++ b/app/continuity/constants.py
@@ -299,10 +299,10 @@ PATCH_STRUCTURED_MATCH_KEYS: dict[str, str] = {
 
 # Max-length bounds per patch target (mirrors Pydantic model constraints).
 PATCH_TARGET_MAX_LENGTH: dict[str, int] = {
-    "continuity.top_priorities": 5,
+    "continuity.top_priorities": 8,
     "continuity.active_concerns": 5,
-    "continuity.active_constraints": 5,
-    "continuity.open_loops": 5,
+    "continuity.active_constraints": 8,
+    "continuity.open_loops": 8,
     "continuity.drift_signals": 5,
     "continuity.working_hypotheses": 5,
     "continuity.long_horizon_commitments": 5,

--- a/app/continuity/validation.py
+++ b/app/continuity/validation.py
@@ -432,11 +432,11 @@ def _validate_low_commitment_fields(capsule: ContinuityCapsule) -> None:
             raise HTTPException(status_code=400, detail="Value too long in continuity.rationale_entries[].tag")
         if len(entry.summary) < 1:
             raise HTTPException(status_code=400, detail="Value too short in continuity.rationale_entries[].summary")
-        if len(entry.summary) > 240:
+        if len(entry.summary) > 320:
             raise HTTPException(status_code=400, detail="Value too long in continuity.rationale_entries[].summary")
         if len(entry.reasoning) < 1:
             raise HTTPException(status_code=400, detail="Value too short in continuity.rationale_entries[].reasoning")
-        if len(entry.reasoning) > 400:
+        if len(entry.reasoning) > 560:
             raise HTTPException(status_code=400, detail="Value too long in continuity.rationale_entries[].reasoning")
         for alt in list(entry.alternatives_considered):
             if len(alt) < 1:

--- a/app/models.py
+++ b/app/models.py
@@ -771,8 +771,8 @@ class RationaleEntry(BaseModel):
     tag: str = Field(min_length=1, max_length=80)
     kind: Literal["decision", "assumption", "tension"]
     status: Literal["active", "superseded", "retired"]
-    summary: str
-    reasoning: str
+    summary: str = Field(max_length=320)
+    reasoning: str = Field(max_length=560)
     alternatives_considered: List[str] = Field(default_factory=list, max_length=3)
     depends_on: List[str] = Field(default_factory=list, max_length=3)
     supersedes: Optional[str] = Field(default=None, max_length=80)
@@ -784,10 +784,10 @@ class RationaleEntry(BaseModel):
 class ContinuityState(BaseModel):
     """Operational orientation state preserved across resets and compaction."""
 
-    top_priorities: List[str] = Field(max_length=5)
+    top_priorities: List[str] = Field(max_length=8)
     active_concerns: List[str] = Field(max_length=5)
-    active_constraints: List[str] = Field(max_length=5)
-    open_loops: List[str] = Field(max_length=5)
+    active_constraints: List[str] = Field(max_length=8)
+    open_loops: List[str] = Field(max_length=8)
     stance_summary: str = Field(max_length=240)
     drift_signals: List[str] = Field(max_length=5)
     working_hypotheses: List[str] = Field(default_factory=list, max_length=5)
@@ -868,9 +868,9 @@ class SessionEndSnapshot(BaseModel):
     """
 
     # P0 — required, always override capsule.continuity counterparts
-    open_loops: List[str] = Field(max_length=5)
-    top_priorities: List[str] = Field(max_length=5)
-    active_constraints: List[str] = Field(max_length=5)
+    open_loops: List[str] = Field(max_length=8)
+    top_priorities: List[str] = Field(max_length=8)
+    active_constraints: List[str] = Field(max_length=8)
     stance_summary: str = Field(max_length=240)
 
     # P1 — optional; None = preserve capsule value, explicit value = override

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -100,7 +100,7 @@ The system is designed so that a fully-populated capsule with practical content 
 
 ### Per-item string constraints
 
-Most list item strings in `ContinuityState` do not have a per-item character limit enforced in the model — the system relies on list count limits (max 3–5 items per field) and the deterministic trim mechanism to control total size. The exceptions with explicit character limits are:
+Most list item strings in `ContinuityState` do not have a per-item character limit enforced in the model. The system relies on per-field list-count limits, which vary by field as documented in the field table below, plus the deterministic trim mechanism to control total size. The exceptions with explicit character limits are:
 
 | Field | Max length |
 |-------|-----------|
@@ -330,7 +330,7 @@ When `session_end_snapshot` is omitted or null, behavior and response are identi
 When `merge_mode` is `"preserve"`, the service inspects the raw JSON body to determine per-field intent:
 
 - **Required list fields** (`top_priorities`, `active_concerns`, `active_constraints`, `open_loops`, `drift_signals`): `[]` in JSON → preserve stored value; non-empty → override.
-- **Optional list fields** (`working_hypotheses`, `long_horizon_commitments`, `session_trajectory`, `trailing_notes`, `curiosity_queue`, `negative_decisions`, `rationale_entries`): absent → preserve; `[]` → override to empty; `null` → clear; non-empty → override.
+- **Optional list fields** (`working_hypotheses`, `long_horizon_commitments`, `session_trajectory`, `trailing_notes`, `curiosity_queue`, `negative_decisions`, `rationale_entries`, `related_documents`): absent → preserve; `[]` → override to empty; `null` → clear; non-empty → override.
 - **Optional object fields** (`relationship_model`, `retrieval_hints`): absent → preserve; `null` → clear; present → override.
 - **Capsule-level fields** (`attention_policy`, `freshness`, `canonical_sources`, `metadata`, `stable_preferences`): absent → preserve; `null` → clear to type-appropriate empty; present → override.
 - **`thread_descriptor`**: absent → preserve entire stored descriptor; `null` → clear; present → merge sub-fields (`keywords`, `scope_anchors`, `identity_anchors` are individually merge-eligible).

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -31,10 +31,11 @@ Total: **~94 distinct fields** across all nested objects.
 
 | Area | Items | Max chars per item |
 |------|-------|--------------------|
-| ContinuityState lists (6 required) | 5 each = 30 strings | no per-item limit |
+| ContinuityState required lists | `top_priorities` 8, `active_concerns` 5, `active_constraints` 8, `open_loops` 8, `drift_signals` 5 = 34 strings | no per-item limit |
 | ContinuityState optional lists (5) | 3–5 each = 23 strings | no per-item limit |
 | `negative_decisions` | 4 × (160 + 240) = 1,600 chars | structured |
-| `rationale_entries` | 6 × (80 + 240 + 400 + 3×160 + 3×120 + 80) = ~7,680 chars | structured |
+| `rationale_entries` | 6 × (80 + 320 + 560 + 3×160 + 3×120 + 80) = ~10,800 chars | structured |
+| `related_documents` | 8 × (240 + 32 + 120 + 32) = ~3,392 chars | structured metadata |
 | `stable_preferences` | 12 × (80 + 240) = 3,840 chars | structured |
 | `stance_summary` | 1 string | 240 chars |
 | `relationship_model` lists (2) | 5 each = 10 strings | no per-item limit |
@@ -64,8 +65,8 @@ The system is designed so that a fully-populated capsule with practical content 
 
 | Section | ~Tokens | Fields | Notes |
 |---------|---------|--------|-------|
-| Core orientation (6 required lists + `stance_summary`) | ~670 | 31 strings + 1 scalar | Always present — the essential orientation |
-| Optional lists (`working_hypotheses`, `long_horizon_commitments`, `session_trajectory`, `negative_decisions`, `trailing_notes`, `curiosity_queue`, `rationale_entries`) | ~1,400–2,800 | 27 strings + 4+6 objects | Trimmed first under token pressure; upper bound assumes all `rationale_entries` slots fully populated |
+| Core orientation (5 required lists + `stance_summary`) | ~760 | 34 strings + 1 scalar | Always present — the essential orientation |
+| Optional lists (`working_hypotheses`, `long_horizon_commitments`, `session_trajectory`, `negative_decisions`, `trailing_notes`, `curiosity_queue`, `rationale_entries`, `related_documents`) | ~1,500–3,300 | 27 strings + 4+6+8 objects | Trimmed first under token pressure; upper bound assumes all `rationale_entries` and `related_documents` slots fully populated |
 | `retrieval_hints` (`must_include`, `avoid`, `load_next`) | ~270 | up to 24 strings | Dropped early in trim order |
 | `relationship_model` (`trust_level`, `preferred_style`, `sensitivity_notes`) | ~200 | up to 11 fields | Dropped early in trim order |
 | `attention_policy` (`early_load`, `presence_bias_overrides`) | ~175 | up to 13 strings | |
@@ -107,8 +108,8 @@ Most list item strings in `ContinuityState` do not have a per-item character lim
 | `negative_decisions[].decision` | 160 chars |
 | `negative_decisions[].rationale` | 240 chars |
 | `rationale_entries[].tag` | 80 chars |
-| `rationale_entries[].summary` | 240 chars |
-| `rationale_entries[].reasoning` | 400 chars |
+| `rationale_entries[].summary` | 320 chars |
+| `rationale_entries[].reasoning` | 560 chars |
 | `rationale_entries[].alternatives_considered[]` | 160 chars |
 | `rationale_entries[].depends_on[]` | 120 chars |
 | `conflict_summary` (in `verification_state`) | 240 chars |
@@ -187,10 +188,10 @@ These are the core orientation fields that an agent writes to preserve working s
 
 | Field | Type | Required | Constraints | Purpose |
 |-------|------|----------|-------------|---------|
-| `top_priorities` | list of strings | yes | max 5 | What matters most right now |
+| `top_priorities` | list of strings | yes | max 8 | What matters most right now |
 | `active_concerns` | list of strings | yes | max 5 | Active worries or risks |
-| `active_constraints` | list of strings | yes | max 5 | Hard boundaries on action |
-| `open_loops` | list of strings | yes | max 5 | Unresolved questions or pending items |
+| `active_constraints` | list of strings | yes | max 8 | Hard boundaries on action |
+| `open_loops` | list of strings | yes | max 8 | Unresolved questions or pending items |
 | `stance_summary` | string | yes | max 240 chars | Current direction in one sentence |
 | `drift_signals` | list of strings | yes | max 5 | Signs that orientation may be shifting |
 | `working_hypotheses` | list of strings | no | max 5, default `[]` | Current best-guess assumptions |
@@ -200,6 +201,7 @@ These are the core orientation fields that an agent writes to preserve working s
 | `trailing_notes` | list of strings | no | max 3, default `[]` | Low-priority context worth preserving |
 | `curiosity_queue` | list of strings | no | max 5, default `[]` | Questions to revisit later |
 | `rationale_entries` | list of RationaleEntry | no | max 6, default `[]` | Decision rationale, assumptions, and unresolved tensions |
+| `related_documents` | list of structured metadata objects | no | max 8, default omitted | Bounded repo-relative document references; see discovery schema for the exact entry shape |
 | `relationship_model` | ContinuityRelationshipModel | no | | Relationship-specific hints |
 | `retrieval_hints` | ContinuityRetrievalHints | no | | Preferences for what to load next |
 
@@ -214,8 +216,8 @@ One bounded, agent-authored decision rationale or unresolved tension. Tags must 
 | `tag` | string | yes | 1–80 chars, unique within the list |
 | `kind` | `"decision"` \| `"assumption"` \| `"tension"` | yes | |
 | `status` | `"active"` \| `"superseded"` \| `"retired"` | yes | |
-| `summary` | string | yes | 1–240 chars |
-| `reasoning` | string | yes | 1–400 chars |
+| `summary` | string | yes | 1–320 chars |
+| `reasoning` | string | yes | 1–560 chars |
 | `alternatives_considered` | list of strings | no | max 3 items, each 1–160 chars |
 | `depends_on` | list of strings | no | max 3 items, each 1–120 chars |
 | `supersedes` | string | no | max 80 chars. Must reference a tag in the same list with `status: "superseded"` |
@@ -300,9 +302,9 @@ When `session_end_snapshot` is provided, the server merges its fields into `caps
 
 | Field | Type | Required | Maps to | Override behavior |
 |-------|------|----------|---------|-------------------|
-| `open_loops` | list of strings (max 5, each ≤ 160 chars) | yes | `capsule.continuity.open_loops` | Always overrides |
-| `top_priorities` | list of strings (max 5, each ≤ 160 chars) | yes | `capsule.continuity.top_priorities` | Always overrides |
-| `active_constraints` | list of strings (max 5, each ≤ 160 chars) | yes | `capsule.continuity.active_constraints` | Always overrides |
+| `open_loops` | list of strings (max 8, each ≤ 160 chars) | yes | `capsule.continuity.open_loops` | Always overrides |
+| `top_priorities` | list of strings (max 8, each ≤ 160 chars) | yes | `capsule.continuity.top_priorities` | Always overrides |
+| `active_constraints` | list of strings (max 8, each ≤ 160 chars) | yes | `capsule.continuity.active_constraints` | Always overrides |
 | `stance_summary` | string (≤ 240 chars) | yes | `capsule.continuity.stance_summary` | Always overrides |
 | `negative_decisions` | list of NegativeDecision (max 4) | no | `capsule.continuity.negative_decisions` | `null` = preserve capsule value; explicit value = override |
 | `session_trajectory` | list of strings (max 5, each ≤ 80 chars) | no | `capsule.continuity.session_trajectory` | `null` = preserve capsule value; explicit value = override |

--- a/tests/test_continuity_176_patch.py
+++ b/tests/test_continuity_176_patch.py
@@ -293,9 +293,9 @@ class TestPatchAppendMaxLength(unittest.TestCase):
             _setup_dirs(root)
             gm = _GitManagerStub(root)
             auth = _AuthStub()
-            # Seed with 5 open_loops (max)
+            # Seed with 8 open_loops (max)
             _seed_capsule(root, gm, auth, extra_continuity={
-                "open_loops": ["a", "b", "c", "d", "e"],
+                "open_loops": [f"loop-{index}" for index in range(8)],
             })
 
             with self.assertRaises(HTTPException) as ctx:
@@ -303,7 +303,10 @@ class TestPatchAppendMaxLength(unittest.TestCase):
                     {"target": "continuity.open_loops", "action": "append", "value": "overflow"},
                 ])
             self.assertEqual(ctx.exception.status_code, 400)
-            self.assertIn("max length", ctx.exception.detail)
+            self.assertEqual(
+                ctx.exception.detail,
+                "append would exceed max length (8) for continuity.open_loops",
+            )
 
     def test_append_exceeds_negative_decisions_max(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -329,6 +332,102 @@ class TestPatchAppendMaxLength(unittest.TestCase):
                 ])
             self.assertEqual(ctx.exception.status_code, 400)
             self.assertIn("max length", ctx.exception.detail)
+
+
+class TestPatch217RebalancedCoreListLimits(unittest.TestCase):
+    """Lock the widened #217 patch-path bounds for the three rebalanced core lists."""
+
+    def test_append_allows_growth_from_five_to_six(self) -> None:
+        fields = (
+            ("top_priorities", "continuity.top_priorities", "priority"),
+            ("open_loops", "continuity.open_loops", "loop"),
+            ("active_constraints", "continuity.active_constraints", "constraint"),
+        )
+
+        for field_name, target, prefix in fields:
+            with self.subTest(field=field_name):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    _setup_dirs(root)
+                    gm = _GitManagerStub(root)
+                    auth = _AuthStub()
+                    _seed_capsule(
+                        root,
+                        gm,
+                        auth,
+                        extra_continuity={field_name: [f"{prefix}-{index}" for index in range(5)]},
+                    )
+
+                    result = _patch(root, gm, auth, [
+                        {"target": target, "action": "append", "value": f"{prefix}-5"},
+                    ])
+
+                    self.assertTrue(result["ok"])
+                    capsule = _read_persisted_capsule(root)
+                    self.assertEqual(len(capsule["continuity"][field_name]), 6)
+                    self.assertEqual(capsule["continuity"][field_name][-1], f"{prefix}-5")
+
+    def test_append_allows_growth_up_to_eight(self) -> None:
+        fields = (
+            ("top_priorities", "continuity.top_priorities", "priority"),
+            ("open_loops", "continuity.open_loops", "loop"),
+            ("active_constraints", "continuity.active_constraints", "constraint"),
+        )
+
+        for field_name, target, prefix in fields:
+            with self.subTest(field=field_name):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    _setup_dirs(root)
+                    gm = _GitManagerStub(root)
+                    auth = _AuthStub()
+                    _seed_capsule(
+                        root,
+                        gm,
+                        auth,
+                        extra_continuity={field_name: [f"{prefix}-{index}" for index in range(7)]},
+                    )
+
+                    result = _patch(root, gm, auth, [
+                        {"target": target, "action": "append", "value": f"{prefix}-7"},
+                    ])
+
+                    self.assertTrue(result["ok"])
+                    capsule = _read_persisted_capsule(root)
+                    self.assertEqual(len(capsule["continuity"][field_name]), 8)
+                    self.assertEqual(capsule["continuity"][field_name][-1], f"{prefix}-7")
+
+    def test_append_rejects_growth_from_eight_to_nine(self) -> None:
+        fields = (
+            ("top_priorities", "continuity.top_priorities", "priority"),
+            ("open_loops", "continuity.open_loops", "loop"),
+            ("active_constraints", "continuity.active_constraints", "constraint"),
+        )
+
+        for field_name, target, prefix in fields:
+            with self.subTest(field=field_name):
+                with tempfile.TemporaryDirectory() as tmp:
+                    root = Path(tmp)
+                    _setup_dirs(root)
+                    gm = _GitManagerStub(root)
+                    auth = _AuthStub()
+                    _seed_capsule(
+                        root,
+                        gm,
+                        auth,
+                        extra_continuity={field_name: [f"{prefix}-{index}" for index in range(8)]},
+                    )
+
+                    with self.assertRaises(HTTPException) as ctx:
+                        _patch(root, gm, auth, [
+                            {"target": target, "action": "append", "value": f"{prefix}-8"},
+                        ])
+
+                    self.assertEqual(ctx.exception.status_code, 400)
+                    self.assertEqual(
+                        ctx.exception.detail,
+                        f"append would exceed max length (8) for {target}",
+                    )
 
 
 class TestPatchRemoveStringList(unittest.TestCase):

--- a/tests/test_continuity_217_slice3_limits.py
+++ b/tests/test_continuity_217_slice3_limits.py
@@ -1,0 +1,238 @@
+"""Tests for #217 slice 3: exact bounded continuity limit rebalance."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from app.config import Settings
+from app.continuity.service import continuity_read_service
+from app.continuity.validation import _validate_capsule
+from app.main import discovery_tools
+from app.models import ContinuityCapsule, ContinuityReadRequest, SessionEndSnapshot
+from tests.helpers import AllowAllAuthStub
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _settings(repo_root: Path) -> Settings:
+    return Settings(
+        repo_root=repo_root,
+        auto_init_git=False,
+        git_author_name="n/a",
+        git_author_email="n/a",
+        tokens={},
+        audit_log_enabled=False,
+    )
+
+
+def _related_document(index: int) -> dict[str, str]:
+    return {
+        "path": f"docs/spec-{index}.md",
+        "kind": "spec",
+        "label": f"Spec {index}",
+        "relevance": "supporting",
+    }
+
+
+def _base_capsule_payload(
+    *,
+    top_count: int = 1,
+    loop_count: int = 1,
+    constraint_count: int = 1,
+    rationale_summary: str = "Short rationale summary.",
+    rationale_reasoning: str = "Short rationale reasoning.",
+    related_documents: object | None = None,
+) -> dict:
+    now = _now_iso()
+    continuity: dict[str, object] = {
+        "top_priorities": [f"priority {index}" for index in range(top_count)],
+        "active_concerns": ["concern 0"],
+        "active_constraints": [f"constraint {index}" for index in range(constraint_count)],
+        "open_loops": [f"loop {index}" for index in range(loop_count)],
+        "stance_summary": "Keep the continuity contract deterministic while widening the targeted bounds.",
+        "drift_signals": [],
+        "rationale_entries": [
+            {
+                "tag": "limit_rebalance",
+                "kind": "decision",
+                "status": "active",
+                "summary": rationale_summary,
+                "reasoning": rationale_reasoning,
+                "last_confirmed_at": now,
+            }
+        ],
+    }
+    if related_documents is not None:
+        continuity["related_documents"] = related_documents
+    return {
+        "schema_version": "1.1",
+        "subject_kind": "user",
+        "subject_id": "slice3-agent",
+        "updated_at": now,
+        "verified_at": now,
+        "verification_kind": "self_review",
+        "source": {
+            "producer": "slice3-test",
+            "update_reason": "manual",
+            "inputs": [],
+        },
+        "continuity": continuity,
+        "confidence": {"continuity": 0.9, "relationship_model": 0.0},
+    }
+
+
+def _write_active_capsule(repo_root: Path, payload: dict) -> None:
+    target = repo_root / "memory" / "continuity"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "user-slice3-agent.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestContinuity217Slice3Limits(unittest.TestCase):
+    """Lock the exact slice-3 continuity bounds from #217."""
+
+    def test_continuity_state_accepts_rebalanced_maxima(self) -> None:
+        capsule = ContinuityCapsule.model_validate(
+            _base_capsule_payload(
+                top_count=8,
+                loop_count=8,
+                constraint_count=8,
+                related_documents=[_related_document(index) for index in range(8)],
+            )
+        )
+
+        self.assertEqual(len(capsule.continuity.top_priorities), 8)
+        self.assertEqual(len(capsule.continuity.open_loops), 8)
+        self.assertEqual(len(capsule.continuity.active_constraints), 8)
+        self.assertEqual(len(capsule.continuity.related_documents), 8)
+
+    def test_continuity_state_rejects_nine_item_core_lists(self) -> None:
+        for field_name in ("top_priorities", "open_loops", "active_constraints"):
+            payload = _base_capsule_payload(top_count=8, loop_count=8, constraint_count=8)
+            payload["continuity"][field_name] = [f"{field_name} {index}" for index in range(9)]
+            with self.assertRaises(ValidationError, msg=field_name):
+                ContinuityCapsule.model_validate(payload)
+
+    def test_session_end_snapshot_accepts_eight_items(self) -> None:
+        snapshot = SessionEndSnapshot.model_validate(
+            {
+                "open_loops": [f"loop {index}" for index in range(8)],
+                "top_priorities": [f"priority {index}" for index in range(8)],
+                "active_constraints": [f"constraint {index}" for index in range(8)],
+                "stance_summary": "Capture enough bounded state to resume real work without losing determinism.",
+            }
+        )
+
+        self.assertEqual(len(snapshot.open_loops), 8)
+        self.assertEqual(len(snapshot.top_priorities), 8)
+        self.assertEqual(len(snapshot.active_constraints), 8)
+
+    def test_session_end_snapshot_rejects_nine_items(self) -> None:
+        with self.assertRaises(ValidationError):
+            SessionEndSnapshot.model_validate(
+                {
+                    "open_loops": [f"loop {index}" for index in range(9)],
+                    "top_priorities": ["priority 0"],
+                    "active_constraints": ["constraint 0"],
+                    "stance_summary": "Valid stance summary.",
+                }
+            )
+
+    def test_validate_capsule_accepts_rebalanced_rationale_lengths(self) -> None:
+        capsule = ContinuityCapsule.model_validate(
+            _base_capsule_payload(
+                rationale_summary="s" * 320,
+                rationale_reasoning="r" * 560,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            result, _ = _validate_capsule(Path(td), capsule)
+
+        entry = result["continuity"]["rationale_entries"][0]
+        self.assertEqual(len(entry["summary"]), 320)
+        self.assertEqual(len(entry["reasoning"]), 560)
+
+    def test_model_rejects_rationale_lengths_past_new_maxima(self) -> None:
+        cases = (
+            ("summary", "s" * 321, "reasoning ok"),
+            ("reasoning", "summary ok", "r" * 561),
+        )
+
+        for field_name, summary, reasoning in cases:
+            with self.assertRaises(ValidationError, msg=field_name):
+                ContinuityCapsule.model_validate(
+                    _base_capsule_payload(
+                        rationale_summary=summary,
+                        rationale_reasoning=reasoning,
+                    )
+                )
+
+    def test_read_degrades_invalid_related_documents_without_failing_rebalanced_capsule(self) -> None:
+        repo_root = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(repo_root, ignore_errors=True))
+        _settings(repo_root)
+        payload = _base_capsule_payload(
+            top_count=8,
+            loop_count=8,
+            constraint_count=8,
+            rationale_summary="s" * 320,
+            rationale_reasoning="r" * 560,
+            related_documents=[
+                {
+                    "path": "docs/spec.md",
+                    "kind": "Spec",
+                    "label": "Invalid kind should degrade on read",
+                }
+            ],
+        )
+        _write_active_capsule(repo_root, payload)
+
+        out = continuity_read_service(
+            repo_root=repo_root,
+            auth=AllowAllAuthStub(),
+            req=ContinuityReadRequest(subject_kind="user", subject_id="slice3-agent", allow_fallback=True),
+            now=datetime.now(timezone.utc),
+            audit=lambda *_args, **_kwargs: None,
+        )
+
+        self.assertEqual(out["recovery_warnings"], ["related_documents_omitted_invalid"])
+        continuity = out["capsule"]["continuity"]
+        self.assertEqual(len(continuity["top_priorities"]), 8)
+        self.assertEqual(len(continuity["open_loops"]), 8)
+        self.assertEqual(len(continuity["active_constraints"]), 8)
+        self.assertEqual(len(continuity["rationale_entries"][0]["summary"]), 320)
+        self.assertEqual(len(continuity["rationale_entries"][0]["reasoning"]), 560)
+        self.assertNotIn("related_documents", continuity)
+
+    def test_public_schema_exposes_slice3_limits(self) -> None:
+        payload = discovery_tools()
+        by_name = {tool["name"]: tool for tool in payload["tools"]}
+        schema = by_name["continuity.upsert"]["input_schema"]
+        continuity_ref = schema["$defs"]["ContinuityCapsule"]["properties"]["continuity"]["$ref"].split("/")[-1]
+        continuity_schema = schema["$defs"][continuity_ref]
+        rationale_ref = continuity_schema["properties"]["rationale_entries"]["items"]["$ref"].split("/")[-1]
+        rationale_schema = schema["$defs"][rationale_ref]
+        snapshot_ref = schema["properties"]["session_end_snapshot"]["anyOf"][0]["$ref"].split("/")[-1]
+        snapshot_schema = schema["$defs"][snapshot_ref]
+
+        self.assertEqual(continuity_schema["properties"]["top_priorities"]["maxItems"], 8)
+        self.assertEqual(continuity_schema["properties"]["open_loops"]["maxItems"], 8)
+        self.assertEqual(continuity_schema["properties"]["active_constraints"]["maxItems"], 8)
+        self.assertEqual(continuity_schema["properties"]["related_documents"]["maxItems"], 8)
+        self.assertEqual(rationale_schema["properties"]["summary"]["maxLength"], 320)
+        self.assertEqual(rationale_schema["properties"]["reasoning"]["maxLength"], 560)
+        self.assertEqual(snapshot_schema["properties"]["open_loops"]["maxItems"], 8)
+        self.assertEqual(snapshot_schema["properties"]["top_priorities"]["maxItems"], 8)
+        self.assertEqual(snapshot_schema["properties"]["active_constraints"]["maxItems"], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rationale_entries_122.py
+++ b/tests/test_rationale_entries_122.py
@@ -416,15 +416,11 @@ class TestValidateRationaleEntries(unittest.TestCase):
             self.assertIn("Duplicate", str(ctx.exception.detail))
 
     def test_summary_too_long_rejected(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            payload = _base_capsule_payload(rationale_entries=[
-                _sample_entry(summary="x" * 241),
-            ])
-            capsule = ContinuityCapsule(**payload)
-            with self.assertRaises(HTTPException) as ctx:
-                _validate_capsule(Path(td), capsule)
-            self.assertEqual(ctx.exception.status_code, 400)
-            self.assertIn("too long", str(ctx.exception.detail).lower())
+        payload = _base_capsule_payload(rationale_entries=[
+            _sample_entry(summary="x" * 321),
+        ])
+        with self.assertRaises(ValidationError):
+            ContinuityCapsule(**payload)
 
     def test_summary_empty_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -438,15 +434,11 @@ class TestValidateRationaleEntries(unittest.TestCase):
             self.assertIn("too short", str(ctx.exception.detail).lower())
 
     def test_reasoning_too_long_rejected(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            payload = _base_capsule_payload(rationale_entries=[
-                _sample_entry(reasoning="x" * 401),
-            ])
-            capsule = ContinuityCapsule(**payload)
-            with self.assertRaises(HTTPException) as ctx:
-                _validate_capsule(Path(td), capsule)
-            self.assertEqual(ctx.exception.status_code, 400)
-            self.assertIn("too long", str(ctx.exception.detail).lower())
+        payload = _base_capsule_payload(rationale_entries=[
+            _sample_entry(reasoning="x" * 561),
+        ])
+        with self.assertRaises(ValidationError):
+            ContinuityCapsule(**payload)
 
     def test_reasoning_empty_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -606,20 +598,20 @@ class TestValidateRationaleEntries(unittest.TestCase):
     def test_max_length_summary_accepted(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             payload = _base_capsule_payload(rationale_entries=[
-                _sample_entry(summary="s" * 240),
+                _sample_entry(summary="s" * 320),
             ])
             capsule = ContinuityCapsule(**payload)
             result, _ = _validate_capsule(Path(td), capsule)
-            self.assertEqual(len(result["continuity"]["rationale_entries"][0]["summary"]), 240)
+            self.assertEqual(len(result["continuity"]["rationale_entries"][0]["summary"]), 320)
 
     def test_max_length_reasoning_accepted(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             payload = _base_capsule_payload(rationale_entries=[
-                _sample_entry(reasoning="r" * 400),
+                _sample_entry(reasoning="r" * 560),
             ])
             capsule = ContinuityCapsule(**payload)
             result, _ = _validate_capsule(Path(td), capsule)
-            self.assertEqual(len(result["continuity"]["rationale_entries"][0]["reasoning"]), 400)
+            self.assertEqual(len(result["continuity"]["rationale_entries"][0]["reasoning"]), 560)
 
     def test_max_length_alternative_accepted(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
This PR completes `#217`. Slices 1, 2, and 3 together now satisfy the full hardened issue body.

Completed across this branch history:
- `related_documents` public field and schema
- exact write-time validation and reject-only behavior
- exact degraded-read omission and warning behavior
- preserve-mode consistency
- exact limit rebalance:
  - `top_priorities = 8`
  - `open_loops = 8`
  - `active_constraints = 8`
  - `rationale_entries.summary = 320`
  - `rationale_entries.reasoning = 560`
  - `related_documents = 8`
- patch-path alignment for the rebalanced list limits
- docs/schema/runtime/tests consistency

Closes #217
Refs #218

## Verification
- `./.venv/bin/python -m unittest -v tests.test_related_documents_217_slice1 tests.test_related_documents_217_slice2 tests.test_continuity_217_slice3_limits tests.test_rationale_entries_122 tests.test_continuity_176_patch tests.test_continuity_176_preserve tests.test_continuity_167_session_end_snapshot`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`
