### PR TITLE
Add derived graph UI inspector

### DIFF
--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -496,7 +496,14 @@ def _sse_event(event: str, data: dict[str, Any], event_id: int) -> str:
 
 def _render_graph_response(*, settings: Settings, subject_kind: str | None, subject_id: str | None) -> HTMLResponse:
     """Call the graph helper and render the graph inspector page."""
-    graph = _ui_live_graph_summary(settings=settings, subject_kind=subject_kind, subject_id=subject_id)
+    try:
+        graph = _ui_live_graph_summary(settings=settings, subject_kind=subject_kind, subject_id=subject_id)
+    except Exception:
+        graph = _empty_ui_graph_summary(
+            subject_kind=subject_kind,
+            subject_id=subject_id,
+            warning="graph_derivation_failed",
+        )
     live_stream_path = None
     if subject_kind is not None and subject_id is not None:
         live_stream_path = _ui_events_href(graph_subject_kind=subject_kind, graph_subject_id=subject_id)
@@ -632,7 +639,12 @@ def _ui_live_snapshot(
                 warning="ui_detail_snapshot_failed",
             )
 
-    if graph_subject_kind is not None and graph_subject_id is not None:
+    if (
+        graph_subject_kind is not None
+        and graph_subject_id is not None
+        and graph_subject_kind != ""
+        and graph_subject_id != ""
+    ):
         try:
             graph = _ui_live_graph_summary(
                 settings=settings,

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -23,6 +23,7 @@ from app.continuity.listing import (
     _scan_cold_summaries,
     _scan_fallback_summaries,
 )
+from app.context.graph import derive_internal_graph_slice1
 from app.discovery import capabilities_payload, health_payload
 from app.git_manager import GitManager
 from app.models import ContinuityReadRequest
@@ -274,6 +275,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
                 ]
             ),
             related_artifact_rows=rendered_sections["related_artifact_rows"],
+            graph_link_section=_continuity_graph_link_section(subject_kind, subject_id),
             startup_summary_html=rendered_sections["startup_summary_html"],
             trust_signals_html=rendered_sections["trust_signals_html"],
             top_priorities_html=rendered_sections["top_priorities_html"],
@@ -295,6 +297,42 @@ def build_ui_router(*, app_version: str) -> APIRouter:
             content=body,
         )
 
+    @router.get("/graph", response_class=HTMLResponse)
+    def ui_graph(
+        request: Request,
+        subject_kind: str | None = Query(default=None),
+        subject_id: str | None = Query(default=None),
+    ) -> HTMLResponse:
+        """Render the read-only derived graph selector or query-addressed graph."""
+        settings = get_settings()
+        _enforce_ui_access(request, settings)
+        has_subject_kind = "subject_kind" in request.query_params
+        has_subject_id = "subject_id" in request.query_params
+        if not has_subject_kind and not has_subject_id:
+            return _graph_page(
+                current_path="/ui/graph",
+                subject_kind=None,
+                subject_id=None,
+                graph=None,
+                live_stream_path=None,
+            )
+        return _render_graph_response(
+            settings=settings,
+            subject_kind=subject_kind if has_subject_kind else None,
+            subject_id=subject_id if has_subject_id else None,
+        )
+
+    @router.get("/graph/{subject_kind}/{subject_id}", response_class=HTMLResponse)
+    def ui_graph_detail(
+        request: Request,
+        subject_kind: str,
+        subject_id: str,
+    ) -> HTMLResponse:
+        """Render one read-only derived graph detail page."""
+        settings = get_settings()
+        _enforce_ui_access(request, settings)
+        return _render_graph_response(settings=settings, subject_kind=subject_kind, subject_id=subject_id)
+
     @router.get("/events")
     async def ui_events(
         request: Request,
@@ -304,6 +342,8 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         health_status: str | None = Query(default=None),
         detail_subject_kind: str | None = Query(default=None),
         detail_subject_id: str | None = Query(default=None),
+        graph_subject_kind: str | None = Query(default=None),
+        graph_subject_id: str | None = Query(default=None),
     ) -> StreamingResponse:
         """Stream bounded read-only UI snapshots for progressive enhancement."""
         settings = get_settings()
@@ -313,6 +353,8 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         artifact_state = _normalize_ui_filter(artifact_state, UI_ARTIFACT_STATES)
         health_status = _normalize_ui_filter(health_status, UI_HEALTH_STATUSES)
         detail_subject_kind = _normalize_ui_filter(detail_subject_kind, UI_SUBJECT_KINDS)
+        graph_subject_kind = _coerce_optional_query_value(graph_subject_kind)
+        graph_subject_id = _coerce_optional_query_value(graph_subject_id)
 
         async def event_stream() -> Any:
             event_id = 0
@@ -329,6 +371,8 @@ def build_ui_router(*, app_version: str) -> APIRouter:
                     health_status=health_status,
                     detail_subject_kind=detail_subject_kind,
                     detail_subject_id=detail_subject_id,
+                    graph_subject_kind=graph_subject_kind,
+                    graph_subject_id=graph_subject_id,
                 )
                 event_id += 1
                 yield _sse_event("ui-snapshot", snapshot, event_id)
@@ -409,6 +453,7 @@ def _page(*, title: str, current_path: str, content: str) -> HTMLResponse:
         title=html.escape(title),
         overview_nav_class=_nav_class(current_path == "/ui/"),
         continuity_nav_class=_nav_class(current_path.startswith("/ui/continuity")),
+        graph_nav_class=_nav_class(current_path.startswith("/ui/graph")),
         content=content,
     )
     return HTMLResponse(html_doc)
@@ -431,6 +476,13 @@ def _normalize_ui_filter(value: str | None, allowed: tuple[str, ...]) -> str | N
     return None
 
 
+def _coerce_optional_query_value(value: Any) -> str | None:
+    """Coerce direct endpoint-call defaults to the same shape as FastAPI query values."""
+    if value is None or isinstance(value, str):
+        return value
+    return None
+
+
 def _bool_label(value: bool) -> str:
     """Return a lowercase boolean label for human-readable tables."""
     return "true" if value else "false"
@@ -440,6 +492,68 @@ def _sse_event(event: str, data: dict[str, Any], event_id: int) -> str:
     """Encode one deterministic SSE event frame."""
     payload = json.dumps(data, sort_keys=True, separators=(",", ":"))
     return f"id: {event_id}\nevent: {event}\ndata: {payload}\n\n"
+
+
+def _render_graph_response(*, settings: Settings, subject_kind: str | None, subject_id: str | None) -> HTMLResponse:
+    """Call the graph helper and render the graph inspector page."""
+    graph = _ui_live_graph_summary(settings=settings, subject_kind=subject_kind, subject_id=subject_id)
+    live_stream_path = None
+    if subject_kind is not None and subject_id is not None:
+        live_stream_path = _ui_events_href(graph_subject_kind=subject_kind, graph_subject_id=subject_id)
+    return _graph_page(
+        current_path="/ui/graph",
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+        graph=graph,
+        live_stream_path=live_stream_path,
+    )
+
+
+def _graph_page(
+    *,
+    current_path: str,
+    subject_kind: str | None,
+    subject_id: str | None,
+    graph: dict[str, Any] | None,
+    live_stream_path: str | None,
+) -> HTMLResponse:
+    """Render the graph inspector around optional helper-backed sections."""
+    graph_sections = ""
+    if graph is None:
+        empty_state = '<section class="panel"><p class="muted">No graph anchor selected.</p></section>'
+        graph_sections = empty_state
+    else:
+        sections = graph.get("sections") if isinstance(graph.get("sections"), dict) else _graph_sections(graph)
+        live_panel = ""
+        if live_stream_path is not None:
+            live_panel = (
+                f'<section class="panel" data-live-page="graph" data-live-stream="{html.escape(live_stream_path)}">'
+                "<h2>Live Updates</h2>"
+                '<p class="muted" data-live-connection>Live updates waiting for connection.</p>'
+                '<p class="muted">Data refreshed: <span data-live-generated-at>Not connected</span></p>'
+                "<noscript><p class=\"muted\">JavaScript disabled; live updates are unavailable.</p></noscript>"
+                "</section>"
+            )
+        graph_sections = (
+            '<section class="panel"><h2>Anchor</h2><div data-live-graph-anchor>'
+            f'{sections["anchor_html"]}</div></section>'
+            '<section class="panel"><h2>Source / Status</h2><div data-live-graph-source-status>'
+            f'{sections["source_status_html"]}</div></section>'
+            '<section class="panel"><h2>Warnings</h2><div data-live-graph-warnings>'
+            f'{sections["warnings_html"]}</div></section>'
+            '<section class="panel"><h2>Nodes</h2><div data-live-graph-nodes>'
+            f'{sections["nodes_html"]}</div></section>'
+            '<section class="panel"><h2>Edges</h2><div data-live-graph-edges>'
+            f'{sections["edges_html"]}</div></section>'
+            f"{live_panel}"
+        )
+    body = render_template(
+        "graph.html",
+        subject_kind_value=html.escape(subject_kind or ""),
+        subject_id_value=html.escape(subject_id or ""),
+        graph_sections=graph_sections,
+    )
+    return _page(title="Derived Graph", current_path=current_path, content=body)
 
 
 def _ui_live_snapshot(
@@ -454,6 +568,8 @@ def _ui_live_snapshot(
     health_status: str | None,
     detail_subject_kind: str | None,
     detail_subject_id: str | None,
+    graph_subject_kind: str | None,
+    graph_subject_id: str | None,
 ) -> dict[str, Any]:
     """Build one bounded live-update snapshot for the operator UI."""
     warnings: list[str] = []
@@ -466,6 +582,7 @@ def _ui_live_snapshot(
         warning=None,
     )
     detail: dict[str, Any] | None = None
+    graph: dict[str, Any] | None = None
 
     try:
         overview = _ui_live_overview_summary(
@@ -515,6 +632,21 @@ def _ui_live_snapshot(
                 warning="ui_detail_snapshot_failed",
             )
 
+    if graph_subject_kind is not None and graph_subject_id is not None:
+        try:
+            graph = _ui_live_graph_summary(
+                settings=settings,
+                subject_kind=graph_subject_kind,
+                subject_id=graph_subject_id,
+            )
+        except Exception as exc:
+            warnings.append(f"ui_graph_snapshot_failed:{exc.__class__.__name__}")
+            graph = _empty_ui_graph_summary(
+                subject_kind=graph_subject_kind,
+                subject_id=graph_subject_id,
+                warning="ui_graph_snapshot_failed",
+            )
+
     return {
         "schema_version": "1.0",
         "ok": not warnings,
@@ -523,6 +655,7 @@ def _ui_live_snapshot(
         "overview": overview,
         "continuity": continuity,
         "detail": detail,
+        "graph": graph,
     }
 
 
@@ -674,6 +807,126 @@ def _ui_live_detail_summary(
     }
 
 
+def _ui_live_graph_summary(*, settings: Settings, subject_kind: str | None, subject_id: str | None) -> dict[str, Any]:
+    """Build the bounded graph summary used by the page and SSE stream."""
+    result = derive_internal_graph_slice1(
+        repo_root=settings.repo_root,
+        subject_kind=subject_kind,
+        subject_id=subject_id,
+    )
+    anchor = result.get("anchor") if isinstance(result.get("anchor"), dict) else None
+    nodes = [node for node in list(result.get("nodes") or []) if isinstance(node, dict)]
+    edges = [edge for edge in list(result.get("edges") or []) if isinstance(edge, dict)]
+    warnings = [str(item) for item in list(result.get("warnings") or [])]
+    graph = {
+        "available": True,
+        "warning": None,
+        "subject_kind": _graph_display_value(subject_kind),
+        "subject_id": _graph_display_value(subject_id),
+        "source": "derived_on_demand",
+        "helper": "derive_internal_graph_slice1",
+        "read_only": True,
+        "public_api_expanded": False,
+        "anchor": anchor,
+        "nodes": nodes,
+        "edges": edges,
+        "warnings": warnings,
+        "summary": {
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+            "warning_count": len(warnings),
+        },
+    }
+    graph["sections"] = _graph_sections(graph)
+    return graph
+
+
+def _empty_ui_graph_summary(*, subject_kind: str | None, subject_id: str | None, warning: str | None) -> dict[str, Any]:
+    """Return a deterministic degraded graph summary."""
+    graph = {
+        "available": False,
+        "warning": warning,
+        "subject_kind": _graph_display_value(subject_kind),
+        "subject_id": _graph_display_value(subject_id),
+        "source": "derived_on_demand",
+        "helper": "derive_internal_graph_slice1",
+        "read_only": True,
+        "public_api_expanded": False,
+        "anchor": None,
+        "nodes": [],
+        "edges": [],
+        "warnings": ["graph_derivation_failed"],
+        "summary": {"node_count": 0, "edge_count": 0, "warning_count": 1},
+    }
+    graph["sections"] = _graph_sections(graph)
+    return graph
+
+
+def _graph_display_value(value: str | None) -> str:
+    """Return the graph input display value required by #247."""
+    if value is None:
+        return "n/a"
+    return str(value)
+
+
+def _graph_sections(graph: dict[str, Any]) -> dict[str, str]:
+    """Render escaped graph HTML fragments for page and SSE reuse."""
+    anchor = graph.get("anchor") if isinstance(graph.get("anchor"), dict) else None
+    nodes = [node for node in list(graph.get("nodes") or []) if isinstance(node, dict)]
+    edges = [edge for edge in list(graph.get("edges") or []) if isinstance(edge, dict)]
+    warnings = [str(item) for item in list(graph.get("warnings") or [])]
+    summary = graph.get("summary") if isinstance(graph.get("summary"), dict) else {}
+    if anchor is None:
+        anchor_html = '<p class="muted">No graph anchor resolved.</p>'
+    else:
+        anchor_html = _definition_rows(
+            [
+                ("ID", str(anchor.get("id", ""))),
+                ("Family", str(anchor.get("family", ""))),
+            ]
+        )
+    return {
+        "anchor_html": anchor_html,
+        "source_status_html": _definition_rows(
+            [
+                ("Subject kind", str(graph.get("subject_kind") or "n/a")),
+                ("Subject ID", str(graph.get("subject_id") or "n/a")),
+                ("Source", "derived_on_demand"),
+                ("Helper", "derive_internal_graph_slice1"),
+                ("Read only", "true"),
+                ("Public API expanded", "false"),
+                ("Node count", str(summary.get("node_count", len(nodes)))),
+                ("Edge count", str(summary.get("edge_count", len(edges)))),
+                ("Warning count", str(summary.get("warning_count", len(warnings)))),
+            ]
+        ),
+        "warnings_html": _html_list(warnings),
+        "nodes_html": _html_table(
+            headers=["ID", "Family"],
+            rows=[
+                [
+                    html.escape(str(node.get("id", ""))),
+                    html.escape(str(node.get("family", ""))),
+                ]
+                for node in nodes
+            ],
+            empty_message="No graph neighbor nodes were derived for this anchor.",
+        ),
+        "edges_html": _html_table(
+            headers=["Family", "Source", "Target"],
+            rows=[
+                [
+                    html.escape(str(edge.get("family", ""))),
+                    html.escape(str(edge.get("source_id", ""))),
+                    html.escape(str(edge.get("target_id", ""))),
+                ]
+                for edge in edges
+            ],
+            empty_message="No graph edges were derived for this anchor.",
+        ),
+    }
+
+
 def _empty_ui_overview_summary(*, warning: str | None) -> dict[str, Any]:
     """Return a deterministic degraded overview summary."""
     return {
@@ -764,6 +1017,8 @@ def _ui_events_href(
     health_status: str | None = None,
     detail_subject_kind: str | None = None,
     detail_subject_id: str | None = None,
+    graph_subject_kind: str | None = None,
+    graph_subject_id: str | None = None,
 ) -> str:
     """Build a deterministic SSE URL for one page scope."""
     pairs: list[tuple[str, str]] = []
@@ -779,6 +1034,10 @@ def _ui_events_href(
         pairs.append(("detail_subject_kind", detail_subject_kind))
     if detail_subject_id is not None:
         pairs.append(("detail_subject_id", detail_subject_id))
+    if graph_subject_kind is not None:
+        pairs.append(("graph_subject_kind", graph_subject_kind))
+    if graph_subject_id is not None:
+        pairs.append(("graph_subject_id", graph_subject_id))
     if not pairs:
         return "/ui/events"
     return "/ui/events?" + urlencode(pairs)
@@ -1070,6 +1329,19 @@ def _subject_link(subject_kind: str, subject_id: str) -> str:
     """Render the continuity detail link for one subject."""
     href = f"/ui/continuity/{quote(subject_kind, safe='')}/{quote(subject_id, safe='')}"
     return f'<a href="{href}">{html.escape(subject_id)}</a>'
+
+
+def _continuity_graph_link_section(subject_kind: str, subject_id: str) -> str:
+    """Render the continuity-detail graph link for graph-supported subjects only."""
+    if subject_kind not in {"thread", "task"}:
+        return ""
+    href = f"/ui/graph/{quote(subject_kind, safe='')}/{quote(subject_id, safe='')}"
+    return (
+        '<section class="panel">'
+        "<h2>Derived Graph</h2>"
+        f'<p><a href="{href}">Open derived graph for {html.escape(subject_kind)}/{html.escape(subject_id)}</a></p>'
+        "</section>"
+    )
 
 
 def _option_row(*, value: str, selected: bool) -> str:

--- a/app/ui/static/ui_live.js
+++ b/app/ui/static/ui_live.js
@@ -121,6 +121,17 @@
     }
   }
 
+  function applyGraph(root, payload) {
+    if (!payload.graph || !payload.graph.sections) {
+      return;
+    }
+    setHTML(root.ownerDocument, "[data-live-graph-anchor]", payload.graph.sections.anchor_html || "");
+    setHTML(root.ownerDocument, "[data-live-graph-source-status]", payload.graph.sections.source_status_html || "");
+    setHTML(root.ownerDocument, "[data-live-graph-warnings]", payload.graph.sections.warnings_html || "");
+    setHTML(root.ownerDocument, "[data-live-graph-nodes]", payload.graph.sections.nodes_html || "");
+    setHTML(root.ownerDocument, "[data-live-graph-edges]", payload.graph.sections.edges_html || "");
+  }
+
   function applySnapshot(root, payload) {
     setText(root, "[data-live-generated-at]", payload.generated_at || "unavailable");
     var page = root.getAttribute("data-live-page");
@@ -130,6 +141,8 @@
       applyContinuity(root, payload);
     } else if (page === "detail") {
       applyDetail(root, payload);
+    } else if (page === "graph") {
+      applyGraph(root, payload);
     }
   }
 

--- a/app/ui/templates/continuity_detail.html
+++ b/app/ui/templates/continuity_detail.html
@@ -27,6 +27,7 @@
     ${related_artifact_rows}
   </div>
 </section>
+${graph_link_section}
 <section class="panel">
   <h2>Recovery Warnings</h2>
   <div data-live-detail-recovery-warnings>

--- a/app/ui/templates/graph.html
+++ b/app/ui/templates/graph.html
@@ -1,0 +1,17 @@
+<section class="panel">
+  <h2>Selector</h2>
+  <form method="get" action="/ui/graph" class="filter-form">
+    <label class="filter-field" for="subject_kind">
+      <span>Subject kind</span>
+      <input id="subject_kind" name="subject_kind" type="text" value="${subject_kind_value}" placeholder="thread or task" />
+    </label>
+    <label class="filter-field" for="subject_id">
+      <span>Subject ID</span>
+      <input id="subject_id" name="subject_id" type="text" value="${subject_id_value}" placeholder="anchor id" />
+    </label>
+    <div class="filter-actions">
+      <button type="submit">Apply</button>
+    </div>
+  </form>
+</section>
+${graph_sections}

--- a/app/ui/templates/layout.html
+++ b/app/ui/templates/layout.html
@@ -31,6 +31,7 @@
         <nav class="site-nav">
           <a class="${overview_nav_class}" href="/ui/">Overview</a>
           <a class="${continuity_nav_class}" href="/ui/continuity">Continuity</a>
+          <a class="${graph_nav_class}" href="/ui/graph">Graph</a>
         </nav>
         <label class="theme-control" for="theme-select">
           <span>Theme</span>

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -1337,6 +1337,24 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(failed.status_code, 200)
         self.assertIn("graph_derivation_failed", failed.text)
 
+    def test_ui_graph_helper_exception_degrades_without_leaking_exception_text(self) -> None:
+        """Graph page helper exceptions should render a deterministic warning in band."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self._client(repo_root, COGNIRELAY_UI_ENABLED="true", COGNIRELAY_UI_REQUIRE_LOCALHOST="false")
+            import app.ui.router as ui_router
+
+            router = ui_router.build_ui_router(app_version="test-version")
+            endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/graph/{subject_kind}/{subject_id}")
+            request = _request_with_transport_host("127.0.0.1", path="/ui/graph/thread/some-id")
+            with patch("app.ui.router._ui_live_graph_summary", side_effect=RuntimeError("raw secret")):
+                response = endpoint(request, subject_kind="thread", subject_id="some-id")
+
+        text = response.body.decode("utf-8")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("graph_derivation_failed", text)
+        self.assertNotIn("raw secret", text)
+
     def test_ui_graph_escapes_values_and_keeps_page_read_only(self) -> None:
         """Graph output and selector redisplay should escape HTML and avoid mutation controls."""
         with tempfile.TemporaryDirectory() as td:
@@ -1425,6 +1443,39 @@ class TestOperatorUiSlice1(unittest.TestCase):
                 )
             )
             event = asyncio.run(_read_first_sse_event_chunk(response))
+
+        payload = json.loads(event["data"])
+        self.assertIsNone(payload["graph"])
+
+    def test_ui_events_graph_scope_null_for_empty_subject_id_without_helper_call(self) -> None:
+        """Empty graph SSE params are incomplete and should not call the graph helper."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self._client(repo_root, COGNIRELAY_UI_ENABLED="true", COGNIRELAY_UI_REQUIRE_LOCALHOST="false")
+            import app.ui.router as ui_router
+
+            router = ui_router.build_ui_router(app_version="test-version")
+            endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/events")
+            request = _request_with_transport_host(
+                "127.0.0.1",
+                path="/ui/events",
+                query_string=b"graph_subject_kind=thread&graph_subject_id=",
+            )
+            with patch("app.ui.router._ui_live_graph_summary", side_effect=AssertionError("helper called")):
+                response = asyncio.run(
+                    endpoint(
+                        request,
+                        q=None,
+                        subject_kind=None,
+                        artifact_state=None,
+                        health_status=None,
+                        detail_subject_kind=None,
+                        detail_subject_id=None,
+                        graph_subject_kind="thread",
+                        graph_subject_id="",
+                    )
+                )
+                event = asyncio.run(_read_first_sse_event_chunk(response))
 
         payload = json.loads(event["data"])
         self.assertIsNone(payload["graph"])

--- a/tests/test_ui_issue_199_slice1.py
+++ b/tests/test_ui_issue_199_slice1.py
@@ -314,6 +314,64 @@ def _write_cold(repo_root: Path, *, subject_kind: str, subject_id: str) -> str:
     return cold_stub_path
 
 
+def _create_graph_roots(repo_root: Path) -> None:
+    """Create graph helper discovery roots for UI graph tests."""
+    for rel in (
+        "tasks/open",
+        "tasks/done",
+        "memory/continuity",
+        "memory/continuity/fallback",
+        "memory/continuity/archive",
+        "memory/continuity/cold/index",
+    ):
+        (repo_root / rel).mkdir(parents=True, exist_ok=True)
+
+
+def _write_task(repo_root: Path, *, task_id: str, thread_id: str, blocked_by: list[Any] | None = None) -> None:
+    """Write one task fixture for graph UI tests."""
+    task_dir = repo_root / "tasks" / "open"
+    task_dir.mkdir(parents=True, exist_ok=True)
+    normalized = task_id.strip().lower().replace(" ", "-").replace("/", "-")
+    (task_dir / f"{normalized}.json").write_text(
+        json.dumps({"task_id": task_id, "thread_id": thread_id, "blocked_by": blocked_by or []}),
+        encoding="utf-8",
+    )
+
+
+def _write_graph_capsule(
+    repo_root: Path,
+    *,
+    subject_kind: str,
+    subject_id: str,
+    related_documents: list[dict[str, Any]] | None = None,
+) -> None:
+    """Write a schema-1.1 continuity capsule fixture for graph helper reads."""
+    now = datetime(2026, 4, 15, 9, 30, tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+    payload = {
+        "schema_version": "1.1",
+        "subject_kind": subject_kind,
+        "subject_id": subject_id,
+        "updated_at": now,
+        "verified_at": now,
+        "verification_kind": "self_review",
+        "source": {"producer": "test", "update_reason": "manual", "inputs": []},
+        "continuity": {
+            "top_priorities": [],
+            "active_concerns": [],
+            "active_constraints": [],
+            "open_loops": [],
+            "stance_summary": "",
+            "drift_signals": [],
+            "related_documents": related_documents or [],
+        },
+        "confidence": {"continuity": 0.9, "relationship_model": 0.8},
+    }
+    normalized = subject_id.strip().lower().replace(" ", "-").replace("/", "-")
+    path = repo_root / "memory" / "continuity" / f"{subject_kind}-{normalized}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 class TestOperatorUiSlice1(unittest.TestCase):
     """Validate the first bounded operator UI slice."""
 
@@ -1114,6 +1172,339 @@ class TestOperatorUiSlice1(unittest.TestCase):
         self.assertEqual(detail.status_code, 200)
         self.assertIn('data-live-detail-warning-count', detail.text)
         self.assertIn("Recovery warnings: <span data-live-detail-warning-count>2</span>", detail.text)
+
+    def test_ui_graph_selector_empty_state_has_no_live_controls(self) -> None:
+        """The graph selector route should render a deterministic empty state before helper selection."""
+        with tempfile.TemporaryDirectory() as td:
+            response = _ui_html_response(
+                Path(td),
+                route_path="/ui/graph",
+                request_path="/ui/graph",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": None, "subject_id": None},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Derived Graph", response.text)
+        self.assertIn('<form method="get" action="/ui/graph"', response.text)
+        self.assertIn("No graph anchor selected.", response.text)
+        self.assertNotIn('data-live-page="graph"', response.text)
+        self.assertNotIn("invalid_subject_kind", response.text)
+        self.assertNotIn("anchor_not_found", response.text)
+
+    def test_ui_graph_detail_renders_thread_anchor_graph(self) -> None:
+        """A thread graph should render anchor, task neighbors, document nodes, and linked edges."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_graph_roots(repo_root)
+            _write_graph_capsule(
+                repo_root,
+                subject_kind="thread",
+                subject_id="thread-247",
+                related_documents=[{"path": "docs/issue-247.md", "kind": "issue", "label": "Issue 247"}],
+            )
+            _write_task(repo_root, task_id="task-247", thread_id="thread-247")
+            response = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph/{subject_kind}/{subject_id}",
+                request_path="/ui/graph/thread/thread-247",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "thread-247"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        for label in ("Anchor", "Source / Status", "Warnings", "Nodes", "Edges"):
+            self.assertIn(f"<h2>{label}</h2>", response.text)
+        self.assertIn("thread:thread-247", response.text)
+        self.assertIn("task:task-247", response.text)
+        self.assertIn("document:docs/issue-247.md", response.text)
+        self.assertIn("linked_to_thread", response.text)
+        self.assertIn("references_document", response.text)
+        self.assertIn("<p class=\"muted\">None</p>", response.text)
+        self.assertIn('data-live-page="graph"', response.text)
+
+    def test_ui_graph_detail_renders_task_anchor_graph(self) -> None:
+        """A task graph should render linked-thread and dependency neighbors."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_graph_roots(repo_root)
+            _write_task(repo_root, task_id="task-247", thread_id="thread-247", blocked_by=["task-prereq"])
+            response = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph/{subject_kind}/{subject_id}",
+                request_path="/ui/graph/task/task-247",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "task", "subject_id": "task-247"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("task:task-247", response.text)
+        self.assertIn("thread:thread-247", response.text)
+        self.assertIn("task:task-prereq", response.text)
+        self.assertIn("depends_on", response.text)
+        self.assertIn("linked_to_thread", response.text)
+
+    def test_ui_graph_query_route_matches_canonical_route(self) -> None:
+        """The complete query route should render the same helper-backed graph sections as the canonical route."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_graph_roots(repo_root)
+            _write_task(repo_root, task_id="task-query", thread_id="thread-query")
+            canonical = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph/{subject_kind}/{subject_id}",
+                request_path="/ui/graph/thread/thread-query",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "thread-query"},
+            )
+            query = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph",
+                request_path="/ui/graph",
+                query_string=b"subject_kind=thread&subject_id=thread-query",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "thread-query"},
+            )
+
+        self.assertEqual(canonical.status_code, 200)
+        self.assertEqual(query.status_code, 200)
+        for expected in ("thread:thread-query", "task:task-query", "linked_to_thread", "Node count"):
+            self.assertIn(expected, canonical.text)
+            self.assertIn(expected, query.text)
+
+    def test_ui_graph_partial_query_inputs_render_warning_states(self) -> None:
+        """Partial graph query inputs should call the helper path and return HTTP 200 warning pages."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_graph_roots(repo_root)
+            missing_id = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph",
+                request_path="/ui/graph",
+                query_string=b"subject_kind=thread",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": None},
+            )
+            missing_kind = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph",
+                request_path="/ui/graph",
+                query_string=b"subject_id=thread-247",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": None, "subject_id": "thread-247"},
+            )
+
+        self.assertEqual(missing_id.status_code, 200)
+        self.assertIn("anchor_not_found", missing_id.text)
+        self.assertNotIn('data-live-page="graph"', missing_id.text)
+        self.assertEqual(missing_kind.status_code, 200)
+        self.assertIn("invalid_subject_kind", missing_kind.text)
+        self.assertNotIn('data-live-page="graph"', missing_kind.text)
+
+    def test_ui_graph_warning_states_are_visible_with_http_200(self) -> None:
+        """Helper warning states should render in-page without framework 4xx responses."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_graph_roots(repo_root)
+            not_found = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph/{subject_kind}/{subject_id}",
+                request_path="/ui/graph/thread/missing",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "missing"},
+            )
+            invalid_kind = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph/{subject_kind}/{subject_id}",
+                request_path="/ui/graph/Thread/missing",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "Thread", "subject_id": "missing"},
+            )
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            failed = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph/{subject_kind}/{subject_id}",
+                request_path="/ui/graph/thread/missing",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "missing"},
+            )
+
+        self.assertEqual(not_found.status_code, 200)
+        self.assertIn("anchor_not_found", not_found.text)
+        self.assertEqual(invalid_kind.status_code, 200)
+        self.assertIn("invalid_subject_kind", invalid_kind.text)
+        self.assertEqual(failed.status_code, 200)
+        self.assertIn("graph_derivation_failed", failed.text)
+
+    def test_ui_graph_escapes_values_and_keeps_page_read_only(self) -> None:
+        """Graph output and selector redisplay should escape HTML and avoid mutation controls."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_graph_roots(repo_root)
+            _write_task(
+                repo_root,
+                task_id='task-<script>alert("x")</script>',
+                thread_id='thread-<b>unsafe</b>',
+                blocked_by=['dep-<img src=x onerror=alert(1)>'],
+            )
+            response = _ui_html_response(
+                repo_root,
+                route_path="/ui/graph",
+                request_path="/ui/graph",
+                query_string=b"subject_kind=task&subject_id=task-%3Cscript%3Ealert%28%22x%22%29%3C%2Fscript%3E",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "task", "subject_id": 'task-<script>alert("x")</script>'},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("task-&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;", response.text)
+        self.assertIn("thread:thread-&lt;b&gt;unsafe&lt;/b&gt;", response.text)
+        self.assertIn("dep-&lt;img src=x onerror=alert(1)&gt;", response.text)
+        self.assertNotIn("<script>alert", response.text)
+        self.assertNotIn("<b>unsafe</b>", response.text)
+        self.assertEqual(response.text.count("<form "), 1)
+        for forbidden in ("create", "edit", "delete", "mutate", "schedule", "complete", "archive", "save graph"):
+            self.assertNotIn(f'name="{forbidden}"', response.text.lower())
+            self.assertNotIn(f'action="/ui/{forbidden}', response.text.lower())
+
+    def test_ui_continuity_detail_links_to_encoded_graph_routes_for_threads_and_tasks_only(self) -> None:
+        """Continuity detail should link graph-supported subjects with encoded path segments only."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _write_capsule(repo_root, subject_kind="thread", subject_id="Thread 247?")
+            _write_capsule(repo_root, subject_kind="task", subject_id="Task 247?")
+            _write_capsule(repo_root, subject_kind="user", subject_id="User 247?")
+            thread_detail = _ui_html_response(
+                repo_root,
+                route_path="/ui/continuity/{subject_kind}/{subject_id}",
+                request_path="/ui/continuity/thread/Thread%20247%3F",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "thread", "subject_id": "Thread 247?"},
+            )
+            task_detail = _ui_html_response(
+                repo_root,
+                route_path="/ui/continuity/{subject_kind}/{subject_id}",
+                request_path="/ui/continuity/task/Task%20247%3F",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "task", "subject_id": "Task 247?"},
+            )
+            user_detail = _ui_html_response(
+                repo_root,
+                route_path="/ui/continuity/{subject_kind}/{subject_id}",
+                request_path="/ui/continuity/user/User%20247%3F",
+                env_overrides={"COGNIRELAY_UI_ENABLED": "true", "COGNIRELAY_UI_REQUIRE_LOCALHOST": "false"},
+                endpoint_kwargs={"subject_kind": "user", "subject_id": "User 247?"},
+            )
+
+        self.assertIn('/ui/graph/thread/Thread%20247%3F', thread_detail.text)
+        self.assertIn('/ui/graph/task/Task%20247%3F', task_detail.text)
+        self.assertNotIn("/ui/graph/user", user_detail.text)
+
+    def test_ui_events_graph_scope_null_for_missing_or_incomplete_params(self) -> None:
+        """Graph SSE should remain null when no complete graph scope is requested."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self._client(repo_root, COGNIRELAY_UI_ENABLED="true", COGNIRELAY_UI_REQUIRE_LOCALHOST="false")
+            import app.ui.router as ui_router
+
+            router = ui_router.build_ui_router(app_version="test-version")
+            endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/events")
+            request = _request_with_transport_host("127.0.0.1", path="/ui/events")
+            response = asyncio.run(
+                endpoint(
+                    request,
+                    q=None,
+                    subject_kind=None,
+                    artifact_state=None,
+                    health_status=None,
+                    detail_subject_kind=None,
+                    detail_subject_id=None,
+                    graph_subject_kind="thread",
+                    graph_subject_id=None,
+                )
+            )
+            event = asyncio.run(_read_first_sse_event_chunk(response))
+
+        payload = json.loads(event["data"])
+        self.assertIsNone(payload["graph"])
+
+    def test_ui_events_includes_helper_backed_graph_payload(self) -> None:
+        """Complete graph SSE scope should include summary fields and escaped section fragments."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            _create_graph_roots(repo_root)
+            _write_task(repo_root, task_id="task-sse", thread_id="thread-sse")
+            self._client(repo_root, COGNIRELAY_UI_ENABLED="true", COGNIRELAY_UI_REQUIRE_LOCALHOST="false")
+            import app.ui.router as ui_router
+
+            router = ui_router.build_ui_router(app_version="test-version")
+            endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/events")
+            request = _request_with_transport_host("127.0.0.1", path="/ui/events")
+            response = asyncio.run(
+                endpoint(
+                    request,
+                    q=None,
+                    subject_kind=None,
+                    artifact_state=None,
+                    health_status=None,
+                    detail_subject_kind=None,
+                    detail_subject_id=None,
+                    graph_subject_kind="thread",
+                    graph_subject_id="thread-sse",
+                )
+            )
+            event = asyncio.run(_read_first_sse_event_chunk(response))
+
+        payload = json.loads(event["data"])
+        self.assertTrue(payload["ok"])
+        graph = payload["graph"]
+        self.assertTrue(graph["available"])
+        self.assertEqual(graph["subject_kind"], "thread")
+        self.assertEqual(graph["subject_id"], "thread-sse")
+        self.assertEqual(graph["source"], "derived_on_demand")
+        self.assertEqual(graph["helper"], "derive_internal_graph_slice1")
+        self.assertTrue(graph["read_only"])
+        self.assertFalse(graph["public_api_expanded"])
+        self.assertEqual(graph["summary"]["node_count"], 1)
+        self.assertEqual(graph["summary"]["edge_count"], 1)
+        self.assertIn("task:task-sse", graph["sections"]["nodes_html"])
+        self.assertIn("linked_to_thread", graph["sections"]["edges_html"])
+
+    def test_ui_events_graph_degradation_stays_in_band(self) -> None:
+        """Unexpected graph live failures should return the deterministic degraded graph object."""
+        with tempfile.TemporaryDirectory() as td:
+            repo_root = Path(td)
+            self._client(repo_root, COGNIRELAY_UI_ENABLED="true", COGNIRELAY_UI_REQUIRE_LOCALHOST="false")
+            import app.ui.router as ui_router
+
+            router = ui_router.build_ui_router(app_version="test-version")
+            endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/events")
+            request = _request_with_transport_host("127.0.0.1", path="/ui/events")
+            with patch("app.ui.router._ui_live_graph_summary", side_effect=RuntimeError("boom")):
+                response = asyncio.run(
+                    endpoint(
+                        request,
+                        q=None,
+                        subject_kind=None,
+                        artifact_state=None,
+                        health_status=None,
+                        detail_subject_kind=None,
+                        detail_subject_id=None,
+                        graph_subject_kind="thread",
+                        graph_subject_id="thread-sse",
+                    )
+                )
+                event = asyncio.run(_read_first_sse_event_chunk(response))
+
+        payload = json.loads(event["data"])
+        self.assertFalse(payload["ok"])
+        self.assertIn("ui_graph_snapshot_failed:RuntimeError", payload["warnings"])
+        graph = payload["graph"]
+        self.assertFalse(graph["available"])
+        self.assertEqual(graph["warning"], "ui_graph_snapshot_failed")
+        self.assertEqual(graph["warnings"], ["graph_derivation_failed"])
+        self.assertEqual(graph["summary"], {"node_count": 0, "edge_count": 0, "warning_count": 1})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #247

## Summary
- Adds read-only operator UI graph inspector routes for thread and task continuity subjects, including canonical path routes and query-based selection.
- Renders graph warnings and degradation states in-band with HTTP 200 pages when graph derivation is incomplete or unavailable.
- Extends the UI SSE snapshot payload with bounded graph snapshot data for complete graph scopes, while keeping incomplete scopes null and degraded graph failures in-band.
- Leaves #236 open for task-centric UI, context retrieval inspector, runtime help/onboarding UI, and scheduling follow-ups.

## Verification
- `git diff --check`
- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `./.venv/bin/python -m unittest tests.test_context_graph_219_slice1 -v`
- `./.venv/bin/python -m ruff check app/ui tests/test_ui_issue_199_slice1.py`
- `./.venv/bin/python -m unittest discover -s tests -v`