### PR TITLE
Complete hardened #219 derived graph slice 1

### DIFF
--- a/app/context/graph.py
+++ b/app/context/graph.py
@@ -1,0 +1,323 @@
+"""Internal-only derived graph helper for #219 slice 1."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.continuity.cold import _load_cold_stub
+from app.continuity.persistence import (
+    _load_archive_envelope_with_warnings,
+    _load_capsule_with_warnings,
+    _load_fallback_envelope_payload_with_warnings,
+)
+
+_TASK_ROOTS = ("tasks/open", "tasks/done")
+_CONTINUITY_ROOTS = (
+    "memory/continuity",
+    "memory/continuity/fallback",
+    "memory/continuity/archive",
+    "memory/continuity/cold/index",
+)
+_VALID_SUBJECT_KINDS = {"thread", "task"}
+
+
+def _empty_graph_result(warning: str) -> dict[str, Any]:
+    """Return the exact empty-result shape for one warning."""
+    return {
+        "anchor": None,
+        "nodes": [],
+        "edges": [],
+        "warnings": [warning],
+    }
+
+
+def _is_whitespace_only(value: str) -> bool:
+    """Return whether the string is non-empty and all-whitespace."""
+    return bool(value) and value.isspace()
+
+
+def _is_non_empty_non_whitespace_string(value: Any) -> bool:
+    """Return whether the value participates in slice-1 source-string rules."""
+    return isinstance(value, str) and value != "" and not _is_whitespace_only(value)
+
+
+def _node(family: str, subject_id: str) -> dict[str, str]:
+    """Build one node object."""
+    return {"id": f"{family}:{subject_id}", "family": family}
+
+
+def _add_node(nodes: dict[str, str], *, family: str, subject_id: str, anchor_id: str) -> None:
+    """Add a non-anchor node by canonical ID."""
+    node_id = f"{family}:{subject_id}"
+    if node_id == anchor_id:
+        return
+    nodes[node_id] = family
+
+
+def _add_edge(edges: set[tuple[str, str, str]], *, family: str, source_id: str, target_id: str) -> None:
+    """Add one coalesced edge."""
+    edges.add((family, source_id, target_id))
+
+
+def _related_document_paths(capsule: dict[str, Any]) -> list[str]:
+    """Return slice-1 participating related document paths from one capsule."""
+    continuity = capsule.get("continuity")
+    if not isinstance(continuity, dict):
+        return []
+    related_documents = continuity.get("related_documents")
+    if not isinstance(related_documents, list):
+        return []
+    out: list[str] = []
+    for entry in related_documents:
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("path")
+        if isinstance(path, str) and path != "":
+            out.append(path)
+    return out
+
+
+def _load_task_candidate(path: Path) -> dict[str, Any] | None:
+    """Load one task candidate, skipping unreadable or malformed artifacts."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _enumerate_task_candidates(repo_root: Path) -> list[Path]:
+    """Enumerate the exact slice-1 task candidates."""
+    candidates: list[Path] = []
+    for rel in _TASK_ROOTS:
+        root = repo_root / rel
+        if root.exists() and not root.is_dir():
+            raise OSError(f"Task root is not a directory: {rel}")
+        if not root.exists():
+            continue
+        for path in root.iterdir():
+            if path.is_symlink():
+                continue
+            if not path.is_file():
+                continue
+            if path.suffix != ".json":
+                continue
+            candidates.append(path)
+    return candidates
+
+
+def _load_continuity_candidate(repo_root: Path, rel: str) -> dict[str, Any] | None:
+    """Load one continuity candidate and skip per-artifact failures."""
+    try:
+        if rel.startswith("memory/continuity/cold/index/"):
+            frontmatter = _load_cold_stub(repo_root, rel)
+            return {
+                "subject_kind": frontmatter.get("subject_kind"),
+                "subject_id": frontmatter.get("subject_id"),
+            }
+        if rel.startswith("memory/continuity/fallback/"):
+            payload, _warnings = _load_fallback_envelope_payload_with_warnings(repo_root, rel)
+            capsule = payload.get("capsule")
+            return capsule if isinstance(capsule, dict) else None
+        if rel.startswith("memory/continuity/archive/"):
+            payload, _warnings = _load_archive_envelope_with_warnings(repo_root, rel)
+            capsule = payload.get("capsule")
+            return capsule if isinstance(capsule, dict) else None
+        capsule, _warnings = _load_capsule_with_warnings(repo_root, rel)
+        return capsule if isinstance(capsule, dict) else None
+    except Exception:
+        return None
+
+
+def _enumerate_continuity_candidates(repo_root: Path) -> list[str]:
+    """Enumerate the exact slice-1 continuity candidate paths."""
+    candidates: list[str] = []
+    for rel in _CONTINUITY_ROOTS:
+        root = repo_root / rel
+        if root.exists() and not root.is_dir():
+            raise OSError(f"Continuity root is not a directory: {rel}")
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if not path.is_file():
+                continue
+            candidates.append(str(path.relative_to(repo_root)).replace("\\", "/"))
+    return candidates
+
+
+def _derive_documents_and_reference_edges(
+    *,
+    anchor_id: str,
+    anchor_family: str,
+    capsules: list[dict[str, Any]],
+    nodes: dict[str, str],
+    edges: set[tuple[str, str, str]],
+) -> None:
+    """Derive document nodes and references_document edges from anchor capsules."""
+    for capsule in capsules:
+        try:
+            paths = _related_document_paths(capsule)
+        except Exception:
+            continue
+        for path in paths:
+            _add_node(nodes, family="document", subject_id=path, anchor_id=anchor_id)
+            _add_edge(
+                edges,
+                family="references_document",
+                source_id=f"{anchor_family}:{capsule['subject_id']}",
+                target_id=f"document:{path}",
+            )
+
+
+def _derive_supersedes_edges(
+    *,
+    anchor_id: str,
+    anchor_family: str,
+    capsules: list[dict[str, Any]],
+    nodes: dict[str, str],
+    edges: set[tuple[str, str, str]],
+) -> None:
+    """Derive supersedes neighbor data from anchor capsules."""
+    for capsule in capsules:
+        descriptor = capsule.get("thread_descriptor")
+        if not isinstance(descriptor, dict):
+            continue
+        superseded_by = descriptor.get("superseded_by")
+        if not _is_non_empty_non_whitespace_string(superseded_by):
+            continue
+        _add_node(nodes, family=anchor_family, subject_id=superseded_by, anchor_id=anchor_id)
+        _add_edge(
+            edges,
+            family="supersedes",
+            source_id=f"{anchor_family}:{superseded_by}",
+            target_id=f"{anchor_family}:{capsule['subject_id']}",
+        )
+
+
+def derive_internal_graph_slice1(*, repo_root: Path, subject_kind: Any, subject_id: Any) -> dict[str, Any]:
+    """Derive the internal-only #219 slice-1 one-hop explicit-link graph."""
+    if not isinstance(subject_kind, str) or subject_kind not in _VALID_SUBJECT_KINDS:
+        return _empty_graph_result("invalid_subject_kind")
+    if not _is_non_empty_non_whitespace_string(subject_id):
+        return _empty_graph_result("anchor_not_found")
+
+    try:
+        task_paths = _enumerate_task_candidates(repo_root)
+        continuity_paths = _enumerate_continuity_candidates(repo_root)
+    except Exception:
+        return _empty_graph_result("graph_derivation_failed")
+
+    try:
+        tasks = [payload for path in task_paths if (payload := _load_task_candidate(path)) is not None]
+        continuity_candidates = [
+            capsule
+            for rel in continuity_paths
+            if (capsule := _load_continuity_candidate(repo_root, rel)) is not None
+            and capsule.get("subject_kind") == subject_kind
+        ]
+
+        anchor_id = f"{subject_kind}:{subject_id}"
+        anchor = _node(subject_kind, subject_id)
+
+        if subject_kind == "thread":
+            anchor_tasks = [task for task in tasks if task.get("thread_id") == subject_id]
+            anchor_capsules = [capsule for capsule in continuity_candidates if capsule.get("subject_id") == subject_id]
+        else:
+            anchor_tasks = [task for task in tasks if task.get("task_id") == subject_id]
+            anchor_capsules = [capsule for capsule in continuity_candidates if capsule.get("subject_id") == subject_id]
+
+        if not anchor_tasks and not anchor_capsules:
+            return _empty_graph_result("anchor_not_found")
+
+        nodes: dict[str, str] = {}
+        edges: set[tuple[str, str, str]] = set()
+
+        if subject_kind == "thread":
+            _derive_documents_and_reference_edges(
+                anchor_id=anchor_id,
+                anchor_family="thread",
+                capsules=anchor_capsules,
+                nodes=nodes,
+                edges=edges,
+            )
+            _derive_supersedes_edges(
+                anchor_id=anchor_id,
+                anchor_family="thread",
+                capsules=anchor_capsules,
+                nodes=nodes,
+                edges=edges,
+            )
+            for task in anchor_tasks:
+                task_id_value = task.get("task_id")
+                thread_id_value = task.get("thread_id")
+                if not _is_non_empty_non_whitespace_string(task_id_value):
+                    continue
+                if not _is_non_empty_non_whitespace_string(thread_id_value):
+                    continue
+                _add_node(nodes, family="task", subject_id=task_id_value, anchor_id=anchor_id)
+                _add_edge(
+                    edges,
+                    family="linked_to_thread",
+                    source_id=f"task:{task_id_value}",
+                    target_id=f"thread:{thread_id_value}",
+                )
+        else:
+            for task in anchor_tasks:
+                task_id_value = task.get("task_id")
+                if not _is_non_empty_non_whitespace_string(task_id_value):
+                    continue
+                thread_id_value = task.get("thread_id")
+                if _is_non_empty_non_whitespace_string(thread_id_value):
+                    _add_node(nodes, family="thread", subject_id=thread_id_value, anchor_id=anchor_id)
+                    _add_edge(
+                        edges,
+                        family="linked_to_thread",
+                        source_id=f"task:{task_id_value}",
+                        target_id=f"thread:{thread_id_value}",
+                    )
+                blocked_by = task.get("blocked_by")
+                if not isinstance(blocked_by, list):
+                    continue
+                for dependency in blocked_by:
+                    if not _is_non_empty_non_whitespace_string(dependency):
+                        continue
+                    _add_node(nodes, family="task", subject_id=dependency, anchor_id=anchor_id)
+                    _add_edge(
+                        edges,
+                        family="depends_on",
+                        source_id=f"task:{task_id_value}",
+                        target_id=f"task:{dependency}",
+                    )
+            _derive_documents_and_reference_edges(
+                anchor_id=anchor_id,
+                anchor_family="task",
+                capsules=anchor_capsules,
+                nodes=nodes,
+                edges=edges,
+            )
+            _derive_supersedes_edges(
+                anchor_id=anchor_id,
+                anchor_family="task",
+                capsules=anchor_capsules,
+                nodes=nodes,
+                edges=edges,
+            )
+
+        sorted_nodes = [
+            {"id": node_id, "family": nodes[node_id]}
+            for node_id in sorted(nodes)
+        ]
+        sorted_edges = [
+            {"family": family, "source_id": source_id, "target_id": target_id}
+            for family, source_id, target_id in sorted(edges)
+        ]
+        return {
+            "anchor": anchor,
+            "nodes": sorted_nodes,
+            "edges": sorted_edges,
+            "warnings": [],
+        }
+    except Exception:
+        return _empty_graph_result("graph_derivation_failed")

--- a/app/context/graph.py
+++ b/app/context/graph.py
@@ -93,10 +93,10 @@ def _enumerate_task_candidates(repo_root: Path) -> list[Path]:
     candidates: list[Path] = []
     for rel in _TASK_ROOTS:
         root = repo_root / rel
+        if not root.exists():
+            raise OSError(f"Task root is missing: {rel}")
         if root.exists() and not root.is_dir():
             raise OSError(f"Task root is not a directory: {rel}")
-        if not root.exists():
-            continue
         for path in root.iterdir():
             if path.is_symlink():
                 continue
@@ -112,11 +112,8 @@ def _load_continuity_candidate(repo_root: Path, rel: str) -> dict[str, Any] | No
     """Load one continuity candidate and skip per-artifact failures."""
     try:
         if rel.startswith("memory/continuity/cold/index/"):
-            frontmatter = _load_cold_stub(repo_root, rel)
-            return {
-                "subject_kind": frontmatter.get("subject_kind"),
-                "subject_id": frontmatter.get("subject_id"),
-            }
+            _load_cold_stub(repo_root, rel)
+            return None
         if rel.startswith("memory/continuity/fallback/"):
             payload, _warnings = _load_fallback_envelope_payload_with_warnings(repo_root, rel)
             capsule = payload.get("capsule")
@@ -136,11 +133,13 @@ def _enumerate_continuity_candidates(repo_root: Path) -> list[str]:
     candidates: list[str] = []
     for rel in _CONTINUITY_ROOTS:
         root = repo_root / rel
+        if not root.exists():
+            raise OSError(f"Continuity root is missing: {rel}")
         if root.exists() and not root.is_dir():
             raise OSError(f"Continuity root is not a directory: {rel}")
-        if not root.exists():
-            continue
         for path in root.rglob("*"):
+            if path.is_symlink():
+                continue
             if not path.is_file():
                 continue
             candidates.append(str(path.relative_to(repo_root)).replace("\\", "/"))
@@ -196,7 +195,7 @@ def _derive_supersedes_edges(
         )
 
 
-def derive_internal_graph_slice1(*, repo_root: Path, subject_kind: Any, subject_id: Any) -> dict[str, Any]:
+def derive_internal_graph_slice1(*, repo_root: Path, subject_kind: Any = None, subject_id: Any = None) -> dict[str, Any]:
     """Derive the internal-only #219 slice-1 one-hop explicit-link graph."""
     if not isinstance(subject_kind, str) or subject_kind not in _VALID_SUBJECT_KINDS:
         return _empty_graph_result("invalid_subject_kind")

--- a/tests/test_context_graph_219_slice1.py
+++ b/tests/test_context_graph_219_slice1.py
@@ -140,48 +140,116 @@ def _write_text(repo_root: Path, rel: str, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def _create_required_graph_roots(repo_root: Path) -> None:
+    """Create every required slice-1 discovery root."""
+    for rel in (
+        "tasks/open",
+        "tasks/done",
+        "memory/continuity",
+        "memory/continuity/fallback",
+        "memory/continuity/archive",
+        "memory/continuity/cold/index",
+    ):
+        (repo_root / rel).mkdir(parents=True, exist_ok=True)
+
+
 class TestContextGraph219Slice1(unittest.TestCase):
     """Validate the exact internal-only graph helper contract for #219 slice 1."""
 
+    def test_invalid_subject_kind_returns_exact_empty_shape_for_full_matrix(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            invalid_cases = [
+                {},
+                {"subject_kind": None},
+                {"subject_kind": 123},
+                {"subject_kind": ""},
+                {"subject_kind": "   "},
+                {"subject_kind": "Thread"},
+                {"subject_kind": "TASK"},
+                {"subject_kind": " task "},
+            ]
+
+            for kwargs in invalid_cases:
+                with self.subTest(kwargs=kwargs):
+                    result = derive_internal_graph_slice1(
+                        repo_root=repo_root,
+                        subject_id="task-1",
+                        **kwargs,
+                    )
+                    self.assertEqual(
+                        result,
+                        {
+                            "anchor": None,
+                            "nodes": [],
+                            "edges": [],
+                            "warnings": ["invalid_subject_kind"],
+                        },
+                    )
+
+    def test_invalid_subject_id_returns_anchor_not_found_for_full_matrix(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            invalid_cases = [
+                {},
+                {"subject_id": None},
+                {"subject_id": 123},
+                {"subject_id": ""},
+                {"subject_id": "   "},
+            ]
+
+            for kwargs in invalid_cases:
+                with self.subTest(kwargs=kwargs):
+                    result = derive_internal_graph_slice1(
+                        repo_root=repo_root,
+                        subject_kind="thread",
+                        **kwargs,
+                    )
+                    self.assertEqual(
+                        result,
+                        {
+                            "anchor": None,
+                            "nodes": [],
+                            "edges": [],
+                            "warnings": ["anchor_not_found"],
+                        },
+                    )
+
     def test_invalid_subject_kind_wins_validation_precedence(self) -> None:
         with tempfile.TemporaryDirectory() as td:
-            result = derive_internal_graph_slice1(
-                repo_root=Path(td),
-                subject_kind=" task ",
-                subject_id="   ",
-            )
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            invalid_pairs = [
+                {},
+                {"subject_kind": None},
+                {"subject_kind": 123, "subject_id": None},
+                {"subject_kind": "", "subject_id": ""},
+                {"subject_kind": "   ", "subject_id": "   "},
+                {"subject_kind": " task ", "subject_id": "   "},
+            ]
 
-        self.assertEqual(
-            result,
-            {
-                "anchor": None,
-                "nodes": [],
-                "edges": [],
-                "warnings": ["invalid_subject_kind"],
-            },
-        )
-
-    def test_invalid_subject_id_returns_anchor_not_found(self) -> None:
-        with tempfile.TemporaryDirectory() as td:
-            result = derive_internal_graph_slice1(
-                repo_root=Path(td),
-                subject_kind="thread",
-                subject_id="   ",
-            )
-
-        self.assertEqual(
-            result,
-            {
-                "anchor": None,
-                "nodes": [],
-                "edges": [],
-                "warnings": ["anchor_not_found"],
-            },
-        )
+            for kwargs in invalid_pairs:
+                with self.subTest(kwargs=kwargs):
+                    result = derive_internal_graph_slice1(
+                        repo_root=repo_root,
+                        **kwargs,
+                    )
+                    self.assertEqual(
+                        result,
+                        {
+                            "anchor": None,
+                            "nodes": [],
+                            "edges": [],
+                            "warnings": ["invalid_subject_kind"],
+                        },
+                    )
 
     def test_task_anchor_unions_corroborating_artifacts_and_orders_nodes_and_edges(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
             task_open = {
                 "task_id": "task-1",
                 "thread_id": "thread-z",
@@ -266,6 +334,7 @@ class TestContextGraph219Slice1(unittest.TestCase):
     def test_thread_anchor_uses_exact_task_globs_and_one_hop_only(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
             capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
             capsule["continuity"]["related_documents"] = [
                 {"path": "docs/thread.md", "kind": "spec", "label": "Thread spec"},
@@ -308,9 +377,41 @@ class TestContextGraph219Slice1(unittest.TestCase):
             ],
         )
 
+    def test_continuity_symlinked_file_is_ignored_before_capsule_load(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
+            regular_rel = "memory/continuity/thread-thread-1.json"
+            symlink_rel = "memory/continuity/thread-link.json"
+            _write_json(repo_root, regular_rel, capsule)
+            (repo_root / symlink_rel).symlink_to(repo_root / regular_rel)
+            regular_payload = json.loads((repo_root / regular_rel).read_text(encoding="utf-8"))
+            load_calls: list[str] = []
+
+            def _load_capsule(repo_root_arg: Path, rel: str) -> tuple[dict[str, object], list[str]]:
+                self.assertEqual(repo_root_arg, repo_root)
+                load_calls.append(rel)
+                self.assertNotEqual(rel, symlink_rel)
+                return regular_payload, []
+
+            with patch("app.context.graph._load_capsule_with_warnings", side_effect=_load_capsule):
+                result = derive_internal_graph_slice1(
+                    repo_root=repo_root,
+                    subject_kind="thread",
+                    subject_id="thread-1",
+                )
+
+        self.assertEqual(result["warnings"], [])
+        self.assertEqual(result["anchor"], {"id": "thread:thread-1", "family": "thread"})
+        self.assertEqual(result["nodes"], [])
+        self.assertEqual(result["edges"], [])
+        self.assertEqual(load_calls, [regular_rel])
+
     def test_missing_anchor_returns_exact_empty_shape(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
             _write_json(repo_root, "tasks/open/task-1.json", {"task_id": "task-1", "thread_id": "thread-1"})
 
             result = derive_internal_graph_slice1(
@@ -332,6 +433,7 @@ class TestContextGraph219Slice1(unittest.TestCase):
     def test_invalid_candidates_are_silently_skipped_after_discovery(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
             _write_text(repo_root, "tasks/open/task-1.json", "{not-json")
             _write_text(repo_root, "memory/continuity/weird.txt", "{not-json")
 
@@ -354,6 +456,7 @@ class TestContextGraph219Slice1(unittest.TestCase):
     def test_continuity_candidate_enumeration_is_recursive_and_not_extension_filtered(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
             capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
             _write_text(repo_root, "memory/continuity/deep/anchor.data", json.dumps(capsule))
 
@@ -371,6 +474,7 @@ class TestContextGraph219Slice1(unittest.TestCase):
     def test_related_document_sanitation_exception_is_silent_skip_for_that_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
             capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
             _write_json(repo_root, "memory/continuity/thread-thread-1.json", capsule)
 
@@ -388,12 +492,179 @@ class TestContextGraph219Slice1(unittest.TestCase):
 
     def test_required_source_discovery_failure_returns_graph_derivation_failed(self) -> None:
         with tempfile.TemporaryDirectory() as td:
+            _create_required_graph_roots(Path(td))
             with patch("app.context.graph._enumerate_task_candidates", side_effect=OSError("nope")):
                 result = derive_internal_graph_slice1(
                     repo_root=Path(td),
                     subject_kind="thread",
                     subject_id="thread-1",
                 )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["graph_derivation_failed"],
+            },
+        )
+
+    def test_cold_stub_only_does_not_produce_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            _write_text(
+                repo_root,
+                "memory/continuity/cold/index/thread-thread-1-20260423T000000Z.md",
+                _cold_stub_text(
+                    subject_kind="thread",
+                    subject_id="thread-1",
+                    archive_rel="memory/continuity/archive/thread-thread-1-20260423T000000Z.json",
+                ),
+            )
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["anchor_not_found"],
+            },
+        )
+
+    def test_missing_tasks_open_root_returns_graph_derivation_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            (repo_root / "tasks" / "open").rmdir()
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["graph_derivation_failed"],
+            },
+        )
+
+    def test_missing_tasks_done_root_returns_graph_derivation_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            (repo_root / "tasks" / "done").rmdir()
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["graph_derivation_failed"],
+            },
+        )
+
+    def test_missing_memory_continuity_root_returns_graph_derivation_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            (repo_root / "memory" / "continuity" / "fallback").rmdir()
+            (repo_root / "memory" / "continuity" / "archive").rmdir()
+            (repo_root / "memory" / "continuity" / "cold" / "index").rmdir()
+            (repo_root / "memory" / "continuity" / "cold").rmdir()
+            (repo_root / "memory" / "continuity").rmdir()
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["graph_derivation_failed"],
+            },
+        )
+
+    def test_missing_memory_continuity_fallback_root_returns_graph_derivation_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            (repo_root / "memory" / "continuity" / "fallback").rmdir()
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["graph_derivation_failed"],
+            },
+        )
+
+    def test_missing_memory_continuity_archive_root_returns_graph_derivation_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            (repo_root / "memory" / "continuity" / "archive").rmdir()
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["graph_derivation_failed"],
+            },
+        )
+
+    def test_missing_memory_continuity_cold_index_root_returns_graph_derivation_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_required_graph_roots(repo_root)
+            (repo_root / "memory" / "continuity" / "cold" / "index").rmdir()
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
 
         self.assertEqual(
             result,

--- a/tests/test_context_graph_219_slice1.py
+++ b/tests/test_context_graph_219_slice1.py
@@ -1,0 +1,433 @@
+"""Tests for #219 slice 1 internal graph derivation."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from app.context.graph import derive_internal_graph_slice1
+from app.context.service import context_retrieve_service
+from app.models import ContextRetrieveRequest
+
+
+class _AuthStub:
+    """Auth stub that permits reads used by graph and retrieval tests."""
+
+    peer_id = "peer-test"
+
+    def require(self, _scope: str) -> None:
+        return None
+
+    def require_read_path(self, _path: str) -> None:
+        return None
+
+
+class _GitManagerStub:
+    """Git manager stub for retrieval tests."""
+
+    def latest_commit(self) -> str:
+        return "test-sha"
+
+
+def _base_capsule(*, subject_kind: str, subject_id: str) -> dict[str, object]:
+    """Return a minimal continuity capsule fixture."""
+    now = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return {
+        "schema_version": "1.1",
+        "subject_kind": subject_kind,
+        "subject_id": subject_id,
+        "updated_at": now,
+        "verified_at": now,
+        "verification_kind": "self_review",
+        "source": {"producer": "test", "update_reason": "manual", "inputs": []},
+        "continuity": {
+            "top_priorities": [],
+            "active_concerns": [],
+            "active_constraints": [],
+            "open_loops": [],
+            "stance_summary": "",
+            "drift_signals": [],
+        },
+        "confidence": {"continuity": 0.9, "relationship_model": 0.8},
+    }
+
+
+def _fallback_payload(capsule: dict[str, object]) -> dict[str, object]:
+    """Wrap a capsule in the fallback envelope shape."""
+    return {
+        "schema_type": "continuity_fallback_snapshot",
+        "schema_version": "1.1",
+        "captured_at": "2026-04-23T00:00:00Z",
+        "active_path": f"memory/continuity/{capsule['subject_kind']}-{capsule['subject_id']}.json",
+        "capsule": capsule,
+    }
+
+
+def _archive_payload(capsule: dict[str, object]) -> dict[str, object]:
+    """Wrap a capsule in the archive envelope shape."""
+    return {
+        "schema_type": "continuity_archive_envelope",
+        "schema_version": "1.1",
+        "archived_at": "2026-04-23T00:00:00Z",
+        "reason": "fixture",
+        "capsule": capsule,
+    }
+
+
+def _cold_stub_text(*, subject_kind: str, subject_id: str, archive_rel: str) -> str:
+    """Return a minimal valid cold-stub fixture."""
+    return "\n".join(
+        [
+            "---",
+            "type: continuity_cold_stub",
+            'schema_version: "1.1"',
+            "artifact_state: cold",
+            f"subject_kind: {subject_kind}",
+            f"subject_id: {subject_id}",
+            f"source_archive_path: {archive_rel}",
+            f"cold_storage_path: memory/continuity/cold/{Path(archive_rel).name}.gz",
+            "archived_at: 2026-04-23T00:00:00Z",
+            "cold_stored_at: 2026-04-23T00:00:00Z",
+            "verification_kind: self_review",
+            "verification_status: self_attested",
+            "health_status: healthy",
+            "freshness_class: durable",
+            "phase: fresh",
+            "update_reason: fixture",
+            "---",
+            "## top_priorities",
+            "",
+            "## active_constraints",
+            "",
+            "## active_concerns",
+            "",
+            "## open_loops",
+            "",
+            "## stance_summary",
+            "",
+            "## drift_signals",
+            "",
+            "## session_trajectory",
+            "",
+            "## trailing_notes",
+            "",
+            "## curiosity_queue",
+            "",
+            "## negative_decisions",
+            "",
+            "## rationale_entries",
+            "",
+            "",
+        ]
+    )
+
+
+def _write_json(repo_root: Path, rel: str, payload: object) -> None:
+    """Write one JSON fixture."""
+    path = repo_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_text(repo_root: Path, rel: str, text: str) -> None:
+    """Write one text fixture."""
+    path = repo_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestContextGraph219Slice1(unittest.TestCase):
+    """Validate the exact internal-only graph helper contract for #219 slice 1."""
+
+    def test_invalid_subject_kind_wins_validation_precedence(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            result = derive_internal_graph_slice1(
+                repo_root=Path(td),
+                subject_kind=" task ",
+                subject_id="   ",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["invalid_subject_kind"],
+            },
+        )
+
+    def test_invalid_subject_id_returns_anchor_not_found(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            result = derive_internal_graph_slice1(
+                repo_root=Path(td),
+                subject_kind="thread",
+                subject_id="   ",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["anchor_not_found"],
+            },
+        )
+
+    def test_task_anchor_unions_corroborating_artifacts_and_orders_nodes_and_edges(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            task_open = {
+                "task_id": "task-1",
+                "thread_id": "thread-z",
+                "blocked_by": ["task-b", "task-a", "task-a", "   ", None],
+            }
+            task_done = {
+                "task_id": "task-1",
+                "thread_id": "thread-a",
+                "blocked_by": ["task-c"],
+            }
+            _write_json(repo_root, "tasks/open/task-1.json", task_open)
+            _write_json(repo_root, "tasks/done/task-1.json", task_done)
+
+            active_capsule = _base_capsule(subject_kind="task", subject_id="task-1")
+            active_capsule["continuity"]["related_documents"] = [
+                {"path": "docs/zeta.md", "kind": "spec", "label": "Zeta"},
+                {"path": "docs/alpha.md", "kind": "spec", "label": "Alpha"},
+                {"path": "docs/alpha.md", "kind": "spec", "label": "Alpha duplicate"},
+            ]
+            active_capsule["thread_descriptor"] = {"label": "task-1", "lifecycle": "superseded", "superseded_by": "task-next"}
+            fallback_capsule = _base_capsule(subject_kind="task", subject_id="task-1")
+            fallback_capsule["continuity"]["related_documents"] = [
+                {"path": "docs/beta.md", "kind": "note", "label": "Beta"},
+            ]
+            fallback_capsule["thread_descriptor"] = {"label": "task-1", "lifecycle": "superseded", "superseded_by": "task-next-2"}
+            _write_json(repo_root, "memory/continuity/task-task-1.json", active_capsule)
+            _write_json(repo_root, "memory/continuity/fallback/task-task-1.json", _fallback_payload(fallback_capsule))
+            _write_json(repo_root, "memory/continuity/archive/task-task-1-20260423T000000Z.json", _archive_payload(fallback_capsule))
+            _write_text(
+                repo_root,
+                "memory/continuity/cold/index/task-task-1-20260423T000000Z.md",
+                _cold_stub_text(
+                    subject_kind="task",
+                    subject_id="task-1",
+                    archive_rel="memory/continuity/archive/task-task-1-20260423T000000Z.json",
+                ),
+            )
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="task",
+                subject_id="task-1",
+            )
+
+        self.assertEqual(result["warnings"], [])
+        self.assertEqual(result["anchor"], {"id": "task:task-1", "family": "task"})
+        self.assertEqual(
+            result["nodes"],
+            [
+                {"id": "document:docs/alpha.md", "family": "document"},
+                {"id": "document:docs/beta.md", "family": "document"},
+                {"id": "document:docs/zeta.md", "family": "document"},
+                {"id": "task:task-a", "family": "task"},
+                {"id": "task:task-b", "family": "task"},
+                {"id": "task:task-c", "family": "task"},
+                {"id": "task:task-next", "family": "task"},
+                {"id": "task:task-next-2", "family": "task"},
+                {"id": "thread:thread-a", "family": "thread"},
+                {"id": "thread:thread-z", "family": "thread"},
+            ],
+        )
+        self.assertEqual(
+            result["edges"],
+            [
+                {"family": "depends_on", "source_id": "task:task-1", "target_id": "task:task-a"},
+                {"family": "depends_on", "source_id": "task:task-1", "target_id": "task:task-b"},
+                {"family": "depends_on", "source_id": "task:task-1", "target_id": "task:task-c"},
+                {"family": "linked_to_thread", "source_id": "task:task-1", "target_id": "thread:thread-a"},
+                {"family": "linked_to_thread", "source_id": "task:task-1", "target_id": "thread:thread-z"},
+                {"family": "references_document", "source_id": "task:task-1", "target_id": "document:docs/alpha.md"},
+                {"family": "references_document", "source_id": "task:task-1", "target_id": "document:docs/beta.md"},
+                {"family": "references_document", "source_id": "task:task-1", "target_id": "document:docs/zeta.md"},
+                {"family": "supersedes", "source_id": "task:task-next", "target_id": "task:task-1"},
+                {"family": "supersedes", "source_id": "task:task-next-2", "target_id": "task:task-1"},
+            ],
+        )
+        self.assertNotIn(result["anchor"], result["nodes"])
+        self.assertEqual(set(result["anchor"].keys()), {"id", "family"})
+        self.assertTrue(all(set(node.keys()) == {"id", "family"} for node in result["nodes"]))
+        self.assertTrue(all(set(edge.keys()) == {"family", "source_id", "target_id"} for edge in result["edges"]))
+
+    def test_thread_anchor_uses_exact_task_globs_and_one_hop_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
+            capsule["continuity"]["related_documents"] = [
+                {"path": "docs/thread.md", "kind": "spec", "label": "Thread spec"},
+            ]
+            capsule["thread_descriptor"] = {"label": "thread-1", "lifecycle": "superseded", "superseded_by": "thread-2"}
+            _write_json(repo_root, "memory/continuity/thread-thread-1.json", capsule)
+            _write_json(repo_root, "tasks/open/task-1.json", {"task_id": "task-1", "thread_id": "thread-1", "blocked_by": ["task-hidden"]})
+            _write_json(repo_root, "tasks/done/task-2.json", {"task_id": "task-2", "thread_id": "thread-1"})
+            _write_json(repo_root, "tasks/open/nested/task-3.json", {"task_id": "task-3", "thread_id": "thread-1"})
+            _write_json(repo_root, "tasks/open/task-4.txt", {"task_id": "task-4", "thread_id": "thread-1"})
+            target = repo_root / "tasks" / "open" / "task-1.json"
+            symlink_path = repo_root / "tasks" / "done" / "task-link.json"
+            symlink_path.parent.mkdir(parents=True, exist_ok=True)
+            symlink_path.symlink_to(target)
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(result["warnings"], [])
+        self.assertEqual(result["anchor"], {"id": "thread:thread-1", "family": "thread"})
+        self.assertEqual(
+            result["nodes"],
+            [
+                {"id": "document:docs/thread.md", "family": "document"},
+                {"id": "task:task-1", "family": "task"},
+                {"id": "task:task-2", "family": "task"},
+                {"id": "thread:thread-2", "family": "thread"},
+            ],
+        )
+        self.assertEqual(
+            result["edges"],
+            [
+                {"family": "linked_to_thread", "source_id": "task:task-1", "target_id": "thread:thread-1"},
+                {"family": "linked_to_thread", "source_id": "task:task-2", "target_id": "thread:thread-1"},
+                {"family": "references_document", "source_id": "thread:thread-1", "target_id": "document:docs/thread.md"},
+                {"family": "supersedes", "source_id": "thread:thread-2", "target_id": "thread:thread-1"},
+            ],
+        )
+
+    def test_missing_anchor_returns_exact_empty_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_json(repo_root, "tasks/open/task-1.json", {"task_id": "task-1", "thread_id": "thread-1"})
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-missing",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["anchor_not_found"],
+            },
+        )
+
+    def test_invalid_candidates_are_silently_skipped_after_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_text(repo_root, "tasks/open/task-1.json", "{not-json")
+            _write_text(repo_root, "memory/continuity/weird.txt", "{not-json")
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="task",
+                subject_id="task-1",
+            )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["anchor_not_found"],
+            },
+        )
+
+    def test_continuity_candidate_enumeration_is_recursive_and_not_extension_filtered(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
+            _write_text(repo_root, "memory/continuity/deep/anchor.data", json.dumps(capsule))
+
+            result = derive_internal_graph_slice1(
+                repo_root=repo_root,
+                subject_kind="thread",
+                subject_id="thread-1",
+            )
+
+        self.assertEqual(result["warnings"], [])
+        self.assertEqual(result["anchor"], {"id": "thread:thread-1", "family": "thread"})
+        self.assertEqual(result["nodes"], [])
+        self.assertEqual(result["edges"], [])
+
+    def test_related_document_sanitation_exception_is_silent_skip_for_that_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
+            _write_json(repo_root, "memory/continuity/thread-thread-1.json", capsule)
+
+            with patch("app.context.graph._related_document_paths", side_effect=RuntimeError("boom")):
+                result = derive_internal_graph_slice1(
+                    repo_root=repo_root,
+                    subject_kind="thread",
+                    subject_id="thread-1",
+                )
+
+        self.assertEqual(result["warnings"], [])
+        self.assertEqual(result["anchor"], {"id": "thread:thread-1", "family": "thread"})
+        self.assertEqual(result["nodes"], [])
+        self.assertEqual(result["edges"], [])
+
+    def test_required_source_discovery_failure_returns_graph_derivation_failed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with patch("app.context.graph._enumerate_task_candidates", side_effect=OSError("nope")):
+                result = derive_internal_graph_slice1(
+                    repo_root=Path(td),
+                    subject_kind="thread",
+                    subject_id="thread-1",
+                )
+
+        self.assertEqual(
+            result,
+            {
+                "anchor": None,
+                "nodes": [],
+                "edges": [],
+                "warnings": ["graph_derivation_failed"],
+            },
+        )
+
+    def test_context_retrieve_contract_remains_internal_only(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            now = datetime.now(timezone.utc)
+            capsule = _base_capsule(subject_kind="thread", subject_id="thread-1")
+            capsule["continuity"]["related_documents"] = [
+                {"path": "docs/thread.md", "kind": "spec", "label": "Thread spec"},
+            ]
+            _write_json(repo_root, "memory/continuity/thread-thread-1.json", capsule)
+            _write_text(repo_root, "docs/thread.md", "thread doc")
+
+            result = context_retrieve_service(
+                repo_root=repo_root,
+                auth=_AuthStub(),
+                req=ContextRetrieveRequest(task="unused", subject_kind="thread", subject_id="thread-1"),
+                now=now,
+                audit=lambda *_args, **_kwargs: None,
+            )
+
+        self.assertNotIn("graph", result)
+        self.assertNotIn("anchor", result)
+        self.assertIn("bundle", result)
+        self.assertNotIn("graph", result["bundle"])
+        self.assertNotIn("anchor", result["bundle"])
+        self.assertIn("continuity_state", result["bundle"])
+        self.assertIn("recent_relevant", result["bundle"])


### PR DESCRIPTION
## Summary

This PR completes the full hardened `#219` issue body rather than a slice-only checkpoint.

Closes #219
Refs #218

`#219` is now complete across:
- internal-only derived graph helper
- exact `thread` / `task` / `document` node families
- exact `references_document`, `linked_to_thread`, `depends_on`, and `supersedes` edges
- exact anchor-producing source rules
- exact task candidate enumeration
- exact continuity candidate enumeration
- exact warning and failure-classification behavior
- exact coalescing and ordering behavior
- no external retrieval-contract change
- no cache/materialization/graph DB

## Notes

- Keeps graph derivation internal-only and derived on demand from existing stored artifacts.
- Preserves the existing external `context.retrieve` contract and ordering.
- Adds the final hardening fixes for missing required roots, cold-stub non-admission, continuity symlink exclusion, and the matching regression coverage.

## Verification

- `./.venv/bin/python -m unittest tests.test_context_graph_219_slice1 -v`
- `./.venv/bin/python -m unittest tests.test_related_documents_217_slice1 tests.test_related_documents_217_slice2 tests.test_context_retrieval_213_slice1 -v`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`
