### PR TITLE
[codex] Close #213 live runtime mixed retrieval gap

### DIFF
--- a/app/context/service.py
+++ b/app/context/service.py
@@ -168,6 +168,59 @@ def _assemble_mixed_retrieval_bundle(
     return bundle
 
 
+def _supports_internal_mixed_retrieval(req: ContextRetrieveRequest) -> bool:
+    """Return whether the request should use the bounded #213 mixed retrieval path."""
+    return req.subject_kind in {"thread", "task"} and bool(req.subject_id)
+
+
+def _mixed_retrieval_recent_relevant(bundle: dict[str, list[dict[str, Any]]], limit: int) -> list[dict[str, Any]]:
+    """Flatten the internal mixed-retrieval bundle into the external recent_relevant list.
+
+    The external response shape stays unchanged, so the internal three-class
+    retrieval is projected into one deterministic evidence list:
+    supporting documents first, then search fallback hits. Cross-class
+    duplicates are preserved because #213 forbids cross-class deduplication.
+    """
+    if limit <= 0:
+        return []
+
+    recent: list[dict[str, Any]] = []
+
+    for row in bundle.get("supporting_documents", []):
+        if not isinstance(row, dict):
+            continue
+        path = row.get("path")
+        if not isinstance(path, str):
+            continue
+        content = row.get("content")
+        snippet = _snippet_text(content) if isinstance(content, str) else ""
+        if isinstance(content, str):
+            item_type, _ = _record_type_importance(path, content)
+        else:
+            item_type = str(Path(path).suffix.lstrip(".") or (Path(path).parts[0] if Path(path).parts else "unknown"))
+        projected = {
+            "path": path,
+            "type": item_type,
+            "snippet": snippet,
+            "score": 0.0,
+        }
+        warning = row.get("warning")
+        if isinstance(warning, str) and warning:
+            projected["warning"] = warning
+        recent.append(projected)
+        if len(recent) >= limit:
+            return recent
+
+    for row in bundle.get("search_hits", []):
+        if not isinstance(row, dict):
+            continue
+        recent.append(row)
+        if len(recent) >= limit:
+            return recent
+
+    return recent
+
+
 def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run a git command inside the repository without raising on failure.
 
@@ -544,27 +597,36 @@ def context_retrieve_service(
     auth.require("search")
     core_memory = _load_core_memory(repo_root, auth)
     continuity_state = build_continuity_state(repo_root=repo_root, auth=auth, req=req, now=now)
-    index_health = _index_health(repo_root, now)
-    if index_health == "missing":
-        recent = _raw_scan_recent_relevant(repo_root, auth, req)
-        continuity_state["recovery_warnings"] = list(continuity_state.get("recovery_warnings", [])) + ["continuity_index_missing"]
+    if _supports_internal_mixed_retrieval(req):
+        mixed_retrieval = _assemble_mixed_retrieval_bundle(
+            repo_root=repo_root,
+            auth=auth,
+            req=req,
+            now=now,
+        )
+        recent = _mixed_retrieval_recent_relevant(mixed_retrieval, req.limit)
     else:
-        try:
-            recent = search_index(
-                repo_root,
-                req.task,
-                req.limit,
-                include_types=req.include_types or None,
-                time_window_days=req.time_window_days,
-            )
-            recent = _filter_search_results_for_auth(recent, auth)
-            recent = _exclude_continuity_cold_results(recent)
-        except Exception:
+        index_health = _index_health(repo_root, now)
+        if index_health == "missing":
             recent = _raw_scan_recent_relevant(repo_root, auth, req)
-            index_health = "stale"
-        if index_health == "stale":
-            continuity_state["recovery_warnings"] = list(continuity_state.get("recovery_warnings", [])) + ["continuity_index_stale"]
-    recent = _pack_recent_relevant(recent, req.limit)
+            continuity_state["recovery_warnings"] = list(continuity_state.get("recovery_warnings", [])) + ["continuity_index_missing"]
+        else:
+            try:
+                recent = search_index(
+                    repo_root,
+                    req.task,
+                    req.limit,
+                    include_types=req.include_types or None,
+                    time_window_days=req.time_window_days,
+                )
+                recent = _filter_search_results_for_auth(recent, auth)
+                recent = _exclude_continuity_cold_results(recent)
+            except Exception:
+                recent = _raw_scan_recent_relevant(repo_root, auth, req)
+                index_health = "stale"
+            if index_health == "stale":
+                continuity_state["recovery_warnings"] = list(continuity_state.get("recovery_warnings", [])) + ["continuity_index_stale"]
+        recent = _pack_recent_relevant(recent, req.limit)
     open_questions = [row["snippet"] for row in recent[:10] if "?" in row.get("snippet", "")]
     bundle = {
         "task": req.task,

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -642,7 +642,7 @@ Response:
 }
 ```
 
-When derived search indexes are stale, `continuity_state.warnings` includes `"continuity_index_stale"`. When indexes are missing, retrieval falls back to a bounded raw scan and adds `"continuity_index_missing"`.
+When derived search indexes are stale, `continuity_state.recovery_warnings` includes `"continuity_index_stale"`. When indexes are missing, retrieval falls back to a bounded raw scan and adds `"continuity_index_missing"` to `continuity_state.recovery_warnings`.
 
 The bounded `#213` mixed-retrieval bundle remains internal-only in slice 1 and is not part of the external `POST /v1/context/retrieve` response shape.
 

--- a/tests/test_context_retrieval_213_slice1.py
+++ b/tests/test_context_retrieval_213_slice1.py
@@ -253,7 +253,7 @@ class TestMixedRetrievalSlice1(unittest.TestCase):
             ],
         )
 
-    def test_context_retrieve_keeps_mixed_retrieval_internal_only(self) -> None:
+    def test_context_retrieve_uses_internal_mixed_retrieval_for_thread_subjects(self) -> None:
         req = ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-abc")
         continuity_state = {
             "present": False,
@@ -272,9 +272,18 @@ class TestMixedRetrievalSlice1(unittest.TestCase):
         with (
             patch("app.context.service._load_core_memory", return_value=[]),
             patch("app.context.service.build_continuity_state", return_value=continuity_state),
-            patch("app.context.service._index_health", return_value="healthy"),
-            patch("app.context.service.search_index", return_value=[]),
-            patch("app.context.service._assemble_mixed_retrieval_bundle") as mixed_retrieval_mock,
+            patch(
+                "app.context.service._assemble_mixed_retrieval_bundle",
+                return_value={
+                    "continuity": [{"subject_kind": "thread", "subject_id": "thread-abc"}],
+                    "supporting_documents": [
+                        {"ok": True, "path": "docs/specs/thread-abc.md", "content": "Spec body? yes."},
+                    ],
+                    "search_hits": [
+                        {"path": "docs/notes/thread-abc.md", "type": "note", "snippet": "Search follow-on.", "score": 2.0},
+                    ],
+                },
+            ) as mixed_retrieval_mock,
         ):
             now = datetime.now(timezone.utc)
             auth = _AuthStub()
@@ -286,7 +295,12 @@ class TestMixedRetrievalSlice1(unittest.TestCase):
                 audit=lambda *_args, **_kwargs: None,
             )
 
-        mixed_retrieval_mock.assert_not_called()
+        mixed_retrieval_mock.assert_called_once_with(
+            repo_root=Path("."),
+            auth=auth,
+            req=req,
+            now=now,
+        )
         self.assertEqual(
             set(result["bundle"].keys()),
             {
@@ -301,8 +315,78 @@ class TestMixedRetrievalSlice1(unittest.TestCase):
                 "continuity_state",
             },
         )
+        self.assertEqual(
+            result["bundle"]["recent_relevant"],
+            [
+                {
+                    "path": "docs/specs/thread-abc.md",
+                    "type": "docs",
+                    "snippet": "Spec body? yes.",
+                    "score": 0.0,
+                },
+                {
+                    "path": "docs/notes/thread-abc.md",
+                    "type": "note",
+                    "snippet": "Search follow-on.",
+                    "score": 2.0,
+                },
+            ],
+        )
+        self.assertEqual(result["bundle"]["open_questions"], ["Spec body? yes."])
         self.assertNotIn("mixed_retrieval", result["bundle"])
         self.assertNotIn("continuity", result["bundle"])
+        self.assertNotIn("supporting_documents", result["bundle"])
+        self.assertNotIn("search_hits", result["bundle"])
+
+    def test_context_retrieve_preserves_cross_class_duplicates_without_exposing_internal_bundle(self) -> None:
+        req = ContextRetrieveRequest(task="unused", subject_kind="task", subject_id="task-42", limit=3)
+        continuity_state = {
+            "present": True,
+            "requested_selectors": [],
+            "omitted_selectors": [],
+            "capsules": [{"subject_kind": "task", "subject_id": "task-42"}],
+            "selection_order": [],
+            "budget": {"token_budget_hint": "normal"},
+            "warnings": [],
+            "fallback_used": False,
+            "recovery_warnings": [],
+            "trust_signals": None,
+            "salience_metadata": None,
+        }
+
+        with (
+            patch("app.context.service._load_core_memory", return_value=[]),
+            patch("app.context.service.build_continuity_state", return_value=continuity_state),
+            patch(
+                "app.context.service._assemble_mixed_retrieval_bundle",
+                return_value={
+                    "continuity": [{"subject_kind": "task", "subject_id": "task-42"}],
+                    "supporting_documents": [
+                        {"ok": True, "path": "docs/tasks/task-42.md", "content": "Task support"},
+                    ],
+                    "search_hits": [
+                        {"path": "docs/tasks/task-42.md", "type": "task_note", "snippet": "Fallback hit", "score": 1.0},
+                        {"path": "docs/other.md", "type": "note", "snippet": "Second hit", "score": 0.5},
+                    ],
+                },
+            ),
+        ):
+            result = context_retrieve_service(
+                repo_root=Path("."),
+                auth=_AuthStub(),
+                req=req,
+                now=datetime.now(timezone.utc),
+                audit=lambda *_args, **_kwargs: None,
+            )
+
+        self.assertEqual(
+            [item["path"] for item in result["bundle"]["recent_relevant"]],
+            [
+                "docs/tasks/task-42.md",
+                "docs/tasks/task-42.md",
+                "docs/other.md",
+            ],
+        )
         self.assertNotIn("supporting_documents", result["bundle"])
         self.assertNotIn("search_hits", result["bundle"])
 


### PR DESCRIPTION
Fixes #213

## What changed
- activated the internal #213 mixed-retrieval assembler on the live thread/task selector path in context.retrieve while keeping the external response shape unchanged
- replaced the previous non-call regression with runtime-level tests that prove the internal assembler is used and remains internal-only
- aligned payload-reference warning placement with runtime by documenting stale/missing retrieval degradation under continuity_state.recovery_warnings

## Why
The merged slice-1 work left the deterministic mixed-retrieval contract isolated in a helper instead of active on the real retrieval path, so #213 was not yet complete against its hardened issue body.

## Impact
- thread/task selector retrieval now executes the exact continuity -> related_documents -> search fallback sequence internally
- no new external HTTP/API surface was introduced; context.retrieve still returns the same bounded bundle shape
- docs, runtime, and targeted regression coverage are now aligned on degraded warning placement and internal/external boundaries

## Validation
- ./.venv/bin/python -m unittest -v tests.test_context_retrieval_213_slice1
- ./.venv/bin/python -m unittest -v tests.test_context_retrieval tests.test_related_documents_217_slice1 tests.test_related_documents_217_slice2
- ./.venv/bin/python -m ruff check app tests tools
