### PR TITLE
Fix #227: finalize continuity budget hardening

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,4 +1,4 @@
-"""Product-contract constants for context retrieval request budgeting."""
+"""Application-wide product-contract constants."""
 
 CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS = 12_000
 CONTEXT_RETRIEVE_MIN_MAX_TOKENS = 256

--- a/app/context_contract.py
+++ b/app/context_contract.py
@@ -1,0 +1,5 @@
+"""Product-contract constants for context retrieval request budgeting."""
+
+CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS = 12_000
+CONTEXT_RETRIEVE_MIN_MAX_TOKENS = 256
+CONTEXT_RETRIEVE_MAX_MAX_TOKENS = 100_000

--- a/app/continuity/constants.py
+++ b/app/continuity/constants.py
@@ -317,5 +317,8 @@ PATCH_TARGET_MAX_LENGTH: dict[str, int] = {
     "thread_descriptor.identity_anchors": 4,
 }
 
-# Capsule size limit in bytes (12 KB).
-CAPSULE_SIZE_LIMIT_BYTES = 12 * 1024
+# Product-contract continuity capsule write cap (#227).
+CAPSULE_SIZE_LIMIT_KB = 20
+CAPSULE_SIZE_LIMIT_BYTES = CAPSULE_SIZE_LIMIT_KB * 1024
+CAPSULE_SIZE_LIMIT_LABEL = f"{CAPSULE_SIZE_LIMIT_KB} KB"
+CAPSULE_SIZE_LIMIT_ERROR_DETAIL = f"Continuity capsule exceeds {CAPSULE_SIZE_LIMIT_LABEL} serialized UTF-8"

--- a/app/continuity/service.py
+++ b/app/continuity/service.py
@@ -50,6 +50,7 @@ from app.models import (
 )
 from app.storage import canonical_json, safe_path, write_bytes_file, write_text_file
 from app.continuity.constants import (
+    CAPSULE_SIZE_LIMIT_ERROR_DETAIL,
     CAPSULE_SIZE_LIMIT_BYTES,
     CONTINUITY_ARCHIVE_SCHEMA_TYPE,
     CONTINUITY_ARCHIVE_SCHEMA_VERSION,
@@ -603,7 +604,7 @@ def continuity_upsert_service(
         # machine above.  This is the binding check — Phase 1 is an early
         # reject on the smaller pre-mutation payload.
         if len(new_bytes) > CAPSULE_SIZE_LIMIT_BYTES:
-            raise HTTPException(status_code=400, detail="Continuity capsule exceeds 12 KB serialized UTF-8")
+            raise HTTPException(status_code=400, detail=CAPSULE_SIZE_LIMIT_ERROR_DETAIL)
         if old_bytes != new_bytes:
             stripped_req = ContinuityUpsertRequest(
                 subject_kind=req.subject_kind,
@@ -913,7 +914,7 @@ def continuity_patch_service(
         canonical = canonical_json(capsule_snapshot.model_dump(mode="json", exclude_none=True))
         new_bytes = canonical.encode("utf-8")
         if len(new_bytes) > CAPSULE_SIZE_LIMIT_BYTES:
-            raise HTTPException(status_code=400, detail="Continuity capsule exceeds 12 KB serialized UTF-8")
+            raise HTTPException(status_code=400, detail=CAPSULE_SIZE_LIMIT_ERROR_DETAIL)
 
         capsule_sha256 = hashlib.sha256(new_bytes).hexdigest()
         changed = old_bytes != new_bytes
@@ -1038,7 +1039,7 @@ def continuity_lifecycle_service(
         canonical = canonical_json(capsule.model_dump(mode="json", exclude_none=True))
         new_bytes = canonical.encode("utf-8")
         if len(new_bytes) > CAPSULE_SIZE_LIMIT_BYTES:
-            raise HTTPException(status_code=400, detail="Continuity capsule exceeds 12 KB serialized UTF-8")
+            raise HTTPException(status_code=400, detail=CAPSULE_SIZE_LIMIT_ERROR_DETAIL)
 
         capsule_sha256 = hashlib.sha256(new_bytes).hexdigest()
         changed = old_bytes != new_bytes

--- a/app/continuity/trimming.py
+++ b/app/continuity/trimming.py
@@ -181,11 +181,8 @@ def _trim_capsule(capsule: dict[str, Any], max_tokens: int) -> tuple[dict[str, A
 
 def _budget(requested_max_tokens: int) -> dict[str, int]:
     """Compute the continuity token reservation from the requested budget."""
-    token_budget_hint = min(requested_max_tokens, 4000)
-    if token_budget_hint < 1000:
-        reserved = min(150, max(0, int(token_budget_hint * 0.2)))
-    else:
-        reserved = min(800, max(200, int(token_budget_hint * 0.2)))
+    token_budget_hint = requested_max_tokens
+    reserved = requested_max_tokens
     return {
         "requested_max_tokens_estimate": requested_max_tokens,
         "token_budget_hint": token_budget_hint,

--- a/app/continuity/validation.py
+++ b/app/continuity/validation.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from app.continuity.constants import (
+    CAPSULE_SIZE_LIMIT_ERROR_DETAIL,
     CAPSULE_SIZE_LIMIT_BYTES,
     CONTINUITY_CAPSULE_SCHEMA_VERSION,
     CONTINUITY_SUPPORTED_CAPSULE_SCHEMA_VERSIONS,
@@ -638,7 +639,7 @@ def _validate_capsule(repo_root: Path, capsule: ContinuityCapsule) -> tuple[dict
     payload = capsule.model_dump(mode="json", exclude_none=True)
     canonical = canonical_json(payload)
     if len(canonical.encode("utf-8")) > CAPSULE_SIZE_LIMIT_BYTES:
-        raise HTTPException(status_code=400, detail="Continuity capsule exceeds 12 KB serialized UTF-8")
+        raise HTTPException(status_code=400, detail=CAPSULE_SIZE_LIMIT_ERROR_DETAIL)
     return payload, canonical
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,12 @@ from typing import Annotated, Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, model_validator
 from pydantic.json_schema import SkipJsonSchema
 
+from app.context_contract import (
+    CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS,
+    CONTEXT_RETRIEVE_MAX_MAX_TOKENS,
+    CONTEXT_RETRIEVE_MIN_MAX_TOKENS,
+)
+
 
 PeerId = Annotated[str, Field(min_length=1, max_length=200)]
 
@@ -91,7 +97,11 @@ class ContextRetrieveRequest(BaseModel):
     continuity_resilience_policy: Literal["allow_fallback", "prefer_active", "require_active"] = "allow_fallback"
     continuity_selectors: List["ContinuitySelector"] = Field(default_factory=list, max_length=4)
     continuity_max_capsules: int = Field(default=1, ge=1, le=4)
-    max_tokens_estimate: int = Field(default=4000, ge=256, le=100000)
+    max_tokens_estimate: int = Field(
+        default=CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS,
+        ge=CONTEXT_RETRIEVE_MIN_MAX_TOKENS,
+        le=CONTEXT_RETRIEVE_MAX_MAX_TOKENS,
+    )
     include_types: List[str] = Field(default_factory=list)
     time_window_days: int = Field(default=30, ge=1, le=3650)
     limit: int = Field(default=10, ge=1, le=100)

--- a/app/models.py
+++ b/app/models.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, ConfigDict, Field, WithJsonSchema, model_validator
 from pydantic.json_schema import SkipJsonSchema
 
-from app.context_contract import (
+from app.constants import (
     CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS,
     CONTEXT_RETRIEVE_MAX_MAX_TOKENS,
     CONTEXT_RETRIEVE_MIN_MAX_TOKENS,

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -76,7 +76,7 @@ The system is designed so that a fully-populated capsule with practical content 
 | Top-level metadata (`subject_kind`, `subject_id`, timestamps, etc.) | ~60 | ~6 fields | |
 | **Total (fully populated)** | **~3,400–3,800** | **~94 fields** | **~14 KB JSON (theoretical; see note below)** |
 
-> **Note on write-time size limit:** The server enforces a 12 KB serialized-UTF-8 cap on each capsule at write time. The ~14 KB figure above is the theoretical maximum when *every* optional field is populated at its maximum length simultaneously — a shape that exceeds the write limit and would be rejected. In practice a fully-featured capsule with realistic content fits within 10–11 KB. When populating both `stable_preferences` (up to ~4.6 KB at max lengths) and the full set of continuity fields, agents should expect to trade off less-critical optional content to stay within the 12 KB cap.
+> **Note on write-time size limit:** The server enforces a 20 KB serialized-UTF-8 cap on each capsule at write time. The ~14 KB figure above is the theoretical maximum when *every* optional field is populated at its maximum length simultaneously. In practice a fully-featured capsule with realistic content fits within the 20 KB cap with bounded headroom, including rich `stable_preferences`.
 
 ### Context window impact
 
@@ -94,9 +94,9 @@ The system is designed so that a fully-populated capsule with practical content 
 
 **Full capsule** — populate every field including `relationship_model`, `retrieval_hints`, `attention_policy`, `negative_decisions`, `rationale_entries`, `session_trajectory`, `verification_state`, and `capsule_health`. This costs approximately **~2,800–3,600 tokens** and provides the richest possible orientation.
 
-**Under token pressure** — the system trims optional fields in two phases. Phase 1 drops whole optional sections in deterministic order: `metadata`, `canonical_sources`, `freshness`, `attention_policy.presence_bias_overrides`, `relationship_model` sub-fields (`sensitivity_notes`, `preferred_style`), `retrieval_hints` sub-fields (`avoid`, `load_next`), `trailing_notes`, `curiosity_queue`, `rationale_entries`, `negative_decisions`, `working_hypotheses`, then `stable_preferences` (dropped as a whole unit — all-or-nothing). Phase 2, if still over budget, progressively trims `retrieval_hints.must_include`, the remaining `relationship_model`, `long_horizon_commitments`, `stance_summary`, `drift_signals`, and finally the core lists. The 6 required core lists and `stance_summary` are trimmed only as a last resort. When `stable_preferences` is trimmed, `"stable_preferences"` appears in `trimmed_fields`; when `rationale_entries` is trimmed, `"continuity.rationale_entries"` appears in `trimmed_fields`.
+**Under token pressure** — the system trims optional fields in two phases. Phase 1 drops whole optional sections in deterministic order: `metadata`, `canonical_sources`, `freshness`, `attention_policy.presence_bias_overrides`, `relationship_model` sub-fields (`sensitivity_notes`, `preferred_style`), `retrieval_hints` sub-fields (`avoid`, `load_next`), `trailing_notes`, `curiosity_queue`, `rationale_entries`, `negative_decisions`, `working_hypotheses`, then `stable_preferences` (dropped as a whole unit — all-or-nothing). Phase 2, if still over budget, progressively trims `retrieval_hints.must_include`, the remaining `relationship_model`, `long_horizon_commitments`, `stance_summary`, `drift_signals`, and finally the core lists. The 6 required core lists and `stance_summary` are trimmed only as a last resort. This trim order is a fixed product-contract rule. When `stable_preferences` is trimmed, `"stable_preferences"` appears in `trimmed_fields`; when `rationale_entries` is trimmed, `"continuity.rationale_entries"` appears in `trimmed_fields`.
 
-**Multi-capsule retrieval** — `POST /v1/context/retrieve` supports loading up to 4 capsules via `continuity_selectors` and `continuity_max_capsules`. At full population, 4 capsules would cost ~10,000–11,000 tokens. The `max_tokens_estimate` parameter controls the total continuity token budget directly. Its product-contract default is `12,000`, and an explicit request value overrides that default for the current call.
+**Multi-capsule retrieval** — `POST /v1/context/retrieve` supports loading up to 4 capsules via `continuity_selectors` and `continuity_max_capsules`. At full population, 4 capsules would cost ~10,000–11,000 tokens. The `max_tokens_estimate` parameter controls the total continuity token budget directly. Its product-contract default is `12,000`, and an explicit request value overrides that default for the current call. The fixed default is intended to fit a rich thread capsule, rich task capsule, and rich user/preferences capsule together without pathological trimming.
 
 ### Per-item string constraints
 
@@ -205,7 +205,7 @@ These are the core orientation fields that an agent writes to preserve working s
 | `relationship_model` | ContinuityRelationshipModel | no | | Relationship-specific hints |
 | `retrieval_hints` | ContinuityRetrievalHints | no | | Preferences for what to load next |
 
-Optional fields have a deterministic trim order under token pressure. When the capsule must fit within a budget, the system trims from the bottom of the table upward — `retrieval_hints` first, then `relationship_model`, then `curiosity_queue`, then `rationale_entries`, and so on.
+Optional fields have a deterministic trim order under token pressure. When the capsule must fit within a budget, trimming follows the fixed two-phase order documented above: whole optional sections drop first in deterministic order, then the remaining `retrieval_hints`, `relationship_model`, `long_horizon_commitments`, `stance_summary`, `drift_signals`, and finally the core lists are trimmed only as a last resort.
 
 ### RationaleEntry
 
@@ -627,7 +627,7 @@ Response:
     "core_memory": [{"path": "...", "snippet": "..."}],
     "recent_relevant": [{"path": "...", "type": "...", "snippet": "...", "score": 1.0}],
     "open_questions": ["..."],
-    "token_budget_hint": "12000",
+    "token_budget_hint": 12000,
     "time_window_days": 30,
     "notes": ["..."],
     "continuity_state": {

--- a/docs/payload-reference.md
+++ b/docs/payload-reference.md
@@ -96,7 +96,7 @@ The system is designed so that a fully-populated capsule with practical content 
 
 **Under token pressure** — the system trims optional fields in two phases. Phase 1 drops whole optional sections in deterministic order: `metadata`, `canonical_sources`, `freshness`, `attention_policy.presence_bias_overrides`, `relationship_model` sub-fields (`sensitivity_notes`, `preferred_style`), `retrieval_hints` sub-fields (`avoid`, `load_next`), `trailing_notes`, `curiosity_queue`, `rationale_entries`, `negative_decisions`, `working_hypotheses`, then `stable_preferences` (dropped as a whole unit — all-or-nothing). Phase 2, if still over budget, progressively trims `retrieval_hints.must_include`, the remaining `relationship_model`, `long_horizon_commitments`, `stance_summary`, `drift_signals`, and finally the core lists. The 6 required core lists and `stance_summary` are trimmed only as a last resort. When `stable_preferences` is trimmed, `"stable_preferences"` appears in `trimmed_fields`; when `rationale_entries` is trimmed, `"continuity.rationale_entries"` appears in `trimmed_fields`.
 
-**Multi-capsule retrieval** — `POST /v1/context/retrieve` supports loading up to 4 capsules via `continuity_selectors` and `continuity_max_capsules`. At full population, 4 capsules would cost ~10,000–11,000 tokens. The `max_tokens_estimate` parameter (default 4,000) controls the total continuity token budget, and the system trims each capsule to fit.
+**Multi-capsule retrieval** — `POST /v1/context/retrieve` supports loading up to 4 capsules via `continuity_selectors` and `continuity_max_capsules`. At full population, 4 capsules would cost ~10,000–11,000 tokens. The `max_tokens_estimate` parameter controls the total continuity token budget directly. Its product-contract default is `12,000`, and an explicit request value overrides that default for the current call.
 
 ### Per-item string constraints
 
@@ -611,7 +611,7 @@ At least one delete flag must be `true`.
 | `continuity_resilience_policy` | `"allow_fallback"` \| `"prefer_active"` \| `"require_active"` | no | default `"allow_fallback"` |
 | `continuity_selectors` | list of ContinuitySelector | no | max 4 items |
 | `continuity_max_capsules` | integer | no | 1–4, default 1 |
-| `max_tokens_estimate` | integer | no | 256–100,000, default 4000 |
+| `max_tokens_estimate` | integer | no | 256–100,000, default 12000 |
 | `include_types` | list of strings | no | default `[]` |
 | `time_window_days` | integer | no | 1–3650, default 30 |
 | `limit` | integer | no | 1–100, default 10 |
@@ -627,7 +627,7 @@ Response:
     "core_memory": [{"path": "...", "snippet": "..."}],
     "recent_relevant": [{"path": "...", "type": "...", "snippet": "...", "score": 1.0}],
     "open_questions": ["..."],
-    "token_budget_hint": "4000",
+    "token_budget_hint": "12000",
     "time_window_days": 30,
     "notes": ["..."],
     "continuity_state": {

--- a/tests/test_context_retrieval.py
+++ b/tests/test_context_retrieval.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from app.config import Settings
+from app.context_contract import CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS
 from app.context.service import _select_top_raw_scan_candidates
 from app.indexer import rebuild_index
 from app.main import context_retrieve, recent_list, search
@@ -240,6 +241,53 @@ class TestContextRetrieval(unittest.TestCase):
             bundle = result["bundle"]
             self.assertEqual(len(bundle["recent_relevant"]), 1)
             self.assertEqual(bundle["recent_relevant"][0]["path"], "journal/2026/2026-03-20.md")
+
+    def test_context_retrieve_uses_contract_default_budget_when_omitted(self) -> None:
+        """Omitted max_tokens_estimate should use the contract default without hidden down-clamping."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            (repo_root / "memory" / "core").mkdir(parents=True, exist_ok=True)
+            (repo_root / "memory" / "core" / "identity.md").write_text(
+                "---\ntype: core_memory\n---\nAgent identity.",
+                encoding="utf-8",
+            )
+
+            settings = self._settings(repo_root)
+            with patch("app.main._services", return_value=(settings, _GitManagerStub())):
+                result = context_retrieve(ContextRetrieveRequest(task="startup"), auth=_AuthStub())
+
+            self.assertTrue(result["ok"])
+            bundle = result["bundle"]
+            budget = bundle["continuity_state"]["budget"]
+            self.assertEqual(bundle["token_budget_hint"], CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS)
+            self.assertEqual(budget["requested_max_tokens_estimate"], CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS)
+            self.assertEqual(budget["token_budget_hint"], CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS)
+            self.assertEqual(budget["continuity_tokens_reserved"], CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS)
+
+    def test_context_retrieve_preserves_explicit_budget_override(self) -> None:
+        """Explicit max_tokens_estimate should remain the effective continuity budget."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            (repo_root / "memory" / "core").mkdir(parents=True, exist_ok=True)
+            (repo_root / "memory" / "core" / "identity.md").write_text(
+                "---\ntype: core_memory\n---\nAgent identity.",
+                encoding="utf-8",
+            )
+
+            settings = self._settings(repo_root)
+            with patch("app.main._services", return_value=(settings, _GitManagerStub())):
+                result = context_retrieve(
+                    ContextRetrieveRequest(task="startup", max_tokens_estimate=2048),
+                    auth=_AuthStub(),
+                )
+
+            self.assertTrue(result["ok"])
+            bundle = result["bundle"]
+            budget = bundle["continuity_state"]["budget"]
+            self.assertEqual(bundle["token_budget_hint"], 2048)
+            self.assertEqual(budget["requested_max_tokens_estimate"], 2048)
+            self.assertEqual(budget["token_budget_hint"], 2048)
+            self.assertEqual(budget["continuity_tokens_reserved"], 2048)
 
 
 if __name__ == "__main__":

--- a/tests/test_context_retrieval.py
+++ b/tests/test_context_retrieval.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from app.config import Settings
-from app.context_contract import CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS
+from app.constants import CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS
 from app.context.service import _select_top_raw_scan_candidates
 from app.indexer import rebuild_index
 from app.main import context_retrieve, recent_list, search

--- a/tests/test_context_retrieval.py
+++ b/tests/test_context_retrieval.py
@@ -1,5 +1,6 @@
 """Tests for context retrieval search, recency, and limit behavior."""
 
+import json
 import os
 import tempfile
 import unittest
@@ -38,6 +39,101 @@ class _GitManagerStub:
     def latest_commit(self) -> str:
         """Return a stable fake commit hash."""
         return "test-sha"
+
+
+def _now_iso() -> str:
+    """Return a deterministic ISO timestamp for continuity fixtures."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_continuity_capsule(repo_root: Path, payload: dict) -> None:
+    """Persist a continuity capsule fixture under the repo root."""
+    continuity_dir = repo_root / "memory" / "continuity"
+    continuity_dir.mkdir(parents=True, exist_ok=True)
+    path = continuity_dir / f"{payload['subject_kind']}-{payload['subject_id']}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _rich_capsule(subject_kind: str, subject_id: str, *, include_prefs: bool = False) -> dict:
+    """Return a bounded but rich continuity capsule used for #227 practicality checks."""
+    now = _now_iso()
+    capsule = {
+        "schema_version": "1.1",
+        "subject_kind": subject_kind,
+        "subject_id": subject_id,
+        "updated_at": now,
+        "verified_at": now,
+        "verification_kind": "self_review",
+        "source": {
+            "producer": "test-hook",
+            "update_reason": "manual",
+            "inputs": [f"memory/core/input-{idx}.md" for idx in range(6)],
+        },
+        "confidence": {"continuity": 0.9, "relationship_model": 0.7},
+        "attention_policy": {
+            "early_load": [f"early-load {idx} " + "x" * 40 for idx in range(5)],
+            "presence_bias_overrides": [f"presence-bias {idx} " + "y" * 40 for idx in range(4)],
+        },
+        "freshness": {
+            "freshness_class": "situational",
+            "expires_at": "2099-01-01T00:00:00Z",
+            "stale_after_seconds": 2592000,
+        },
+        "canonical_sources": [f"docs/source-{idx}.md" for idx in range(4)],
+        "metadata": {"project": "CogniRelay", "slice": "#227"},
+        "continuity": {
+            "top_priorities": [f"top priority {idx} " + "a" * 80 for idx in range(6)],
+            "active_concerns": [f"concern {idx} " + "b" * 80 for idx in range(4)],
+            "active_constraints": [f"constraint {idx} " + "c" * 80 for idx in range(6)],
+            "open_loops": [f"loop {idx} " + "d" * 80 for idx in range(6)],
+            "stance_summary": "Rich orientation stance " + "e" * 120,
+            "drift_signals": [f"drift {idx} " + "f" * 80 for idx in range(4)],
+            "working_hypotheses": [f"hypothesis {idx} " + "g" * 60 for idx in range(3)],
+            "long_horizon_commitments": [f"commitment {idx} " + "h" * 60 for idx in range(3)],
+            "trailing_notes": [f"note {idx} " + "i" * 60 for idx in range(2)],
+            "curiosity_queue": [f"question {idx} " + "j" * 60 for idx in range(3)],
+            "rationale_entries": [
+                {
+                    "tag": f"rationale-{idx}",
+                    "kind": "decision",
+                    "status": "active",
+                    "summary": "summary " + "k" * 120,
+                    "reasoning": "reasoning " + "l" * 180,
+                    "alternatives_considered": ["alt " + "m" * 40],
+                    "depends_on": ["dep " + "n" * 30],
+                    "created_at": now,
+                    "updated_at": now,
+                }
+                for idx in range(2)
+            ],
+            "related_documents": [
+                {"path": f"docs/doc-{idx}.md", "kind": "spec", "label": "label " + "o" * 40, "relevance": "supporting"}
+                for idx in range(2)
+            ],
+            "relationship_model": {
+                "trust_level": "high",
+                "preferred_style": [f"style {idx} " + "p" * 40 for idx in range(3)],
+                "sensitivity_notes": [f"sensitivity {idx} " + "q" * 40 for idx in range(3)],
+            },
+            "retrieval_hints": {
+                "must_include": [f"must-include {idx} " + "r" * 40 for idx in range(4)],
+                "avoid": [f"avoid {idx} " + "s" * 40 for idx in range(3)],
+                "load_next": [f"load-next {idx} " + "t" * 40 for idx in range(3)],
+            },
+        },
+    }
+    if include_prefs:
+        capsule["stable_preferences"] = [
+            {
+                "tag": f"pref-{idx}",
+                "content": "preference " + "u" * 120,
+                "created_at": now,
+                "updated_at": now,
+                "last_confirmed_at": now,
+            }
+            for idx in range(6)
+        ]
+    return capsule
 
 
 class TestContextRetrieval(unittest.TestCase):
@@ -288,6 +384,69 @@ class TestContextRetrieval(unittest.TestCase):
             self.assertEqual(budget["requested_max_tokens_estimate"], 2048)
             self.assertEqual(budget["token_budget_hint"], 2048)
             self.assertEqual(budget["continuity_tokens_reserved"], 2048)
+
+    def test_context_retrieve_default_budget_supports_rich_thread_task_user_capsules(self) -> None:
+        """The #227 default budget should fit rich thread/task/user capsules without trim changes."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            (repo_root / "memory" / "core").mkdir(parents=True, exist_ok=True)
+            (repo_root / "memory" / "core" / "identity.md").write_text(
+                "---\ntype: core_memory\n---\nAgent identity.",
+                encoding="utf-8",
+            )
+            capsules = [
+                _rich_capsule("thread", "thread-227"),
+                _rich_capsule("task", "task-227"),
+                _rich_capsule("user", "user-227", include_prefs=True),
+            ]
+            for capsule in capsules:
+                _write_continuity_capsule(repo_root, capsule)
+            rebuild_index(repo_root)
+
+            settings = self._settings(repo_root)
+            with patch("app.main._services", return_value=(settings, _GitManagerStub())):
+                result = context_retrieve(
+                    ContextRetrieveRequest(
+                        task="resume issue 227 work",
+                        continuity_selectors=[
+                            {"subject_kind": "thread", "subject_id": "thread-227"},
+                            {"subject_kind": "task", "subject_id": "task-227"},
+                            {"subject_kind": "user", "subject_id": "user-227"},
+                        ],
+                        continuity_max_capsules=3,
+                    ),
+                    auth=_AuthStub(),
+                )
+
+            self.assertTrue(result["ok"])
+            continuity_state = result["bundle"]["continuity_state"]
+            self.assertEqual(result["bundle"]["token_budget_hint"], CONTEXT_RETRIEVE_DEFAULT_MAX_TOKENS)
+            self.assertEqual(len(continuity_state["capsules"]), 3)
+            self.assertFalse(continuity_state["trust_signals"]["completeness"]["any_trimmed"])
+            self.assertEqual(continuity_state["warnings"], [])
+            user_capsule = next(c for c in continuity_state["capsules"] if c["subject_kind"] == "user")
+            self.assertGreater(len(user_capsule.get("stable_preferences", [])), 0)
+            for capsule in continuity_state["capsules"]:
+                completeness = capsule["trust_signals"]["completeness"]
+                self.assertFalse(completeness["trimmed"])
+                self.assertEqual(completeness["trimmed_fields"], [])
+
+    def test_payload_reference_matches_budget_contract(self) -> None:
+        """Docs should expose the retrieval budget contract and fixed trim policy."""
+        payload_reference = Path(__file__).resolve().parents[1] / "docs" / "payload-reference.md"
+        text = payload_reference.read_text(encoding="utf-8")
+
+        self.assertIn("| `max_tokens_estimate` | integer | no | 256–100,000, default 12000 |", text)
+        self.assertIn('"token_budget_hint": 12000', text)
+        self.assertIn("This trim order is a fixed product-contract rule.", text)
+        self.assertIn(
+            "trimming follows the fixed two-phase order documented above: whole optional "
+            "sections drop first in deterministic order, then the remaining "
+            "`retrieval_hints`, `relationship_model`, `long_horizon_commitments`, "
+            "`stance_summary`, `drift_signals`, and finally the core lists are "
+            "trimmed only as a last resort.",
+            text,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_continuity_120_thread_identity.py
+++ b/tests/test_continuity_120_thread_identity.py
@@ -8,6 +8,11 @@ from typing import Any
 from unittest.mock import patch
 
 from app.config import Settings
+from app.continuity.constants import (
+    CAPSULE_SIZE_LIMIT_BYTES,
+    CAPSULE_SIZE_LIMIT_ERROR_DETAIL,
+    CAPSULE_SIZE_LIMIT_LABEL,
+)
 from app.main import continuity_list, continuity_read, continuity_upsert
 from app.models import (
     ContinuityCapsule,
@@ -17,9 +22,11 @@ from app.models import (
 )
 from app.continuity.validation import (
     _strip_service_managed_descriptor_fields,
+    _validate_capsule,
     _validate_lifecycle_transition_request,
     _validate_thread_descriptor,
 )
+from app.storage import canonical_json
 
 from fastapi import HTTPException
 
@@ -134,6 +141,26 @@ def _td(
     if superseded_by is not None:
         d["superseded_by"] = superseded_by
     return d
+
+
+def _capsule_with_serialized_size(target_bytes: int) -> dict:
+    """Return a valid capsule whose canonical JSON matches the requested size."""
+    payload = _base_capsule(thread_descriptor=_td())
+    payload["metadata"] = {"padding": ""}
+    current = len(canonical_json(ContinuityCapsule(**payload).model_dump(mode="json", exclude_none=True)).encode("utf-8"))
+    if current > target_bytes:
+        raise AssertionError("Base capsule already exceeds target size")
+    payload["metadata"]["padding"] = "x" * (target_bytes - current)
+    current = len(canonical_json(ContinuityCapsule(**payload).model_dump(mode="json", exclude_none=True)).encode("utf-8"))
+    while current > target_bytes:
+        payload["metadata"]["padding"] = payload["metadata"]["padding"][:-1]
+        current = len(canonical_json(ContinuityCapsule(**payload).model_dump(mode="json", exclude_none=True)).encode("utf-8"))
+    while current < target_bytes:
+        payload["metadata"]["padding"] += "x"
+        current = len(canonical_json(ContinuityCapsule(**payload).model_dump(mode="json", exclude_none=True)).encode("utf-8"))
+    if current != target_bytes:
+        raise AssertionError(f"Unable to reach target size {target_bytes}; got {current}")
+    return payload
 
 
 def _do_upsert(
@@ -796,9 +823,9 @@ class TestBackwardCompatibility(unittest.TestCase):
 
 
 class TestSizeLimit(unittest.TestCase):
-    """Maximally-sized thread_descriptor stays under 12 KB."""
+    """Continuity capsule size-cap boundaries stay aligned with the #227 contract."""
 
-    def test_max_descriptor_under_12kb(self) -> None:
+    def test_max_descriptor_under_write_cap(self) -> None:
         td = _td(
             label="x" * 120,
             keywords=["k" * 40] * 6,
@@ -813,6 +840,38 @@ class TestSizeLimit(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             out = _do_upsert(Path(tmp), _base_capsule(thread_descriptor=td))
         self.assertTrue(out["ok"])
+
+    def test_capsule_one_byte_below_write_cap_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            payload = _capsule_with_serialized_size(CAPSULE_SIZE_LIMIT_BYTES - 1)
+            capsule = ContinuityCapsule(**payload)
+            _, canonical = _validate_capsule(Path(td), capsule)
+
+        self.assertEqual(len(canonical.encode("utf-8")), CAPSULE_SIZE_LIMIT_BYTES - 1)
+
+    def test_capsule_exactly_at_write_cap_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            payload = _capsule_with_serialized_size(CAPSULE_SIZE_LIMIT_BYTES)
+            capsule = ContinuityCapsule(**payload)
+            _, canonical = _validate_capsule(Path(td), capsule)
+
+        self.assertEqual(len(canonical.encode("utf-8")), CAPSULE_SIZE_LIMIT_BYTES)
+
+    def test_capsule_one_byte_above_write_cap_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            payload = _capsule_with_serialized_size(CAPSULE_SIZE_LIMIT_BYTES + 1)
+            capsule = ContinuityCapsule(**payload)
+            with self.assertRaises(HTTPException) as ctx:
+                _validate_capsule(Path(td), capsule)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.detail, CAPSULE_SIZE_LIMIT_ERROR_DETAIL)
+
+    def test_payload_reference_mentions_current_write_cap(self) -> None:
+        payload_reference = Path(__file__).resolve().parents[1] / "docs" / "payload-reference.md"
+        text = payload_reference.read_text(encoding="utf-8")
+
+        self.assertIn(f"enforces a {CAPSULE_SIZE_LIMIT_LABEL} serialized-UTF-8 cap", text)
 
 
 # ===========================================================================
@@ -1015,10 +1074,10 @@ class TestTerminalStateErrorMessages(unittest.TestCase):
 
 
 class TestPostMutationSizeCheck(unittest.TestCase):
-    """The authoritative 12 KB size check runs on the final payload including lifecycle fields."""
+    """The authoritative write-cap check runs on the final payload including lifecycle fields."""
 
     def test_boundary_capsule_lifecycle_fields_counted(self) -> None:
-        """A capsule near the 12 KB limit must include lifecycle fields in the size budget."""
+        """A capsule near the write cap must include lifecycle fields in the size budget."""
         # Build a capsule that uses most of the budget via padded metadata
         # so lifecycle fields ("lifecycle":"active") are counted.
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_continuity_176_patch.py
+++ b/tests/test_continuity_176_patch.py
@@ -776,7 +776,7 @@ class TestPatchNormalization(unittest.TestCase):
 
 
 class TestPatchSizeLimit(unittest.TestCase):
-    """AC-15: post-patch validation rejects capsule exceeding 12 KB."""
+    """AC-15: post-patch validation rejects capsules beyond the continuity write cap."""
 
     def test_oversized_capsule_rejected(self) -> None:
         """Post-patch validation catches capsules that exceed field-level or size limits."""

--- a/tests/test_continuity_v1.py
+++ b/tests/test_continuity_v1.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from app.config import Settings
+from app.continuity.constants import CAPSULE_SIZE_LIMIT_LABEL
 from app.continuity.trimming import _render_value, _trim_capsule
 from app.main import continuity_upsert, context_retrieve
 from app.models import ContinuityUpsertRequest, ContextRetrieveRequest
@@ -384,12 +385,13 @@ class TestContinuityV1(unittest.TestCase):
             gm = _GitManagerStub()
             settings = self._settings(repo_root)
             payload = self._capsule_payload()
-            payload["metadata"] = {"x": "y" * (13 * 1024)}
+            payload["metadata"] = {"x": "y" * (25 * 1024)}
             req = ContinuityUpsertRequest(subject_kind="user", subject_id="stef", capsule=payload)  # type: ignore[arg-type]
             with patch("app.main._services", return_value=(settings, gm)):
                 with self.assertRaises(HTTPException) as cm:
                     continuity_upsert(req=req, auth=_AuthStub())
             self.assertEqual(cm.exception.status_code, 400)
+            self.assertIn(CAPSULE_SIZE_LIMIT_LABEL, str(cm.exception.detail))
 
     def test_context_retrieve_expired_capsule_not_loaded(self) -> None:
         """Expired capsules should be omitted from retrieval results."""

--- a/tests/test_continuity_v2_phase2.py
+++ b/tests/test_continuity_v2_phase2.py
@@ -170,7 +170,7 @@ class TestContinuityV2Phase2(unittest.TestCase):
             self.assertEqual(state["omitted_selectors"], ["user:c"])
 
     def test_budget_sharing_uses_even_split_without_redistribution(self) -> None:
-        """Loaded capsules should share the V1 reserve evenly in selector order."""
+        """Loaded capsules should share the explicit request budget evenly in selector order."""
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
             self._write_capsule(repo_root, subject_kind="user", subject_id="a")
@@ -193,10 +193,11 @@ class TestContinuityV2Phase2(unittest.TestCase):
             with patch("app.continuity.context_state._trim_capsule", side_effect=_record_trim):
                 state = build_continuity_state(repo_root=repo_root, auth=_AuthStub(), req=req, now=datetime.now(timezone.utc))
 
-            # Both capsules get equal allocation after subtracting trust_signals overhead
+            # Both capsules get equal allocation after subtracting trust/salience overhead.
             self.assertEqual(len(allocations), 2)
             self.assertEqual(allocations[0], allocations[1], "even split expected")
-            self.assertLess(allocations[0], 400, "trust_signals overhead reduces capsule allocation")
+            self.assertLess(allocations[0], 2000, "trust/signals overhead reduces capsule allocation")
+            self.assertGreater(allocations[0], 1500, "allocation should reflect the explicit 4000-token request budget")
             self.assertGreater(allocations[0], 0, "capsule still gets positive allocation")
             self.assertTrue(state["present"])
 

--- a/tests/test_continuity_v3_phase3.py
+++ b/tests/test_continuity_v3_phase3.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from fastapi import HTTPException
 
 from app.config import Settings
+from app.continuity.constants import CAPSULE_SIZE_LIMIT_LABEL
 from app.continuity.service import continuity_revalidate_service
 from app.main import continuity_revalidate
 from app.models import ContinuityRevalidateRequest
@@ -429,7 +430,7 @@ class TestContinuityV3Phase3(unittest.TestCase):
             self.assertEqual(missing_reason.exception.status_code, 400)
 
     def test_revalidate_rejects_oversized_post_injection_capsule(self) -> None:
-        """Revalidate should enforce the final assembled 12KB size limit."""
+        """Revalidate should enforce the final assembled continuity write cap."""
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
             active = self._capsule_payload()
@@ -442,7 +443,7 @@ class TestContinuityV3Phase3(unittest.TestCase):
             candidate["continuity"]["open_loops"] = ["x" * 160] * 5
             candidate["continuity"]["working_hypotheses"] = ["x" * 160] * 5
             candidate["continuity"]["long_horizon_commitments"] = ["x" * 160] * 5
-            candidate["metadata"] = {f"m{idx}": "x" * 320 for idx in range(12)}
+            candidate["metadata"] = {f"m{idx}": "x" * 2000 for idx in range(12)}
             candidate["canonical_sources"] = [f"memory/core/source-{idx}.md" for idx in range(8)]
             candidate["source"]["inputs"] = [f"memory/core/source-input-{idx}-{'x' * 150}.md"[:200] for idx in range(12)]
 
@@ -462,4 +463,4 @@ class TestContinuityV3Phase3(unittest.TestCase):
                 )
 
             self.assertEqual(cm.exception.status_code, 400)
-            self.assertIn("12 KB", str(cm.exception.detail))
+            self.assertIn(CAPSULE_SIZE_LIMIT_LABEL, str(cm.exception.detail))

--- a/tests/test_salience.py
+++ b/tests/test_salience.py
@@ -750,15 +750,19 @@ class TestBuildContinuityStateSalience(unittest.TestCase):
         ]
         self.assertEqual(ranks, list(range(1, len(ranks) + 1)))
 
-    def test_budget_too_tight_omits_capsule_entirely(self) -> None:
-        """At 256 tokens the capsule cannot fit even without salience and is fully omitted."""
+    def test_minimum_budget_keeps_capsule_with_compact_trust_and_no_salience(self) -> None:
+        """At the request minimum, the capsule should degrade in-place instead of being omitted."""
         state = self._build([_capsule()], max_tokens=256)
-        self.assertEqual(state["capsules"], [])
-        self.assertGreater(len(state["omitted_selectors"]), 0)
+        self.assertEqual(len(state["capsules"]), 1)
+        self.assertIsNone(state["capsules"][0].get("salience"))
+        self.assertEqual(state["omitted_selectors"], [])
+        self.assertTrue(
+            any(CONTINUITY_WARNING_SALIENCE_OMITTED in w for w in state.get("recovery_warnings", [])),
+        )
 
     def test_soft_budget_drops_salience_but_keeps_capsule(self) -> None:
         """Acceptance criterion #9: salience is a soft cost — capsule survives without it."""
-        state = self._build([_capsule()], max_tokens=1175)
+        state = self._build([_capsule()], max_tokens=320)
         capsules = state["capsules"]
         self.assertEqual(len(capsules), 1, "capsule must survive at this budget")
         self.assertIsNone(capsules[0].get("salience"))

--- a/tests/test_stable_preferences_124.py
+++ b/tests/test_stable_preferences_124.py
@@ -1043,9 +1043,9 @@ class TestBuildContinuityStateStablePreferences(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
             # Build a capsule heavy enough that a tight budget forces trimming
-            # of stable_preferences specifically.  At mte=1500 the reserved
-            # continuity budget is ~300 tokens; the ~1,050-token capsule must
-            # trim deep into phase 1, dropping stable_preferences.
+            # of stable_preferences specifically.  At mte=700 the capsule still
+            # survives, but the explicit continuity budget is tight enough to
+            # drop stable_preferences as a whole unit.
             payload = _base_capsule_payload(stable_preferences=_sample_prefs(12))
             payload["continuity"]["working_hypotheses"] = ["wh " * 40] * 5
             payload["continuity"]["trailing_notes"] = ["tn " * 40] * 3
@@ -1058,19 +1058,19 @@ class TestBuildContinuityStateStablePreferences(unittest.TestCase):
             req = ContextRetrieveRequest(
                 task="resume",
                 continuity_selectors=[{"subject_kind": "user", "subject_id": "test-agent"}],
-                max_tokens_estimate=1500,
+                max_tokens_estimate=700,
             )
             state = build_continuity_state(
                 repo_root=repo_root, auth=_AuthStub(), req=req,
                 now=datetime.now(timezone.utc),
             )
-            self.assertTrue(state["present"], "capsule must survive trimming at mte=1500")
+            self.assertTrue(state["present"], "capsule must survive trimming at mte=700")
             capsule = state["capsules"][0]
             # stable_preferences must have been trimmed away.
             self.assertNotIn("stable_preferences", capsule,
-                             "stable_preferences should be trimmed at mte=1500")
+                             "stable_preferences should be trimmed at mte=700")
             ts = capsule.get("trust_signals")
-            self.assertIsNotNone(ts, "trust_signals must be present at mte=1500")
+            self.assertIsNotNone(ts, "trust_signals must be present at mte=700")
             completeness = ts.get("completeness", {})
             trimmed_fields = completeness.get("trimmed_fields", [])
             self.assertIn("stable_preferences", trimmed_fields)


### PR DESCRIPTION
Closes #227

## Summary

`#227` is now complete. The retrieval-budget work plus the write-cap/settings-boundary pass satisfy the full hardened issue body across:

- global serialized continuity capsule write cap fixed at `20 KB`
- native retrieval default fixed at `12000`
- hidden internal continuity down-cap removed
- explicit per-request override preserved
- deterministic trim policy kept as a fixed product-contract rule
- docs/runtime/tests alignment for budget, cap, and trim-order posture
- no hidden env-driven drift introduced

This lands the bounded multi-capsule orientation posture that `#227` required: rich native thread/task/user continuity retrieval remains first-class without making the core continuity contract deployment-dependent.

## Verification

- `./.venv/bin/python -m unittest tests.test_context_retrieval.TestContextRetrieval.test_context_retrieve_default_budget_supports_rich_thread_task_user_capsules tests.test_context_retrieval.TestContextRetrieval.test_payload_reference_matches_budget_contract`
- `./.venv/bin/python -m unittest tests.test_continuity_120_thread_identity.TestSizeLimit tests.test_continuity_120_thread_identity.TestPostMutationSizeCheck tests.test_continuity_176_patch.TestPatchSizeLimit tests.test_continuity_v1.TestContinuityV1.test_continuity_upsert_oversized_capsule_rejected tests.test_continuity_v3_phase3.TestContinuityV3Phase3.test_revalidate_rejects_oversized_post_injection_capsule`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`
