### PR TITLE
Fix UI compatibility parity after post-218 changes

### DIFF
--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -749,7 +749,7 @@ def _empty_ui_detail_summary(*, subject_kind: str, subject_id: str, warning: str
             "stance_summary_html": '<p class="muted">None</p>',
             "related_documents_html": '<p class="muted">No related documents recorded.</p>',
             "thread_descriptor_section": "",
-            "stable_preferences_html": '<p class="muted">No stable preferences recorded.</p>',
+            "stable_preferences_html": _stable_preferences_html(capsule={}, subject_kind=subject_kind),
             "negative_decisions_html": '<p class="muted">No negative decisions recorded.</p>',
             "rationale_entries_html": '<p class="muted">No rationale entries recorded.</p>',
         },

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -235,6 +235,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
             detail=detail,
             capsule=capsule,
             continuity=continuity,
+            subject_kind=subject_kind,
             startup_summary=_startup_summary_for_ui(detail.get("startup_summary")),
             trust_signals=detail.get("trust_signals"),
             related_summary=related_summary,
@@ -281,6 +282,8 @@ def build_ui_router(*, app_version: str) -> APIRouter:
             open_loops_html=rendered_sections["open_loops_html"],
             session_trajectory_html=rendered_sections["session_trajectory_html"],
             stance_summary_html=rendered_sections["stance_summary_html"],
+            related_documents_html=rendered_sections["related_documents_html"],
+            thread_descriptor_section=rendered_sections["thread_descriptor_section"],
             stable_preferences_html=rendered_sections["stable_preferences_html"],
             negative_decisions_html=rendered_sections["negative_decisions_html"],
             rationale_entries_html=rendered_sections["rationale_entries_html"],
@@ -635,6 +638,7 @@ def _ui_live_detail_summary(
         detail=detail,
         capsule=capsule,
         continuity=continuity,
+        subject_kind=subject_kind,
         startup_summary=_startup_summary_for_ui(detail.get("startup_summary")),
         trust_signals=detail.get("trust_signals"),
         related_summary=_related_artifact_summary_rows(subject_kind=subject_kind, rows=related_rows),
@@ -661,6 +665,8 @@ def _ui_live_detail_summary(
             "open_loops_html": rendered_sections["open_loops_html"],
             "session_trajectory_html": rendered_sections["session_trajectory_html"],
             "stance_summary_html": rendered_sections["stance_summary_html"],
+            "related_documents_html": rendered_sections["related_documents_html"],
+            "thread_descriptor_section": rendered_sections["thread_descriptor_section"],
             "stable_preferences_html": rendered_sections["stable_preferences_html"],
             "negative_decisions_html": rendered_sections["negative_decisions_html"],
             "rationale_entries_html": rendered_sections["rationale_entries_html"],
@@ -741,6 +747,8 @@ def _empty_ui_detail_summary(*, subject_kind: str, subject_id: str, warning: str
             "open_loops_html": '<p class="muted">None</p>',
             "session_trajectory_html": '<p class="muted">None</p>',
             "stance_summary_html": '<p class="muted">None</p>',
+            "related_documents_html": '<p class="muted">No related documents recorded.</p>',
+            "thread_descriptor_section": "",
             "stable_preferences_html": '<p class="muted">No stable preferences recorded.</p>',
             "negative_decisions_html": '<p class="muted">No negative decisions recorded.</p>',
             "rationale_entries_html": '<p class="muted">No rationale entries recorded.</p>',
@@ -996,6 +1004,7 @@ def _ui_detail_render_sections(
     detail: dict[str, Any],
     capsule: dict[str, Any],
     continuity: dict[str, Any],
+    subject_kind: str,
     startup_summary: Any,
     trust_signals: Any,
     related_summary: list[list[str]],
@@ -1016,11 +1025,9 @@ def _ui_detail_render_sections(
         "open_loops_html": _html_list(_coerce_str_list(continuity.get("open_loops"))),
         "session_trajectory_html": _html_list(_coerce_str_list(continuity.get("session_trajectory"))),
         "stance_summary_html": _paragraph(continuity.get("stance_summary")),
-        "stable_preferences_html": _structured_table(
-            rows=list(capsule.get("stable_preferences") or []),
-            columns=["tag", "content", "created_at", "updated_at", "last_confirmed_at"],
-            empty_message="No stable preferences recorded.",
-        ),
+        "related_documents_html": _related_documents_table(continuity.get("related_documents")),
+        "thread_descriptor_section": _thread_descriptor_section(capsule.get("thread_descriptor")),
+        "stable_preferences_html": _stable_preferences_html(capsule=capsule, subject_kind=subject_kind),
         "negative_decisions_html": _structured_table(
             rows=list(continuity.get("negative_decisions") or []),
             columns=["decision", "rationale", "created_at", "updated_at", "last_confirmed_at"],
@@ -1187,6 +1194,47 @@ def _render_object(value: Any, *, empty_message: str) -> str:
     if value is None:
         return f'<p class="muted">{html.escape(empty_message)}</p>'
     return _render_value(value)
+
+
+def _related_documents_table(value: Any) -> str:
+    """Render read-only related document metadata for one continuity capsule."""
+    rows = value if isinstance(value, list) else []
+    return _structured_table(
+        rows=rows,
+        columns=["path", "kind", "label", "relevance"],
+        empty_message="No related documents recorded.",
+    )
+
+
+def _thread_descriptor_section(value: Any) -> str:
+    """Render a read-only thread descriptor section when descriptor metadata exists."""
+    if not isinstance(value, dict) or not value:
+        return ""
+    descriptor = {
+        "label": value.get("label"),
+        "keywords": value.get("keywords"),
+        "scope_anchors": value.get("scope_anchors"),
+        "identity_anchors": value.get("identity_anchors"),
+        "lifecycle": value.get("lifecycle"),
+        "superseded_by": value.get("superseded_by"),
+    }
+    return (
+        '<article class="panel">'
+        "<h2>Thread Descriptor</h2>"
+        f"{_render_summary_rows(descriptor)}"
+        "</article>"
+    )
+
+
+def _stable_preferences_html(*, capsule: dict[str, Any], subject_kind: str) -> str:
+    """Render stable preferences only for subject kinds where they are valid."""
+    if subject_kind not in {"user", "peer"}:
+        return '<p class="muted">Not applicable for this subject kind.</p>'
+    return _structured_table(
+        rows=list(capsule.get("stable_preferences") or []),
+        columns=["tag", "content", "created_at", "updated_at", "last_confirmed_at"],
+        empty_message="No stable preferences recorded.",
+    )
 
 
 def _startup_summary_for_ui(value: Any) -> Any:

--- a/app/ui/static/ui_live.js
+++ b/app/ui/static/ui_live.js
@@ -113,6 +113,8 @@
       setHTML(root, "[data-live-detail-open-loops]", payload.detail.sections.open_loops_html || "");
       setHTML(root, "[data-live-detail-session-trajectory]", payload.detail.sections.session_trajectory_html || "");
       setHTML(root, "[data-live-detail-stance-summary]", payload.detail.sections.stance_summary_html || "");
+      setHTML(root, "[data-live-detail-related-documents]", payload.detail.sections.related_documents_html || "");
+      setHTML(root, "[data-live-detail-thread-descriptor]", payload.detail.sections.thread_descriptor_section || "");
       setHTML(root, "[data-live-detail-stable-preferences]", payload.detail.sections.stable_preferences_html || "");
       setHTML(root, "[data-live-detail-negative-decisions]", payload.detail.sections.negative_decisions_html || "");
       setHTML(root, "[data-live-detail-rationale-entries]", payload.detail.sections.rationale_entries_html || "");

--- a/app/ui/templates/continuity_detail.html
+++ b/app/ui/templates/continuity_detail.html
@@ -91,6 +91,17 @@
 </section>
 <section class="grid detail-grid--stacked">
   <article class="panel">
+    <h2>Related Documents</h2>
+    <div data-live-detail-related-documents>
+      ${related_documents_html}
+    </div>
+  </article>
+  <div data-live-detail-thread-descriptor>
+    ${thread_descriptor_section}
+  </div>
+</section>
+<section class="grid detail-grid--stacked">
+  <article class="panel">
     <h2>Stable Preferences</h2>
     <div data-live-detail-stable-preferences>
       ${stable_preferences_html}

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -728,6 +728,39 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertNotIn("prefer readable tables", detail.text)
         self.assertIn("Not applicable for this subject kind.", detail.text)
 
+    def test_ui_detail_page_shows_related_documents_empty_state(self) -> None:
+        """Absent or empty related document metadata should render the documented empty state."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="thread", subject_id="thread-no-related-docs")
+            _write_capsule(
+                repo_root,
+                subject_kind="thread",
+                subject_id="thread-empty-related-docs",
+                related_documents=[],
+            )
+            absent_detail = _ui_html_response(
+                repo_root,
+                route_path="/ui/continuity/{subject_kind}/{subject_id}",
+                request_path="/ui/continuity/thread/thread-no-related-docs",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "thread-no-related-docs"},
+            )
+            empty_detail = _ui_html_response(
+                repo_root,
+                route_path="/ui/continuity/{subject_kind}/{subject_id}",
+                request_path="/ui/continuity/thread/thread-empty-related-docs",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "thread-empty-related-docs"},
+            )
+
+        self.assertEqual(absent_detail.status_code, 200)
+        self.assertIn("Related Documents", absent_detail.text)
+        self.assertIn("No related documents recorded.", absent_detail.text)
+        self.assertEqual(empty_detail.status_code, 200)
+        self.assertIn("Related Documents", empty_detail.text)
+        self.assertIn("No related documents recorded.", empty_detail.text)
+
     def test_ui_detail_page_marks_stable_preferences_not_applicable_for_tasks(self) -> None:
         """Stable preferences should not look like empty user/peer data on task capsules."""
         with tempfile.TemporaryDirectory() as td:
@@ -846,6 +879,50 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertIn("ui_continuity_snapshot_failed:RuntimeError", payload["warnings"])
         self.assertFalse(payload["continuity"]["available"])
         self.assertEqual(payload["continuity"]["latest_recorded_at"], "unavailable")
+
+    def test_ui_events_stream_degraded_detail_marks_task_preferences_not_applicable(self) -> None:
+        """Degraded live detail fallback should preserve stable-preference subject applicability."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self._client(
+                repo_root,
+                COGNIRELAY_UI_ENABLED="true",
+                COGNIRELAY_UI_REQUIRE_LOCALHOST="false",
+            )
+            import app.ui.router as ui_router
+
+            router = ui_router.build_ui_router(app_version="test-version")
+            endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/events")
+            request = _request_with_transport_host(
+                "127.0.0.1",
+                path="/ui/events",
+                query_string=b"detail_subject_kind=task&detail_subject_id=task-245",
+            )
+
+            with patch("app.ui.router._ui_live_detail_summary", side_effect=RuntimeError("boom")):
+                response = asyncio.run(
+                    endpoint(
+                        request,
+                        q=None,
+                        subject_kind=None,
+                        artifact_state=None,
+                        health_status=None,
+                        detail_subject_kind="task",
+                        detail_subject_id="task-245",
+                    )
+                )
+                event = asyncio.run(_read_first_sse_event_chunk(response))
+
+        payload = json.loads(event["data"])
+        self.assertFalse(payload["ok"])
+        self.assertIn("ui_detail_snapshot_failed:RuntimeError", payload["warnings"])
+        self.assertIsNotNone(payload["detail"])
+        self.assertFalse(payload["detail"]["available"])
+        self.assertIn(
+            "Not applicable for this subject kind.",
+            payload["detail"]["sections"]["stable_preferences_html"],
+        )
+        self.assertNotIn("No stable preferences recorded.", payload["detail"]["sections"]["stable_preferences_html"])
 
     def test_ui_events_stream_includes_bounded_detail_summary_when_requested(self) -> None:
         """The SSE endpoint should expose a small detail summary for one subject when requested."""

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -209,6 +209,8 @@ def _write_capsule(
     subject_kind: str,
     subject_id: str,
     capsule_health_status: str | None = None,
+    related_documents: list[dict[str, Any]] | None = None,
+    thread_descriptor: dict[str, Any] | None = None,
 ) -> None:
     """Write one active continuity capsule to the repository fixture."""
     continuity_dir = repo_root / "memory" / "continuity"
@@ -219,6 +221,10 @@ def _write_capsule(
         subject_id=subject_id,
         capsule_health_status=capsule_health_status,
     )
+    if related_documents is not None:
+        payload["continuity"]["related_documents"] = related_documents
+    if thread_descriptor is not None:
+        payload["thread_descriptor"] = thread_descriptor
     (continuity_dir / f"{subject_kind}-{normalized}.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -673,6 +679,72 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertIn("Cold artifacts present", detail.text)
         self.assertIn("Open user archived list", detail.text)
         self.assertIn("Open user cold list", detail.text)
+
+    def test_ui_detail_page_shows_related_documents_and_thread_descriptor(self) -> None:
+        """The detail page should expose V2/V3 compatibility metadata read-only."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(
+                repo_root,
+                subject_kind="thread",
+                subject_id="thread-245",
+                related_documents=[
+                    {
+                        "path": "memory/projects/issue-245.md",
+                        "kind": "issue",
+                        "label": "UI compatibility audit",
+                        "relevance": "primary",
+                    }
+                ],
+                thread_descriptor={
+                    "label": "Issue 245 UI parity",
+                    "keywords": ["ui", "compatibility"],
+                    "scope_anchors": ["operator ui"],
+                    "identity_anchors": [{"kind": "issue", "value": "#245"}],
+                    "lifecycle": "active",
+                    "superseded_by": "thread-246",
+                },
+            )
+            detail = _ui_html_response(
+                repo_root,
+                route_path="/ui/continuity/{subject_kind}/{subject_id}",
+                request_path="/ui/continuity/thread/thread-245",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "thread-245"},
+            )
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertIn("Related Documents", detail.text)
+        self.assertIn("memory/projects/issue-245.md", detail.text)
+        self.assertIn("issue", detail.text)
+        self.assertIn("UI compatibility audit", detail.text)
+        self.assertIn("primary", detail.text)
+        self.assertIn("Thread Descriptor", detail.text)
+        self.assertIn("Issue 245 UI parity", detail.text)
+        self.assertIn("compatibility", detail.text)
+        self.assertIn("operator ui", detail.text)
+        self.assertIn("#245", detail.text)
+        self.assertIn("thread-246", detail.text)
+        self.assertNotIn("prefer readable tables", detail.text)
+        self.assertIn("Not applicable for this subject kind.", detail.text)
+
+    def test_ui_detail_page_marks_stable_preferences_not_applicable_for_tasks(self) -> None:
+        """Stable preferences should not look like empty user/peer data on task capsules."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="task", subject_id="task-245")
+            detail = _ui_html_response(
+                repo_root,
+                route_path="/ui/continuity/{subject_kind}/{subject_id}",
+                request_path="/ui/continuity/task/task-245",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "task", "subject_id": "task-245"},
+            )
+
+        self.assertEqual(detail.status_code, 200)
+        self.assertIn("Stable Preferences", detail.text)
+        self.assertIn("Not applicable for this subject kind.", detail.text)
+        self.assertNotIn("prefer readable tables", detail.text)
 
     def test_ui_detail_page_startup_summary_omits_dedicated_section_duplicates(self) -> None:
         """Startup summary should not duplicate dedicated trust/stable-preference sections."""


### PR DESCRIPTION
Closes #245

## Summary

- Renders continuity detail `related_documents` read-only with path, kind, label, and relevance, including absent/empty metadata empty states.
- Renders `thread_descriptor` metadata read-only on the detail page when present.
- Fixes stable-preferences detail rendering so user/peer capsules retain the preference table behavior while thread/task capsules show the subject-kind applicability message instead of looking like empty preference data.

## Verification

- `git diff --check`
- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `./.venv/bin/python -m ruff check app/ui tests/test_ui_issue_199_slice1.py`
- `./.venv/bin/python -m unittest discover -s tests -v`

## Follow-up

#236 remains open for the UI expansion decision and scheduling spec follow-ups.
