### PR TITLE
Add read-only context retrieval inspector UI

### DIFF
--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -26,10 +26,11 @@ from app.continuity.listing import (
     _scan_fallback_summaries,
 )
 from app.continuity.paths import continuity_fallback_rel_path
+from app.context import context_retrieve_service
 from app.context.graph import derive_internal_graph_slice1
 from app.discovery import capabilities_payload, health_payload
 from app.git_manager import GitManager
-from app.models import ContinuityReadRequest
+from app.models import ContextRetrieveRequest, ContinuityReadRequest
 
 from .render import render_template
 
@@ -361,6 +362,13 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         auth = _ui_auth(client_ip)
         return _task_detail_page(settings=settings, auth=auth, task_id=task_id)
 
+    @router.get("/context", response_class=HTMLResponse)
+    def ui_context(request: Request) -> HTMLResponse:
+        """Render the read-only context retrieval inspector."""
+        settings = get_settings()
+        client_ip = _enforce_ui_access(request, settings)
+        return _context_retrieval_page(settings=settings, client_ip=client_ip, request=request)
+
     @router.get("/graph", response_class=HTMLResponse)
     def ui_graph(
         request: Request,
@@ -478,6 +486,18 @@ def _ui_auth(client_ip: str | None) -> AuthContext:
     )
 
 
+def _ui_context_auth(client_ip: str | None) -> AuthContext:
+    """Build the read-only auth context required for UI retrieval inspection."""
+    return AuthContext(
+        token="ui-operator",
+        peer_id="ui-operator",
+        scopes={"read:files", "search"},
+        read_namespaces={"*"},
+        write_namespaces=set(),
+        client_ip=client_ip,
+    )
+
+
 def _enforce_ui_access(request: Request, settings: Settings) -> str | None:
     """Enforce the optional local-only UI policy."""
     client_ip = _ui_transport_client_ip(request)
@@ -518,6 +538,7 @@ def _page(*, title: str, current_path: str, content: str) -> HTMLResponse:
         overview_nav_class=_nav_class(current_path == "/ui/"),
         continuity_nav_class=_nav_class(current_path.startswith("/ui/continuity")),
         tasks_nav_class=_nav_class(current_path.startswith("/ui/tasks")),
+        retrieval_nav_class=_nav_class(current_path.startswith("/ui/context")),
         graph_nav_class=_nav_class(current_path.startswith("/ui/graph")),
         content=content,
     )
@@ -1104,6 +1125,360 @@ def _dedupe_preserve_order(values: list[str]) -> list[str]:
         seen.add(value)
         result.append(value)
     return result
+
+
+def _context_retrieval_page(*, settings: Settings, client_ip: str | None, request: Request) -> HTMLResponse:
+    """Render the #251 read-only context retrieval inspector."""
+    params = request.query_params
+    has_any_param = any(name in params for name in ("task", "subject_kind", "subject_id"))
+    raw_task = params.get("task") if "task" in params else None
+    raw_subject_kind = params.get("subject_kind") if "subject_kind" in params else None
+    raw_subject_id = params.get("subject_id") if "subject_id" in params else None
+    trimmed_task = (raw_task or "").strip()
+    trimmed_subject_kind = (raw_subject_kind or "").strip()
+    trimmed_subject_id = (raw_subject_id or "").strip()
+
+    validation_warnings = _context_validation_warnings(
+        has_any_param=has_any_param,
+        trimmed_task=trimmed_task,
+        trimmed_subject_kind=trimmed_subject_kind,
+        trimmed_subject_id=trimmed_subject_id,
+    )
+    if not has_any_param:
+        state = _context_ui_state(
+            raw_task=raw_task,
+            raw_subject_kind=raw_subject_kind,
+            raw_subject_id=raw_subject_id,
+            request_run=False,
+            request_params=None,
+            bundle=None,
+            ui_warnings=[],
+            empty_message="No retrieval request has been run.",
+        )
+        return _context_response(state)
+    if validation_warnings:
+        state = _context_ui_state(
+            raw_task=raw_task,
+            raw_subject_kind=raw_subject_kind,
+            raw_subject_id=raw_subject_id,
+            request_run=False,
+            request_params=None,
+            bundle=None,
+            ui_warnings=validation_warnings,
+            empty_message=None,
+        )
+        return _context_response(state)
+
+    req = ContextRetrieveRequest(
+        task=raw_task or "",
+        subject_kind=trimmed_subject_kind or None,
+        subject_id=raw_subject_id if trimmed_subject_kind else None,
+        continuity_mode="auto",
+        continuity_verification_policy="allow_degraded",
+        continuity_resilience_policy="allow_fallback",
+        continuity_selectors=[],
+        continuity_max_capsules=1,
+        max_tokens_estimate=12000,
+        include_types=[],
+        time_window_days=30,
+        limit=10,
+    )
+    request_params = _context_request_param_rows(req)
+    try:
+        result = context_retrieve_service(
+            repo_root=settings.repo_root,
+            auth=_ui_context_auth(client_ip),
+            req=req,
+            now=datetime.now(timezone.utc),
+            audit=_noop_audit,
+        )
+        bundle = result.get("bundle") if isinstance(result, dict) and isinstance(result.get("bundle"), dict) else None
+        ui_warnings: list[str] = []
+    except Exception:
+        bundle = None
+        ui_warnings = ["ui_context_retrieve_failed"]
+    state = _context_ui_state(
+        raw_task=raw_task,
+        raw_subject_kind=raw_subject_kind,
+        raw_subject_id=raw_subject_id,
+        request_run=True,
+        request_params=request_params,
+        bundle=bundle,
+        ui_warnings=ui_warnings,
+        empty_message=None,
+    )
+    return _context_response(state)
+
+
+def _context_validation_warnings(
+    *,
+    has_any_param: bool,
+    trimmed_task: str,
+    trimmed_subject_kind: str,
+    trimmed_subject_id: str,
+) -> list[str]:
+    """Return #251 validation warnings in the required deterministic order."""
+    if not has_any_param:
+        return []
+    warnings: list[str] = []
+    valid_subject_kind = trimmed_subject_kind in UI_SUBJECT_KINDS
+    if trimmed_subject_kind and not valid_subject_kind:
+        warnings.append("ui_context_invalid_subject_kind")
+    if valid_subject_kind and not trimmed_subject_id:
+        warnings.append("ui_context_subject_id_required")
+    if trimmed_subject_id and not trimmed_subject_kind:
+        warnings.append("ui_context_subject_kind_required")
+    if not trimmed_task and not warnings:
+        warnings.append("ui_context_task_required")
+    return warnings
+
+
+def _context_request_param_rows(req: ContextRetrieveRequest) -> list[tuple[str, str]]:
+    """Return effective retrieval request params in the #251 display order."""
+    return [
+        ("task", req.task),
+        ("subject_kind", req.subject_kind or "n/a"),
+        ("subject_id", req.subject_id or "n/a"),
+        ("continuity_mode", req.continuity_mode),
+        ("continuity_verification_policy", req.continuity_verification_policy),
+        ("continuity_resilience_policy", req.continuity_resilience_policy),
+        ("continuity_selectors", _context_json(req.continuity_selectors)),
+        ("continuity_max_capsules", str(req.continuity_max_capsules)),
+        ("max_tokens_estimate", str(req.max_tokens_estimate)),
+        ("include_types", _context_json(req.include_types)),
+        ("time_window_days", str(req.time_window_days)),
+        ("limit", str(req.limit)),
+    ]
+
+
+def _context_ui_state(
+    *,
+    raw_task: str | None,
+    raw_subject_kind: str | None,
+    raw_subject_id: str | None,
+    request_run: bool,
+    request_params: list[tuple[str, str]] | None,
+    bundle: dict[str, Any] | None,
+    ui_warnings: list[str],
+    empty_message: str | None,
+) -> dict[str, Any]:
+    """Collect already-normalized context UI render state."""
+    continuity_state = bundle.get("continuity_state") if isinstance(bundle, dict) and isinstance(bundle.get("continuity_state"), dict) else {}
+    service_warnings = _coerce_str_list(continuity_state.get("warnings"))
+    return {
+        "raw_task": raw_task or "",
+        "raw_subject_kind": raw_subject_kind or "",
+        "raw_subject_id": raw_subject_id or "",
+        "request_run": request_run,
+        "request_params": request_params,
+        "bundle": bundle,
+        "continuity_state": continuity_state,
+        "warnings": service_warnings + ui_warnings,
+        "recovery_warnings": _coerce_str_list(continuity_state.get("recovery_warnings")),
+        "empty_message": empty_message,
+    }
+
+
+def _context_response(state: dict[str, Any]) -> HTMLResponse:
+    """Render the full context inspector page."""
+    bundle = state["bundle"]
+    continuity_state = state["continuity_state"]
+    status_rows = [
+        ("Retrieval run", _bool_label(bool(state["request_run"]))),
+        ("Bundle available", _bool_label(isinstance(bundle, dict))),
+        ("Generated at", str(bundle.get("generated_at") or "n/a") if isinstance(bundle, dict) else "n/a"),
+        ("Read only", "true"),
+    ]
+    body = (
+        '<section class="panel"><h2>Selector</h2>'
+        f"{_context_selector_form(state)}</section>"
+        '<section class="panel"><h2>Request Parameters</h2>'
+        f"{_context_request_params_html(state['request_params'])}</section>"
+        '<section class="panel"><h2>Retrieval Status</h2>'
+        f"{_definition_rows(status_rows)}{_context_empty_message(state)}</section>"
+        '<section class="panel"><h2>Warnings</h2>'
+        f"{_html_list(state['warnings'])}</section>"
+        '<section class="panel"><h2>Recovery Warnings</h2>'
+        f"{_html_list(state['recovery_warnings'])}</section>"
+        '<section class="panel"><h2>Token Budget</h2>'
+        f"{_context_token_budget_html(bundle, continuity_state)}</section>"
+        '<section class="panel"><h2>Continuity State</h2>'
+        f"{_context_continuity_state_html(continuity_state)}</section>"
+        '<section class="panel"><h2>Recent Relevant</h2>'
+        f"{_context_recent_relevant_html(bundle)}</section>"
+        '<section class="panel"><h2>Open Questions</h2>'
+        f"{_html_list(_coerce_str_list(bundle.get('open_questions') if isinstance(bundle, dict) else None))}</section>"
+        '<section class="panel"><h2>Notes</h2>'
+        f"{_html_list(_coerce_str_list(bundle.get('notes') if isinstance(bundle, dict) else None))}</section>"
+    )
+    return _page(title="Context Retrieval", current_path="/ui/context", content=body)
+
+
+def _context_selector_form(state: dict[str, Any]) -> str:
+    """Render the read-only GET selector form, preserving raw values."""
+    return (
+        '<form method="get" action="/ui/context" class="filter-form">'
+        '<label>Task'
+        f'<input type="text" name="task" value="{html.escape(state["raw_task"])}">'
+        "</label>"
+        '<label>Subject Kind'
+        f'<input type="text" name="subject_kind" value="{html.escape(state["raw_subject_kind"])}">'
+        "</label>"
+        '<label>Subject ID'
+        f'<input type="text" name="subject_id" value="{html.escape(state["raw_subject_id"])}">'
+        "</label>"
+        '<button type="submit">Run Retrieval</button>'
+        "</form>"
+    )
+
+
+def _context_empty_message(state: dict[str, Any]) -> str:
+    """Render the default empty-state message when no request has run."""
+    message = state.get("empty_message")
+    if not message:
+        return ""
+    return f'<p class="muted">{html.escape(str(message))}</p>'
+
+
+def _context_request_params_html(rows: list[tuple[str, str]] | None) -> str:
+    """Render attempted/effective context request params or n/a for no run."""
+    if rows is None:
+        return '<p class="muted">n/a</p>'
+    return _definition_rows(rows)
+
+
+def _context_token_budget_html(bundle: dict[str, Any] | None, continuity_state: dict[str, Any]) -> str:
+    """Render top-level and continuity budget posture."""
+    budget = continuity_state.get("budget") if isinstance(continuity_state.get("budget"), dict) else {}
+    rows = [
+        ("token_budget_hint", str(bundle.get("token_budget_hint") or "n/a") if isinstance(bundle, dict) else "n/a"),
+        ("continuity_state.budget", _context_json(budget) if budget else "n/a"),
+    ]
+    if isinstance(budget, dict):
+        for key in sorted(budget):
+            rows.append((f"budget.{key}", _context_render_value(budget.get(key))))
+    return _definition_rows(rows)
+
+
+def _context_continuity_state_html(continuity_state: dict[str, Any]) -> str:
+    """Render continuity state aggregate fields and capsule rows."""
+    capsules = continuity_state.get("capsules") if isinstance(continuity_state.get("capsules"), list) else []
+    rows = [
+        ("present", _context_render_value(continuity_state.get("present"))),
+        ("fallback_used", _context_render_value(continuity_state.get("fallback_used"))),
+        ("requested_selector_count", _context_render_value(continuity_state.get("requested_selector_count"))),
+        ("omitted_selector_count", _context_render_value(continuity_state.get("omitted_selector_count"))),
+        ("capsule_count", str(len(capsules))),
+        ("trust_signals", _context_render_value(continuity_state.get("trust_signals"))),
+        ("salience_metadata", _context_render_value(continuity_state.get("salience_metadata"))),
+    ]
+    return (
+        f"{_definition_rows(rows)}"
+        f"{_html_table(
+            headers=['Subject Kind', 'Subject ID', 'Source State', 'Path', 'Health / Status / Trust / Degraded', 'Recovery Warnings', 'Warnings'],
+            rows=_context_capsule_rows(capsules),
+            empty_message='No continuity capsules returned.',
+        )}"
+    )
+
+
+def _context_capsule_rows(capsules: list[Any]) -> list[list[str]]:
+    """Render capsule rows with graceful per-row degradation."""
+    rows: list[list[str]] = []
+    for capsule in capsules:
+        if not isinstance(capsule, dict):
+            rows.append(["n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "n/a"])
+            continue
+        signal_fields = {
+            key: capsule.get(key)
+            for key in ("health_status", "status", "verification_status", "trust_signals", "degraded", "degraded_reason")
+            if key in capsule
+        }
+        rows.append(
+            [
+                html.escape(str(capsule.get("subject_kind") or "n/a")),
+                html.escape(str(capsule.get("subject_id") or "n/a")),
+                html.escape(str(capsule.get("source_state") or "n/a")),
+                html.escape(str(capsule.get("path") or "n/a")),
+                html.escape(_context_render_value(signal_fields) if signal_fields else "n/a"),
+                html.escape(_context_count_or_na(capsule.get("recovery_warnings"))),
+                html.escape(_context_count_or_na(capsule.get("warnings"))),
+            ]
+        )
+    return rows
+
+
+def _context_recent_relevant_html(bundle: dict[str, Any] | None) -> str:
+    """Render recent_relevant in service order with #251 field/link behavior."""
+    recent = bundle.get("recent_relevant") if isinstance(bundle, dict) else None
+    if not isinstance(recent, list) or not recent:
+        return '<p class="muted">No recent relevant items returned.</p>'
+    rows = [_context_recent_item_row(item) for item in recent]
+    return _html_table(
+        headers=["Path", "Type", "Score", "Modified", "Importance", "Warning", "Snippet", "Links"],
+        rows=rows,
+        empty_message="No recent relevant items returned.",
+    )
+
+
+def _context_recent_item_row(item: Any) -> list[str]:
+    """Render one recent item, degrading malformed shapes in-row."""
+    if not isinstance(item, dict):
+        return ["n/a", "n/a", "n/a", "n/a", "n/a", "None", "n/a", ""]
+    return [
+        html.escape(item["path"]) if isinstance(item.get("path"), str) else "n/a",
+        html.escape(item["type"]) if isinstance(item.get("type"), str) else "n/a",
+        html.escape(str(item["score"])) if _context_is_scalar(item.get("score")) else "n/a",
+        html.escape(item["modified_at"]) if isinstance(item.get("modified_at"), str) else "n/a",
+        html.escape(str(item["importance"])) if _context_is_scalar(item.get("importance")) else "n/a",
+        html.escape(item["warning"]) if isinstance(item.get("warning"), str) else "None",
+        html.escape(item["snippet"]) if isinstance(item.get("snippet"), str) else "n/a",
+        _context_recent_links(item),
+    ]
+
+
+def _context_recent_links(item: dict[str, Any]) -> str:
+    """Render deterministic links from explicit returned identity fields only."""
+    links: list[str] = []
+    subject_kind = item.get("subject_kind")
+    subject_id = item.get("subject_id")
+    if isinstance(subject_kind, str) and isinstance(subject_id, str) and subject_kind in UI_SUBJECT_KINDS:
+        if "/" not in subject_id:
+            links.append(_continuity_subject_link(subject_kind, subject_id, "Continuity"))
+        if subject_kind in {"thread", "task"}:
+            links.append(_graph_query_link(subject_kind, subject_id, "Graph"))
+    task_id = item.get("task_id")
+    if isinstance(task_id, str):
+        links.append(_task_detail_link(task_id))
+    return " ".join(links)
+
+
+def _context_is_scalar(value: Any) -> bool:
+    """Return whether a recent field may be rendered as a scalar."""
+    return isinstance(value, str | int | float | bool)
+
+
+def _context_render_value(value: Any) -> str:
+    """Return a deterministic string for scalar or structured context values."""
+    if value is None:
+        return "n/a"
+    if _context_is_scalar(value):
+        return str(value)
+    return _context_json(value)
+
+
+def _context_json(value: Any) -> str:
+    """Return deterministic JSON for structured context values."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _context_count_or_na(value: Any) -> str:
+    """Render warning counts when present."""
+    if isinstance(value, list):
+        return str(len(value))
+    if value is None:
+        return "n/a"
+    return _context_render_value(value)
 
 
 def _definition_rows_html(rows: list[tuple[str, str]]) -> str:

--- a/app/ui/templates/layout.html
+++ b/app/ui/templates/layout.html
@@ -32,6 +32,7 @@
           <a class="${overview_nav_class}" href="/ui/">Overview</a>
           <a class="${continuity_nav_class}" href="/ui/continuity">Continuity</a>
           <a class="${tasks_nav_class}" href="/ui/tasks">Tasks</a>
+          <a class="${retrieval_nav_class}" href="/ui/context">Retrieval</a>
           <a class="${graph_nav_class}" href="/ui/graph">Graph</a>
         </nav>
         <label class="theme-control" for="theme-select">

--- a/tests/test_ui_issue_251_context_inspector.py
+++ b/tests/test_ui_issue_251_context_inspector.py
@@ -1,0 +1,425 @@
+"""Tests for #251 read-only context retrieval inspector UI."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock, patch
+from urllib.parse import urlencode
+
+from starlette.requests import Request
+
+
+def _reload_ui_router():
+    """Reload config and UI router so env-controlled settings are current."""
+    import app.config as config_module
+    import app.ui.router as ui_router_module
+
+    importlib.reload(config_module)
+    return importlib.reload(ui_router_module)
+
+
+def _request(path: str, *, query_string: bytes = b"") -> Request:
+    """Build a localhost UI request."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "raw_path": path.encode("utf-8"),
+            "query_string": query_string,
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "http_version": "1.1",
+        }
+    )
+
+
+def _ui_context_response(
+    repo_root: Path,
+    *,
+    query: dict[str, str] | None = None,
+    service: Any | None = None,
+) -> tuple[SimpleNamespace, Any]:
+    """Render /ui/context directly and return the response plus service mock."""
+    query_string = urlencode(query or {}).encode("utf-8")
+    with patch.dict(
+        os.environ,
+        {
+            "COGNIRELAY_REPO_ROOT": str(repo_root),
+            "COGNIRELAY_AUTO_INIT_GIT": "true",
+            "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
+        },
+        clear=False,
+    ):
+        ui_router = _reload_ui_router()
+        router = ui_router.build_ui_router(app_version="test-version")
+        endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/context")
+        mock_service = service if service is not None else Mock(return_value=_retrieval_result())
+        with patch.object(ui_router, "context_retrieve_service", mock_service):
+            response = endpoint(_request("/ui/context", query_string=query_string))
+        return SimpleNamespace(status_code=response.status_code, text=response.body.decode("utf-8")), mock_service
+
+
+async def _first_sse_payload(repo_root: Path) -> dict[str, Any]:
+    """Read the first emitted /ui/events snapshot payload."""
+    with patch.dict(
+        os.environ,
+        {
+            "COGNIRELAY_REPO_ROOT": str(repo_root),
+            "COGNIRELAY_AUTO_INIT_GIT": "true",
+            "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
+        },
+        clear=False,
+    ):
+        ui_router = _reload_ui_router()
+        router = ui_router.build_ui_router(app_version="test-version")
+        endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/events")
+        response = await endpoint(
+            _request("/ui/events"),
+            q=None,
+            subject_kind=None,
+            artifact_state=None,
+            health_status=None,
+            detail_subject_kind=None,
+            detail_subject_id=None,
+            graph_subject_kind=None,
+            graph_subject_id=None,
+        )
+        event: dict[str, str] = {}
+        async for raw_chunk in response.body_iterator:
+            chunk = raw_chunk.decode("utf-8") if isinstance(raw_chunk, bytes) else raw_chunk
+            for line in chunk.splitlines():
+                if not line:
+                    if "data" in event:
+                        await response.body_iterator.aclose()
+                        return json.loads(event["data"])
+                    continue
+                if ": " not in line:
+                    continue
+                key, value = line.split(": ", 1)
+                if key != "retry":
+                    event[key] = value
+        raise AssertionError("No SSE payload emitted")
+
+
+def _retrieval_result(**overrides: Any) -> dict[str, Any]:
+    """Build a representative context.retrieve service result."""
+    bundle: dict[str, Any] = {
+        "generated_at": "2026-04-24T12:00:00Z",
+        "recent_relevant": [
+            {
+                "path": "docs/context.md",
+                "type": "markdown",
+                "score": 0.75,
+                "modified_at": "2026-04-23T00:00:00Z",
+                "importance": True,
+                "warning": "index_stale",
+                "snippet": "Relevant context",
+                "subject_kind": "thread",
+                "subject_id": "thread 251",
+                "task_id": "task-251",
+            }
+        ],
+        "open_questions": ["What changed?"],
+        "notes": ["Inspect only."],
+        "token_budget_hint": "within_budget",
+        "continuity_state": {
+            "present": True,
+            "fallback_used": False,
+            "requested_selector_count": 1,
+            "omitted_selector_count": 0,
+            "warnings": [],
+            "recovery_warnings": [],
+            "budget": {"token_budget_hint": "within_budget", "trimmed": False},
+            "trust_signals": {"aggregate": "healthy"},
+            "salience_metadata": {"source": "test"},
+            "capsules": [
+                {
+                    "subject_kind": "thread",
+                    "subject_id": "thread 251",
+                    "source_state": "active",
+                    "path": "memory/continuity/thread-thread-251.json",
+                    "health_status": "healthy",
+                    "trust_signals": {"verified": True},
+                    "degraded": False,
+                    "recovery_warnings": [],
+                    "warnings": [],
+                }
+            ],
+        },
+    }
+    bundle.update(overrides)
+    return {"ok": True, "bundle": bundle}
+
+
+class ContextInspectorIssue251Tests(unittest.TestCase):
+    """Exercise the read-only context retrieval inspector contract."""
+
+    def test_empty_default_state_nav_and_no_service_call(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            service = Mock(return_value=_retrieval_result())
+            response, service = _ui_context_response(Path(tmp), service=service)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('action="/ui/context"', response.text)
+        self.assertIn("No retrieval request has been run.", response.text)
+        self.assertIn('href="/ui/tasks"', response.text)
+        self.assertIn('href="/ui/context"', response.text)
+        self.assertIn('href="/ui/graph"', response.text)
+        self.assertLess(response.text.index('href="/ui/tasks"'), response.text.index('href="/ui/context"'))
+        self.assertLess(response.text.index('href="/ui/context"'), response.text.index('href="/ui/graph"'))
+        service.assert_not_called()
+
+    def test_successful_retrieval_invokes_service_with_exact_defaults_and_renders_sections(self) -> None:
+        captured: dict[str, Any] = {}
+
+        def service(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return _retrieval_result()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            response, _service = _ui_context_response(
+                Path(tmp),
+                query={"task": "  task free form  ", "subject_kind": "thread", "subject_id": "thread-251"},
+                service=Mock(side_effect=service),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        req = captured["req"]
+        self.assertEqual(req.task, "  task free form  ")
+        self.assertEqual(req.subject_kind, "thread")
+        self.assertEqual(req.subject_id, "thread-251")
+        self.assertEqual(req.continuity_mode, "auto")
+        self.assertEqual(req.continuity_verification_policy, "allow_degraded")
+        self.assertEqual(req.continuity_resilience_policy, "allow_fallback")
+        self.assertEqual(req.continuity_selectors, [])
+        self.assertEqual(req.continuity_max_capsules, 1)
+        self.assertEqual(req.max_tokens_estimate, 12000)
+        self.assertEqual(req.include_types, [])
+        self.assertEqual(req.time_window_days, 30)
+        self.assertEqual(req.limit, 10)
+        self.assertEqual(captured["auth"].scopes, {"read:files", "search"})
+        self.assertEqual(captured["auth"].read_namespaces, {"*"})
+        self.assertEqual(captured["auth"].write_namespaces, set())
+        section_names = [
+            "Selector",
+            "Request Parameters",
+            "Retrieval Status",
+            "Warnings",
+            "Recovery Warnings",
+            "Token Budget",
+            "Continuity State",
+            "Recent Relevant",
+            "Open Questions",
+            "Notes",
+        ]
+        positions = [response.text.index(f"<h2>{name}</h2>") for name in section_names]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn("2026-04-24T12:00:00Z", response.text)
+        self.assertIn("within_budget", response.text)
+        self.assertIn("thread 251", response.text)
+        self.assertIn("Relevant context", response.text)
+        self.assertIn("What changed?", response.text)
+        self.assertIn("Inspect only.", response.text)
+
+    def test_warning_and_degraded_retrieval_render_http_200(self) -> None:
+        result = _retrieval_result()
+        state = result["bundle"]["continuity_state"]
+        state["warnings"] = ["continuity_missing_capsule"]
+        state["recovery_warnings"] = ["continuity_index_stale"]
+        state["fallback_used"] = True
+        state["budget"] = {"token_budget_hint": "trimmed", "trimmed": True}
+        state["capsules"][0]["source_state"] = "fallback"
+        state["capsules"][0]["degraded"] = True
+        state["capsules"][0]["degraded_reason"] = "fallback_used"
+        state["capsules"][0]["trust_signals"] = {"stale": True}
+        with tempfile.TemporaryDirectory() as tmp:
+            response, _service = _ui_context_response(
+                Path(tmp),
+                query={"task": "inspect", "subject_kind": "thread", "subject_id": "thread-251"},
+                service=Mock(return_value=result),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("continuity_missing_capsule", response.text)
+        self.assertIn("continuity_index_stale", response.text)
+        self.assertIn("fallback", response.text)
+        self.assertIn("fallback_used", response.text)
+        self.assertIn("trimmed", response.text)
+
+    def test_service_exception_degrades_without_raw_exception_leak(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            response, _service = _ui_context_response(
+                Path(tmp),
+                query={"task": "inspect", "subject_kind": "thread", "subject_id": "thread-251"},
+                service=Mock(side_effect=RuntimeError("raw secret exception")),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("ui_context_retrieve_failed", response.text)
+        self.assertIn("Bundle available</dt><dd>false</dd>", response.text)
+        self.assertIn("inspect", response.text)
+        self.assertNotIn("raw secret exception", response.text)
+
+    def test_invalid_and_incomplete_inputs_warning_order_and_no_invocation(self) -> None:
+        cases = [
+            ({"task": "inspect", "subject_kind": "invalid"}, ["ui_context_invalid_subject_kind"], ["ui_context_subject_id_required"]),
+            ({"task": "", "subject_kind": "", "subject_id": ""}, ["ui_context_task_required"], []),
+            ({"task": "inspect", "subject_kind": "thread"}, ["ui_context_subject_id_required"], []),
+            (
+                {"task": "inspect", "subject_kind": "invalid", "subject_id": ""},
+                ["ui_context_invalid_subject_kind"],
+                ["ui_context_subject_id_required"],
+            ),
+            ({"task": "inspect", "subject_id": "thread-251"}, ["ui_context_subject_kind_required"], []),
+            ({"task": "   ", "subject_kind": "thread", "subject_id": "thread-251"}, ["ui_context_task_required"], []),
+        ]
+        for query, expected, absent in cases:
+            with self.subTest(query=query), tempfile.TemporaryDirectory() as tmp:
+                service = Mock(return_value=_retrieval_result())
+                response, service = _ui_context_response(Path(tmp), query=query, service=service)
+                self.assertEqual(response.status_code, 200)
+                for warning in expected:
+                    self.assertIn(warning, response.text)
+                for warning in absent:
+                    self.assertNotIn(warning, response.text)
+                service.assert_not_called()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            response, service = _ui_context_response(
+                Path(tmp),
+                query={"task": "inspect", "subject_kind": "   ", "subject_id": "thread-251"},
+                service=Mock(return_value=_retrieval_result()),
+            )
+        self.assertLess(response.text.index("ui_context_subject_kind_required"), response.text.index("Warnings</h2>") + 500)
+        service.assert_not_called()
+
+    def test_raw_form_values_are_redisplayed_and_escaped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            response, service = _ui_context_response(
+                Path(tmp),
+                query={
+                    "task": '  <script>alert("task")</script>  ',
+                    "subject_kind": '<b onclick="x">',
+                    "subject_id": '<img src=x onerror=alert(1)>',
+                },
+                service=Mock(return_value=_retrieval_result()),
+            )
+
+        service.assert_not_called()
+        self.assertIn('value="  &lt;script&gt;alert(&quot;task&quot;)&lt;/script&gt;  "', response.text)
+        self.assertIn('value="&lt;b onclick=&quot;x&quot;&gt;"', response.text)
+        self.assertIn('value="&lt;img src=x onerror=alert(1)&gt;"', response.text)
+        self.assertNotIn('<script>alert("task")</script>', response.text)
+        self.assertNotIn("<img src=x onerror=alert(1)>", response.text)
+
+    def test_recent_relevant_scalars_malformed_items_order_and_links(self) -> None:
+        result = _retrieval_result(
+            recent_relevant=[
+                {
+                    "path": "first.md",
+                    "type": "note",
+                    "score": 1,
+                    "modified_at": "2026-04-20",
+                    "importance": False,
+                    "warning": "warn",
+                    "snippet": "first",
+                    "subject_kind": "thread",
+                    "subject_id": "thread/special",
+                    "task_id": "task/special",
+                },
+                ["malformed"],
+                {
+                    "path": "second.md",
+                    "type": "note",
+                    "score": {"bad": "shape"},
+                    "importance": ["bad"],
+                    "snippet": "second",
+                    "subject_kind": "user",
+                    "subject_id": "safe user",
+                    "task_id": "safe-task",
+                },
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            response, _service = _ui_context_response(
+                Path(tmp),
+                query={"task": "inspect"},
+                service=Mock(return_value=result),
+            )
+
+        self.assertLess(response.text.index("first.md"), response.text.index("second.md"))
+        self.assertIn("<td>1</td>", response.text)
+        self.assertIn("<td>False</td>", response.text)
+        self.assertIn("<td>warn</td>", response.text)
+        self.assertIn("<td>n/a</td>", response.text)
+        self.assertIn("/ui/graph?subject_kind=thread&amp;subject_id=thread%2Fspecial", response.text)
+        self.assertNotIn("/ui/continuity/thread/thread%2Fspecial", response.text)
+        self.assertIn("/ui/tasks?task_id=task%2Fspecial", response.text)
+        self.assertIn("/ui/continuity/user/safe%20user", response.text)
+        self.assertIn("/ui/tasks/safe-task", response.text)
+
+    def test_html_escaping_for_service_returned_fields(self) -> None:
+        result = _retrieval_result(
+            generated_at="<script>generated</script>",
+            recent_relevant=[
+                {
+                    "path": "<script>path</script>",
+                    "type": "<b>type</b>",
+                    "score": "<i>score</i>",
+                    "modified_at": "<u>modified</u>",
+                    "importance": "<em>importance</em>",
+                    "warning": "<strong>warning</strong>",
+                    "snippet": "<script>snippet</script>",
+                }
+            ],
+            open_questions=["<script>question</script>"],
+            notes=["<script>note</script>"],
+            token_budget_hint="<script>budget</script>",
+        )
+        state = result["bundle"]["continuity_state"]
+        state["warnings"] = ["<script>warning</script>"]
+        state["recovery_warnings"] = ["<script>recovery</script>"]
+        state["trust_signals"] = {"html": "<script>trust</script>"}
+        state["capsules"][0]["path"] = "<script>capsule</script>"
+        with tempfile.TemporaryDirectory() as tmp:
+            response, _service = _ui_context_response(
+                Path(tmp),
+                query={"task": "<script>task</script>"},
+                service=Mock(return_value=result),
+            )
+
+        self.assertNotIn("<script>path</script>", response.text)
+        self.assertNotIn("<script>question</script>", response.text)
+        self.assertNotIn("<script>warning</script>", response.text)
+        self.assertIn("&lt;script&gt;path&lt;/script&gt;", response.text)
+        self.assertIn("&lt;script&gt;question&lt;/script&gt;", response.text)
+        self.assertIn("&lt;script&gt;warning&lt;/script&gt;", response.text)
+
+    def test_read_only_no_mutation_controls_and_sse_deferred(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            response, _service = _ui_context_response(Path(tmp), query={"task": "inspect"})
+            sse_payload = asyncio.run(_first_sse_payload(Path(tmp)))
+
+        self.assertNotIn('method="post"', response.text.lower())
+        self.assertNotIn("delete", response.text.lower())
+        self.assertNotIn("reminder", response.text.lower())
+        self.assertNotIn("schedule", response.text.lower())
+        self.assertNotIn("onboarding", response.text.lower())
+        self.assertNotIn('data-live-page="context"', response.text)
+        self.assertNotIn("retrieval", sse_payload)
+        self.assertNotIn("context", sse_payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #251

## Summary
- Adds the read-only `/ui/context` Context Retrieval inspector route.
- Supports query params: `task`, `subject_kind`, and `subject_id`.
- Renders effective retrieval request parameters, context bundle status, token budget posture, continuity state, capsules, and recent relevant entries without mutation controls.

## Retrieval/Auth Posture
- Invokes `context_retrieve_service` only after valid inspector input is present.
- Uses the internal UI operator auth context with `read:files` and `search` scopes, wildcard read namespaces, and no write namespaces.
- Uses fixed read-only retrieval defaults: `continuity_mode=auto`, degraded/fallback-tolerant continuity policies, empty selectors/include_types, one continuity capsule, `max_tokens_estimate=12000`, `time_window_days=30`, and `limit=10`.

## Degraded/Warning Rendering
- Validation problems render deterministic in-page warnings without calling retrieval.
- Retrieval exceptions degrade to an in-page `ui_context_retrieve_failed` warning.
- Missing or malformed bundle sections render stable `n/a`/empty states while preserving HTTP 200 behavior where the UI contract allows it.

## Follow-ups
- #236 remains open for runtime help/onboarding UI and scheduling spec follow-ups.

## Verification
- `git diff --check`
- `./.venv/bin/python -m unittest tests.test_ui_issue_251_context_inspector -v`
- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `./.venv/bin/python -m unittest tests.test_ui_issue_249_task_views -v`
- `./.venv/bin/python -m ruff check app/ui tests/test_ui_issue_199_slice1.py tests/test_ui_issue_249_task_views.py tests/test_ui_issue_251_context_inspector.py`
- `./.venv/bin/python -m unittest discover -s tests -v`
