### PR TITLE
Refs #213: deterministic mixed retrieval slice 1

### DIFF
--- a/app/context/service.py
+++ b/app/context/service.py
@@ -16,9 +16,9 @@ from fastapi import HTTPException
 
 from app.auth import AuthContext
 from app.timestamps import format_compact, format_iso, parse_iso
-from app.continuity import build_continuity_state
+from app.continuity import build_continuity_state, continuity_read_service
 from app.indexer import TEXT_SUFFIXES, incremental_rebuild_index, list_recent_files, load_files_index, rebuild_index, search_index
-from app.models import AppendRequest, ContextRetrieveRequest, ContextSnapshotRequest, RecentRequest, SearchRequest, WriteRequest
+from app.models import AppendRequest, ContextRetrieveRequest, ContextSnapshotRequest, ContinuityReadRequest, RecentRequest, SearchRequest, WriteRequest
 from app.git_safety import safe_commit_new_file, safe_commit_updated_file, try_commit_file
 from app.storage import StorageError, read_text_file, safe_path, write_text_file
 
@@ -70,6 +70,102 @@ def _filter_search_results_for_auth(results: list[dict[str, Any]], auth: AuthCon
 def _exclude_continuity_cold_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Drop continuity cold-tier artifacts from context retrieval evidence."""
     return [row for row in results if not _is_continuity_cold_path(str(row.get("path", "")))]
+
+
+def _deduplicate_by_path(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep the first same-class occurrence of each exact path value."""
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for row in rows:
+        path = row.get("path")
+        if not isinstance(path, str):
+            out.append(row)
+            continue
+        if path in seen:
+            continue
+        seen.add(path)
+        out.append(row)
+    return out
+
+
+def _assemble_mixed_retrieval_bundle(
+    *,
+    repo_root: Path,
+    auth: AuthContext,
+    req: ContextRetrieveRequest,
+    now: datetime,
+) -> dict[str, list[dict[str, Any]]]:
+    """Assemble the bounded #213 mixed-retrieval bundle."""
+    bundle: dict[str, list[dict[str, Any]]] = {
+        "continuity": [],
+        "supporting_documents": [],
+        "search_hits": [],
+    }
+    if req.subject_kind not in {"thread", "task"} or not req.subject_id:
+        return bundle
+
+    capsule: dict[str, Any] | None = None
+    try:
+        continuity_result = continuity_read_service(
+            repo_root=repo_root,
+            auth=auth,
+            req=ContinuityReadRequest(
+                subject_kind=req.subject_kind,
+                subject_id=req.subject_id,
+                allow_fallback=False,
+            ),
+            now=now,
+            audit=lambda *_args, **_kwargs: None,
+        )
+        loaded_capsule = continuity_result.get("capsule")
+        if isinstance(loaded_capsule, dict):
+            capsule = loaded_capsule
+            bundle["continuity"] = [loaded_capsule]
+    except HTTPException as exc:
+        if exc.status_code != 404:
+            raise
+
+    if capsule is not None:
+        related_documents = capsule.get("continuity", {}).get("related_documents", [])
+        if isinstance(related_documents, list):
+            supporting_documents: list[dict[str, Any]] = []
+            for entry in related_documents:
+                if not isinstance(entry, dict):
+                    continue
+                path = entry.get("path")
+                if not isinstance(path, str):
+                    continue
+                try:
+                    supporting_document = read_file_service(
+                        repo_root=repo_root,
+                        auth=auth,
+                        path=path,
+                        audit=lambda *_args, **_kwargs: None,
+                    )
+                except Exception:
+                    continue
+                if isinstance(supporting_document, dict):
+                    supporting_documents.append(supporting_document)
+            bundle["supporting_documents"] = _deduplicate_by_path(supporting_documents)
+
+    try:
+        search_result = search_service(
+            repo_root=repo_root,
+            auth=auth,
+            req=SearchRequest(
+                query=req.subject_id,
+                limit=req.limit,
+                sort_by="relevance",
+            ),
+            audit=lambda *_args, **_kwargs: None,
+        )
+        results = search_result.get("results", [])
+        if isinstance(results, list):
+            bundle["search_hits"] = _deduplicate_by_path([row for row in results if isinstance(row, dict)])
+    except Exception:
+        bundle["search_hits"] = []
+
+    return bundle
 
 
 def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -448,6 +544,7 @@ def context_retrieve_service(
     auth.require("search")
     core_memory = _load_core_memory(repo_root, auth)
     continuity_state = build_continuity_state(repo_root=repo_root, auth=auth, req=req, now=now)
+    mixed_retrieval = _assemble_mixed_retrieval_bundle(repo_root=repo_root, auth=auth, req=req, now=now)
     index_health = _index_health(repo_root, now)
     if index_health == "missing":
         recent = _raw_scan_recent_relevant(repo_root, auth, req)
@@ -478,6 +575,7 @@ def context_retrieve_service(
         "open_questions": open_questions[:5],
         "token_budget_hint": continuity_state["budget"]["token_budget_hint"],
         "time_window_days": req.time_window_days,
+        "mixed_retrieval": mixed_retrieval,
         "notes": [
             "For best continuity, run /v1/index/rebuild before retrieve if many files changed.",
             "Use include_types to reduce noise (e.g. ['journal_entry','messages']).",

--- a/app/context/service.py
+++ b/app/context/service.py
@@ -544,7 +544,6 @@ def context_retrieve_service(
     auth.require("search")
     core_memory = _load_core_memory(repo_root, auth)
     continuity_state = build_continuity_state(repo_root=repo_root, auth=auth, req=req, now=now)
-    _assemble_mixed_retrieval_bundle(repo_root=repo_root, auth=auth, req=req, now=now)
     index_health = _index_health(repo_root, now)
     if index_health == "missing":
         recent = _raw_scan_recent_relevant(repo_root, auth, req)

--- a/app/context/service.py
+++ b/app/context/service.py
@@ -544,7 +544,7 @@ def context_retrieve_service(
     auth.require("search")
     core_memory = _load_core_memory(repo_root, auth)
     continuity_state = build_continuity_state(repo_root=repo_root, auth=auth, req=req, now=now)
-    mixed_retrieval = _assemble_mixed_retrieval_bundle(repo_root=repo_root, auth=auth, req=req, now=now)
+    _assemble_mixed_retrieval_bundle(repo_root=repo_root, auth=auth, req=req, now=now)
     index_health = _index_health(repo_root, now)
     if index_health == "missing":
         recent = _raw_scan_recent_relevant(repo_root, auth, req)
@@ -575,7 +575,6 @@ def context_retrieve_service(
         "open_questions": open_questions[:5],
         "token_budget_hint": continuity_state["budget"]["token_budget_hint"],
         "time_window_days": req.time_window_days,
-        "mixed_retrieval": mixed_retrieval,
         "notes": [
             "For best continuity, run /v1/index/rebuild before retrieve if many files changed.",
             "Use include_types to reduce noise (e.g. ['journal_entry','messages']).",

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -644,6 +644,8 @@ Response:
 
 When derived search indexes are stale, `continuity_state.warnings` includes `"continuity_index_stale"`. When indexes are missing, retrieval falls back to a bounded raw scan and adds `"continuity_index_missing"`.
 
+The bounded `#213` mixed-retrieval bundle remains internal-only in slice 1 and is not part of the external `POST /v1/context/retrieve` response shape.
+
 ## Salience Ranking
 
 When `sort="salience"` is set on `POST /v1/continuity/list`, or when capsules are returned through `POST /v1/context/retrieve`, the system applies a deterministic multi-signal sort that surfaces the most decision-relevant capsules first. Nothing is stored — salience is computed at retrieval time from in-memory capsule state.

--- a/tests/test_context_retrieval_213_slice1.py
+++ b/tests/test_context_retrieval_213_slice1.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tempfile
 import unittest
 from datetime import datetime, timezone
 from pathlib import Path
@@ -180,48 +179,120 @@ class TestMixedRetrievalSlice1(unittest.TestCase):
         )
         self.assertEqual(result["search_hits"], [])
 
-    def test_context_retrieve_surfaces_mixed_retrieval_bundle(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            repo_root = Path(td)
-            req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
+    def test_phase_2_continues_after_early_read_exception(self) -> None:
+        req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
+        capsule = {
+            "subject_kind": "thread",
+            "subject_id": "thread-abc",
+            "continuity": {
+                "related_documents": [
+                    {"path": "docs/specs/thread-abc.md", "kind": "spec", "label": "Spec"},
+                    {"path": "docs/notes/thread-abc.md", "kind": "note", "label": "Notes"},
+                ]
+            },
+        }
 
-            with (
-                patch("app.context.service._load_core_memory", return_value=[]),
-                patch(
-                    "app.context.service.build_continuity_state",
-                    return_value={
-                        "present": False,
-                        "requested_selectors": [],
-                        "omitted_selectors": [],
-                        "capsules": [],
-                        "selection_order": [],
-                        "budget": {"token_budget_hint": "normal"},
-                        "warnings": [],
-                        "fallback_used": False,
-                        "recovery_warnings": [],
-                        "trust_signals": None,
-                        "salience_metadata": None,
-                    },
-                ),
-                patch("app.context.service._index_health", return_value="healthy"),
-                patch("app.context.service.search_index", return_value=[]),
-                patch(
-                    "app.context.service._assemble_mixed_retrieval_bundle",
-                    return_value={"continuity": [], "supporting_documents": [], "search_hits": []},
-                ),
-            ):
-                result = context_retrieve_service(
-                    repo_root=repo_root,
-                    auth=_AuthStub(),
-                    req=req,
-                    now=datetime.now(timezone.utc),
-                    audit=lambda *_args, **_kwargs: None,
-                )
+        def _fake_read_file_service(**kwargs: object) -> dict[str, object]:
+            path = kwargs["path"]
+            if path == "docs/specs/thread-abc.md":
+                raise RuntimeError("transient read failure")
+            return {"ok": True, "path": path, "content": f"content for {path}"}
+
+        with (
+            patch("app.context.service.continuity_read_service", return_value={"ok": True, "capsule": capsule}),
+            patch("app.context.service.read_file_service", side_effect=_fake_read_file_service),
+            patch("app.context.service.search_service", return_value={"ok": True, "results": []}),
+        ):
+            result = _assemble_mixed_retrieval_bundle(
+                repo_root=Path("."),
+                auth=_AuthStub(),
+                req=req,
+                now=datetime.now(timezone.utc),
+            )
 
         self.assertEqual(
-            result["bundle"]["mixed_retrieval"],
-            {"continuity": [], "supporting_documents": [], "search_hits": []},
+            result["supporting_documents"],
+            [
+                {
+                    "ok": True,
+                    "path": "docs/notes/thread-abc.md",
+                    "content": "content for docs/notes/thread-abc.md",
+                }
+            ],
         )
+
+    def test_phase_3_uses_degraded_normal_search_results_without_gating_on_ok(self) -> None:
+        req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
+
+        with (
+            patch("app.context.service.continuity_read_service", side_effect=HTTPException(status_code=404, detail="File not found")),
+            patch(
+                "app.context.service.search_service",
+                return_value={
+                    "ok": False,
+                    "warning": "index temporarily stale",
+                    "results": [
+                        {"path": "docs/specs/thread-abc.md", "score": 2.0, "warning": "stale"},
+                        {"path": "docs/notes/thread-abc.md", "score": 1.0},
+                    ],
+                },
+            ),
+        ):
+            result = _assemble_mixed_retrieval_bundle(
+                repo_root=Path("."),
+                auth=_AuthStub(),
+                req=req,
+                now=datetime.now(timezone.utc),
+            )
+
+        self.assertEqual(
+            result["search_hits"],
+            [
+                {"path": "docs/specs/thread-abc.md", "score": 2.0, "warning": "stale"},
+                {"path": "docs/notes/thread-abc.md", "score": 1.0},
+            ],
+        )
+
+    def test_context_retrieve_keeps_mixed_retrieval_internal_only(self) -> None:
+        req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
+        continuity_state = {
+            "present": False,
+            "requested_selectors": [],
+            "omitted_selectors": [],
+            "capsules": [],
+            "selection_order": [],
+            "budget": {"token_budget_hint": "normal"},
+            "warnings": [],
+            "fallback_used": False,
+            "recovery_warnings": [],
+            "trust_signals": None,
+            "salience_metadata": None,
+        }
+
+        with (
+            patch("app.context.service._load_core_memory", return_value=[]),
+            patch("app.context.service.build_continuity_state", return_value=continuity_state),
+            patch("app.context.service._index_health", return_value="healthy"),
+            patch("app.context.service.search_index", return_value=[]),
+            patch("app.context.service._assemble_mixed_retrieval_bundle") as mixed_retrieval_mock,
+        ):
+            now = datetime.now(timezone.utc)
+            auth = _AuthStub()
+            result = context_retrieve_service(
+                repo_root=Path("."),
+                auth=auth,
+                req=req,
+                now=now,
+                audit=lambda *_args, **_kwargs: None,
+            )
+
+        mixed_retrieval_mock.assert_called_once_with(
+            repo_root=Path("."),
+            auth=auth,
+            req=req,
+            now=now,
+        )
+        self.assertNotIn("mixed_retrieval", result["bundle"])
 
 
 if __name__ == "__main__":

--- a/tests/test_context_retrieval_213_slice1.py
+++ b/tests/test_context_retrieval_213_slice1.py
@@ -286,13 +286,25 @@ class TestMixedRetrievalSlice1(unittest.TestCase):
                 audit=lambda *_args, **_kwargs: None,
             )
 
-        mixed_retrieval_mock.assert_called_once_with(
-            repo_root=Path("."),
-            auth=auth,
-            req=req,
-            now=now,
+        mixed_retrieval_mock.assert_not_called()
+        self.assertEqual(
+            set(result["bundle"].keys()),
+            {
+                "task",
+                "generated_at",
+                "core_memory",
+                "recent_relevant",
+                "open_questions",
+                "token_budget_hint",
+                "time_window_days",
+                "notes",
+                "continuity_state",
+            },
         )
         self.assertNotIn("mixed_retrieval", result["bundle"])
+        self.assertNotIn("continuity", result["bundle"])
+        self.assertNotIn("supporting_documents", result["bundle"])
+        self.assertNotIn("search_hits", result["bundle"])
 
 
 if __name__ == "__main__":

--- a/tests/test_context_retrieval_213_slice1.py
+++ b/tests/test_context_retrieval_213_slice1.py
@@ -1,0 +1,228 @@
+"""Tests for #213 slice 1 deterministic mixed retrieval."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from app.context.service import _assemble_mixed_retrieval_bundle, context_retrieve_service
+from app.models import ContextRetrieveRequest
+
+
+class _AuthStub:
+    """Auth stub that allows all reads used in mixed retrieval tests."""
+
+    peer_id = "peer-test"
+
+    def require(self, _scope: str) -> None:
+        return None
+
+    def require_read_path(self, _path: str) -> None:
+        return None
+
+
+class TestMixedRetrievalSlice1(unittest.TestCase):
+    """Validate the bounded deterministic mixed retrieval contract."""
+
+    def test_thread_selector_uses_exact_phase_order_and_same_class_deduplication(self) -> None:
+        req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
+        auth = _AuthStub()
+        calls: list[tuple[str, object]] = []
+        capsule = {
+            "subject_kind": "thread",
+            "subject_id": "thread-abc",
+            "continuity": {
+                "related_documents": [
+                    {"path": "docs/specs/thread-abc.md", "kind": "spec", "label": "Spec"},
+                    {"path": "docs/notes/thread-abc.md", "kind": "note", "label": "Notes"},
+                    {"path": "docs/specs/thread-abc.md", "kind": "spec", "label": "Spec duplicate"},
+                ]
+            },
+        }
+
+        def _fake_continuity_read_service(**kwargs: object) -> dict[str, object]:
+            calls.append(("continuity", kwargs["req"]))
+            return {"ok": True, "capsule": capsule}
+
+        def _fake_read_file_service(**kwargs: object) -> dict[str, object]:
+            path = kwargs["path"]
+            calls.append(("read", path))
+            return {"ok": True, "path": path, "content": f"content for {path}"}
+
+        def _fake_search_service(**kwargs: object) -> dict[str, object]:
+            search_req = kwargs["req"]
+            calls.append(("search", search_req))
+            return {
+                "ok": True,
+                "results": [
+                    {"path": "journal/2026/2026-04-20.md", "score": 3.0},
+                    {"path": "docs/specs/thread-abc.md", "score": 2.0},
+                    {"path": "journal/2026/2026-04-20.md", "score": 1.0},
+                ],
+            }
+
+        with (
+            patch("app.context.service.continuity_read_service", side_effect=_fake_continuity_read_service),
+            patch("app.context.service.read_file_service", side_effect=_fake_read_file_service),
+            patch("app.context.service.search_service", side_effect=_fake_search_service),
+        ):
+            result = _assemble_mixed_retrieval_bundle(
+                repo_root=Path("."),
+                auth=auth,
+                req=req,
+                now=datetime.now(timezone.utc),
+            )
+
+        self.assertEqual(result["continuity"], [capsule])
+        self.assertEqual(
+            result["supporting_documents"],
+            [
+                {
+                    "ok": True,
+                    "path": "docs/specs/thread-abc.md",
+                    "content": "content for docs/specs/thread-abc.md",
+                },
+                {
+                    "ok": True,
+                    "path": "docs/notes/thread-abc.md",
+                    "content": "content for docs/notes/thread-abc.md",
+                },
+            ],
+        )
+        self.assertEqual(
+            result["search_hits"],
+            [
+                {"path": "journal/2026/2026-04-20.md", "score": 3.0},
+                {"path": "docs/specs/thread-abc.md", "score": 2.0},
+            ],
+        )
+        self.assertEqual([name for name, _ in calls], ["continuity", "read", "read", "read", "search"])
+        continuity_req = calls[0][1]
+        self.assertEqual(continuity_req.subject_kind, "thread")
+        self.assertEqual(continuity_req.subject_id, "thread-abc")
+        self.assertFalse(continuity_req.allow_fallback)
+        search_req = calls[-1][1]
+        self.assertEqual(search_req.query, "thread-abc")
+        self.assertEqual(search_req.sort_by, "relevance")
+        self.assertEqual(search_req.include_types, [])
+
+    def test_missing_capsule_skips_related_documents_and_still_executes_search(self) -> None:
+        req = ContextRetrieveRequest(task="unused", subject_kind="task", subject_id="task-42")
+        calls: list[str] = []
+
+        def _fake_continuity_read_service(**_kwargs: object) -> dict[str, object]:
+            calls.append("continuity")
+            raise HTTPException(status_code=404, detail="File not found")
+
+        def _fake_search_service(**kwargs: object) -> dict[str, object]:
+            calls.append("search")
+            search_req = kwargs["req"]
+            return {"ok": True, "results": [{"path": "docs/tasks/task-42.md", "score": 1.0, "query": search_req.query}]}
+
+        with (
+            patch("app.context.service.continuity_read_service", side_effect=_fake_continuity_read_service),
+            patch("app.context.service.read_file_service") as read_file_service_mock,
+            patch("app.context.service.search_service", side_effect=_fake_search_service),
+        ):
+            result = _assemble_mixed_retrieval_bundle(
+                repo_root=Path("."),
+                auth=_AuthStub(),
+                req=req,
+                now=datetime.now(timezone.utc),
+            )
+
+        self.assertEqual(result["continuity"], [])
+        self.assertEqual(result["supporting_documents"], [])
+        self.assertEqual(result["search_hits"], [{"path": "docs/tasks/task-42.md", "score": 1.0, "query": "task-42"}])
+        self.assertEqual(calls, ["continuity", "search"])
+        read_file_service_mock.assert_not_called()
+
+    def test_phase_failures_degrade_without_synthetic_placeholders(self) -> None:
+        req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
+        capsule = {
+            "subject_kind": "thread",
+            "subject_id": "thread-abc",
+            "continuity": {
+                "related_documents": [
+                    {"path": "docs/specs/thread-abc.md", "kind": "spec", "label": "Spec"},
+                    {"path": "docs/notes/thread-abc.md", "kind": "note", "label": "Notes"},
+                ]
+            },
+        }
+
+        def _fake_read_file_service(**kwargs: object) -> dict[str, object]:
+            path = kwargs["path"]
+            if path == "docs/specs/thread-abc.md":
+                return {"ok": False, "path": path, "warning": "not readable now"}
+            raise HTTPException(status_code=404, detail="File not found")
+
+        with (
+            patch("app.context.service.continuity_read_service", return_value={"ok": True, "capsule": capsule}),
+            patch("app.context.service.read_file_service", side_effect=_fake_read_file_service),
+            patch("app.context.service.search_service", side_effect=RuntimeError("search backend offline")),
+        ):
+            result = _assemble_mixed_retrieval_bundle(
+                repo_root=Path("."),
+                auth=_AuthStub(),
+                req=req,
+                now=datetime.now(timezone.utc),
+            )
+
+        self.assertEqual(result["continuity"], [capsule])
+        self.assertEqual(
+            result["supporting_documents"],
+            [{"ok": False, "path": "docs/specs/thread-abc.md", "warning": "not readable now"}],
+        )
+        self.assertEqual(result["search_hits"], [])
+
+    def test_context_retrieve_surfaces_mixed_retrieval_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
+
+            with (
+                patch("app.context.service._load_core_memory", return_value=[]),
+                patch(
+                    "app.context.service.build_continuity_state",
+                    return_value={
+                        "present": False,
+                        "requested_selectors": [],
+                        "omitted_selectors": [],
+                        "capsules": [],
+                        "selection_order": [],
+                        "budget": {"token_budget_hint": "normal"},
+                        "warnings": [],
+                        "fallback_used": False,
+                        "recovery_warnings": [],
+                        "trust_signals": None,
+                        "salience_metadata": None,
+                    },
+                ),
+                patch("app.context.service._index_health", return_value="healthy"),
+                patch("app.context.service.search_index", return_value=[]),
+                patch(
+                    "app.context.service._assemble_mixed_retrieval_bundle",
+                    return_value={"continuity": [], "supporting_documents": [], "search_hits": []},
+                ),
+            ):
+                result = context_retrieve_service(
+                    repo_root=repo_root,
+                    auth=_AuthStub(),
+                    req=req,
+                    now=datetime.now(timezone.utc),
+                    audit=lambda *_args, **_kwargs: None,
+                )
+
+        self.assertEqual(
+            result["bundle"]["mixed_retrieval"],
+            {"continuity": [], "supporting_documents": [], "search_hits": []},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR delivers `#213` slice 1 only.

It covers:
- deterministic mixed-retrieval assembly order
- continuity-first exact read
- `related_documents` follow-on reads from the returned capsule only
- exact phase-3 search fallback posture
- same-class dedupe by exact path
- degraded phase handling
- internal-only mixed-retrieval bundle boundary
- no external API exposure for the internal bundle

## Why
This slice implements the hardened bounded retrieval contract for thread/task mixed retrieval assembly while keeping the mixed bundle internal-only in slice 1.

## Scope
- adds the internal deterministic mixed-retrieval assembler for `thread` and `task`
- consumes `related_documents` only from the returned continuity capsule
- preserves degraded phase behavior without synthetic placeholders
- removes external `context.retrieve` behavioral coupling to the internal mixed-retrieval assembler
- strengthens the regression around the documented external `context.retrieve` shape
- adds a minimal payload-reference clarification that the mixed-retrieval bundle remains internal-only

Refs #213

## Verification
- `./.venv/bin/python -m unittest -v tests.test_context_retrieval_213_slice1`
- `./.venv/bin/python -m unittest -v tests.test_context_retrieval tests.test_related_documents_217_slice1`
- `./.venv/bin/python -m ruff check app tests tools`
