### PR TITLE
Add read-only documentation browser UI

### DIFF
--- a/app/ui/docs.py
+++ b/app/ui/docs.py
@@ -5,18 +5,15 @@ from __future__ import annotations
 import html
 import posixpath
 import re
-import secrets
-import xml.etree.ElementTree as etree
 from dataclasses import dataclass
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote, unquote, urldefrag, urlsplit
 
 import bleach
 import markdown
-from markdown.extensions import Extension
 from markdown.extensions.toc import TocExtension
-from markdown.treeprocessors import Treeprocessor
 
 
 @dataclass(frozen=True)
@@ -131,18 +128,16 @@ def read_doc_source(repo_root: Path, doc: UiDoc) -> tuple[str | None, str | None
 
 def render_doc_markdown(*, source: str, doc: UiDoc) -> RenderedDoc:
     """Render Markdown to sanitized UI HTML with allowlisted doc-link behavior."""
-    token = secrets.token_urlsafe(16)
-    link_extension = _DocsLinkExtension(doc=doc, token=token)
     md = markdown.Markdown(
         extensions=[
             "fenced_code",
             "tables",
             TocExtension(slugify=_slugify_heading, toc_depth="2-3"),
-            link_extension,
         ],
         output_format="html",
     )
     rendered = md.convert(source)
+    rendered = _normalize_rendered_anchors(rendered, doc=doc)
     cleaned = bleach.Cleaner(
         tags=_ALLOWED_TAGS,
         attributes=_allowed_attribute,
@@ -150,9 +145,8 @@ def render_doc_markdown(*, source: str, doc: UiDoc) -> RenderedDoc:
         strip=True,
         strip_comments=True,
     ).clean(rendered)
-    content_html = _restore_generated_doc_links(cleaned, link_extension.generated_hrefs)
     return RenderedDoc(
-        content_html=content_html,
+        content_html=cleaned,
         toc_html=_toc_html(md.toc_tokens),
     )
 
@@ -189,15 +183,19 @@ def _allowed_attribute(tag: str, name: str, value: str) -> bool:
 def _allowed_href(value: str) -> bool:
     if value.startswith("http://") or value.startswith("https://"):
         return True
-    return False
+    if value.startswith("#"):
+        fragment = value[1:]
+        return _is_normalized_fragment(fragment)
+    split = urlsplit(value)
+    if split.scheme or split.netloc or split.query:
+        return False
+    if split.path not in {f"/ui/docs/{doc.doc_id}" for doc in UI_DOCS}:
+        return False
+    return not split.fragment or _is_normalized_fragment(split.fragment)
 
 
-def _restore_generated_doc_links(content: str, generated_hrefs: dict[str, str]) -> str:
-    restored = content
-    for placeholder, href in generated_hrefs.items():
-        restored = restored.replace(html.escape(placeholder, quote=True), html.escape(href, quote=True))
-        restored = restored.replace(placeholder, html.escape(href, quote=True))
-    return restored
+def _is_normalized_fragment(fragment: str) -> bool:
+    return bool(fragment) and quote(unquote(fragment), safe="-._~") == fragment
 
 
 def _toc_html(tokens: list[dict[str, Any]]) -> str:
@@ -226,76 +224,138 @@ def _flatten_toc_tokens(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return flattened
 
 
-class _DocsLinkExtension(Extension):
-    """Python-Markdown extension that rewrites links before final sanitization."""
+def _normalize_rendered_anchors(content: str, *, doc: UiDoc) -> str:
+    """Normalize rendered anchors before final sanitizer validation."""
+    parser = _RenderedAnchorNormalizer(doc=doc)
+    parser.feed(content)
+    parser.close()
+    return parser.content
 
-    def __init__(self, *, doc: UiDoc, token: str) -> None:
-        super().__init__()
+
+class _RenderedAnchorNormalizer(HTMLParser):
+    """Rewrite all rendered anchors through the UI docs link allowlist."""
+
+    def __init__(self, *, doc: UiDoc) -> None:
+        super().__init__(convert_charrefs=False)
         self.doc = doc
-        self.token = token
-        self.generated_hrefs: dict[str, str] = {}
-
-    def extendMarkdown(self, md: markdown.Markdown) -> None:  # noqa: N802 - Markdown extension API
-        md.treeprocessors.register(_DocsLinkTreeprocessor(md, extension=self), "cognirelay_docs_links", 5)
-
-
-class _DocsLinkTreeprocessor(Treeprocessor):
-    """Rewrite Markdown-generated anchors into the docs browser allowlist."""
-
-    def __init__(self, md: markdown.Markdown, *, extension: _DocsLinkExtension) -> None:
-        super().__init__(md)
-        self.extension = extension
-
-    def run(self, root: etree.Element) -> etree.Element:
-        for parent in list(root.iter()):
-            for index, child in enumerate(list(parent)):
-                if child.tag != "a":
-                    continue
-                self._rewrite_link(parent, index, child)
-        return root
-
-    def _rewrite_link(self, parent: etree.Element, index: int, link: etree.Element) -> None:
-        href = str(link.attrib.get("href", ""))
-        replacement = self._replacement_href(href)
-        if replacement is None:
-            _degrade_link(parent, index, link)
-            return
-        link.attrib["href"] = replacement
-        if replacement.startswith("http://") or replacement.startswith("https://"):
-            if not replacement.startswith(self._placeholder_prefix):
-                link.attrib["rel"] = "noreferrer"
+        self._parts: list[str] = []
+        self._anchor: dict[str, Any] | None = None
+        self._anchor_depth = 0
 
     @property
-    def _placeholder_prefix(self) -> str:
-        return f"https://cognirelay.invalid/__ui_docs__/{self.extension.token}/"
+    def content(self) -> str:
+        """Return normalized HTML collected so far."""
+        return "".join(self._parts)
 
-    def _replacement_href(self, href: str) -> str | None:
-        split = urlsplit(href)
-        if split.scheme or split.netloc:
-            if split.scheme in {"http", "https"}:
-                return href
-            return None
-        target, fragment = urldefrag(href)
-        normalized_fragment = normalize_fragment(fragment)
-        if target == "":
-            if not normalized_fragment:
-                return None
-            return self._placeholder(f"fragment/{normalized_fragment}", f"#{normalized_fragment}")
-        normalized_path = _normalize_doc_target(self.extension.doc.path, target)
-        target_doc_id = _UI_DOC_IDS_BY_PATH.get(normalized_path)
-        if target_doc_id is None:
-            return None
-        final_href = f"/ui/docs/{target_doc_id}"
-        placeholder_suffix = f"doc/{target_doc_id}"
-        if normalized_fragment:
-            final_href = f"{final_href}#{normalized_fragment}"
-            placeholder_suffix = f"{placeholder_suffix}/{normalized_fragment}"
-        return self._placeholder(placeholder_suffix, final_href)
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "a" and self._anchor is None:
+            self._anchor = {"attrs": attrs, "html": [], "text": []}
+            self._anchor_depth = 1
+            return
+        if self._anchor is not None:
+            self._anchor_depth += 1
+            self._anchor["html"].append(self._format_starttag(tag, attrs))
+            return
+        self._parts.append(self._format_starttag(tag, attrs))
 
-    def _placeholder(self, suffix: str, final_href: str) -> str:
-        placeholder = self._placeholder_prefix + suffix
-        self.extension.generated_hrefs[placeholder] = final_href
-        return placeholder
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        target = self._anchor["html"] if self._anchor is not None else self._parts
+        target.append(self._format_starttag(tag, attrs, startend=True))
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._anchor is not None:
+            self._anchor_depth -= 1
+            if tag == "a" and self._anchor_depth == 0:
+                self._parts.append(self._render_anchor())
+                self._anchor = None
+                return
+            self._anchor["html"].append(f"</{tag}>")
+            return
+        self._parts.append(f"</{tag}>")
+
+    def handle_data(self, data: str) -> None:
+        if self._anchor is not None:
+            self._anchor["html"].append(html.escape(data, quote=False))
+            self._anchor["text"].append(data)
+            return
+        self._parts.append(html.escape(data, quote=False))
+
+    def handle_entityref(self, name: str) -> None:
+        entity = f"&{name};"
+        if self._anchor is not None:
+            self._anchor["html"].append(entity)
+            self._anchor["text"].append(html.unescape(entity))
+            return
+        self._parts.append(entity)
+
+    def handle_charref(self, name: str) -> None:
+        charref = f"&#{name};"
+        if self._anchor is not None:
+            self._anchor["html"].append(charref)
+            self._anchor["text"].append(html.unescape(charref))
+            return
+        self._parts.append(charref)
+
+    def handle_comment(self, data: str) -> None:
+        target = self._anchor["html"] if self._anchor is not None else self._parts
+        target.append(f"<!--{data}-->")
+
+    def _render_anchor(self) -> str:
+        attrs = list(self._anchor["attrs"])
+        href = _attr_value(attrs, "href")
+        replacement = _replacement_href(self.doc, href or "")
+        if replacement is None:
+            text = "".join(self._anchor["text"])
+            return html.escape(text, quote=False) + " (not available in UI docs allowlist)"
+
+        normalized_attrs = [(name, value) for name, value in attrs if name not in {"href", "rel"}]
+        normalized_attrs.append(("href", replacement))
+        if replacement.startswith("http://") or replacement.startswith("https://"):
+            normalized_attrs.append(("rel", "noreferrer"))
+        return f"<a{_format_attrs(normalized_attrs)}>{''.join(self._anchor['html'])}</a>"
+
+    def _format_starttag(self, tag: str, attrs: list[tuple[str, str | None]], *, startend: bool = False) -> str:
+        suffix = " /" if startend else ""
+        return f"<{tag}{_format_attrs(attrs)}{suffix}>"
+
+
+def _attr_value(attrs: list[tuple[str, str | None]], name: str) -> str | None:
+    for attr_name, attr_value in attrs:
+        if attr_name == name:
+            return attr_value or ""
+    return None
+
+
+def _format_attrs(attrs: list[tuple[str, str | None]]) -> str:
+    formatted = []
+    for name, value in attrs:
+        if value is None:
+            formatted.append(f" {name}")
+            continue
+        formatted.append(f' {name}="{html.escape(value, quote=True)}"')
+    return "".join(formatted)
+
+
+def _replacement_href(doc: UiDoc, href: str) -> str | None:
+    split = urlsplit(href)
+    if split.scheme or split.netloc:
+        if split.scheme in {"http", "https"}:
+            return href
+        return None
+    target, fragment = urldefrag(href)
+    normalized_fragment = normalize_fragment(fragment)
+    if target == "":
+        if not normalized_fragment:
+            return None
+        return f"#{normalized_fragment}"
+    normalized_path = _normalize_doc_target(doc.path, target)
+    target_doc_id = _UI_DOC_IDS_BY_PATH.get(normalized_path)
+    if target_doc_id is None:
+        return None
+    final_href = f"/ui/docs/{target_doc_id}"
+    if normalized_fragment:
+        final_href = f"{final_href}#{normalized_fragment}"
+    return final_href
 
 
 def _normalize_doc_target(source_path: str, target: str) -> str:
@@ -304,10 +364,3 @@ def _normalize_doc_target(source_path: str, target: str) -> str:
     joined = decoded if base == "" else posixpath.join(base, decoded)
     normalized = posixpath.normpath(joined)
     return "" if normalized == "." else normalized
-
-
-def _degrade_link(parent: etree.Element, index: int, link: etree.Element) -> None:
-    span = etree.Element("span")
-    span.text = "".join(link.itertext()) + " (not available in UI docs allowlist)"
-    span.tail = link.tail
-    parent[index] = span

--- a/app/ui/docs.py
+++ b/app/ui/docs.py
@@ -1,0 +1,313 @@
+"""Read-only documentation browser helpers for the operator UI."""
+
+from __future__ import annotations
+
+import html
+import posixpath
+import re
+import secrets
+import xml.etree.ElementTree as etree
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, unquote, urldefrag, urlsplit
+
+import bleach
+import markdown
+from markdown.extensions import Extension
+from markdown.extensions.toc import TocExtension
+from markdown.treeprocessors import Treeprocessor
+
+
+@dataclass(frozen=True)
+class UiDoc:
+    """One fixed documentation entry renderable by the UI."""
+
+    doc_id: str
+    path: str
+    title: str
+    description: str
+
+
+@dataclass(frozen=True)
+class UiDocStatus:
+    """Availability state for one allowlisted UI document."""
+
+    doc: UiDoc
+    available: bool
+    warning: str | None = None
+
+
+@dataclass(frozen=True)
+class RenderedDoc:
+    """Sanitized Markdown output and matching h2/h3 table of contents."""
+
+    content_html: str
+    toc_html: str
+
+
+UI_DOCS: tuple[UiDoc, ...] = (
+    UiDoc("readme", "README.md", "README", "Project overview, quick start, runtime shape, and canonical doc map."),
+    UiDoc(
+        "system-overview",
+        "docs/system-overview.md",
+        "System Overview",
+        "Product shape, architecture, deployment topology, and agent usage model.",
+    ),
+    UiDoc(
+        "payload-reference",
+        "docs/payload-reference.md",
+        "Payload Reference",
+        "Continuity, retrieval, coordination, and schema payload reference.",
+    ),
+    UiDoc(
+        "api-surface",
+        "docs/api-surface.md",
+        "API Surface",
+        "Human-facing summary of implemented HTTP and runtime help surfaces.",
+    ),
+    UiDoc("mcp", "docs/mcp.md", "MCP Guide", "MCP bootstrap flow, tool model, mappings, and response behavior."),
+    UiDoc(
+        "cognirelay-client",
+        "docs/cognirelay-client.md",
+        "CogniRelay CLI Client",
+        "Command-line client requirements, usage, and examples.",
+    ),
+    UiDoc(
+        "agent-onboarding",
+        "docs/agent-onboarding.md",
+        "Agent Onboarding",
+        "Practical startup, hook, workflow, retrieval, and anti-pattern guidance for agents.",
+    ),
+)
+UI_DOCS_BY_ID: dict[str, UiDoc] = {doc.doc_id: doc for doc in UI_DOCS}
+_UI_DOC_IDS_BY_PATH: dict[str, str] = {doc.path: doc.doc_id for doc in UI_DOCS}
+_ALLOWED_TAGS = {
+    "a",
+    "p",
+    "br",
+    "strong",
+    "em",
+    "code",
+    "pre",
+    "blockquote",
+    "ul",
+    "ol",
+    "li",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "hr",
+}
+_HEADING_TAGS = {"h1", "h2", "h3", "h4", "h5", "h6"}
+
+
+def doc_statuses(repo_root: Path) -> list[UiDocStatus]:
+    """Return fixed-order availability for all allowlisted docs."""
+    return [_doc_status(repo_root, doc) for doc in UI_DOCS]
+
+
+def read_doc_source(repo_root: Path, doc: UiDoc) -> tuple[str | None, str | None]:
+    """Read one allowlisted doc, degrading to deterministic warning codes."""
+    path = repo_root / doc.path
+    if not path.is_file():
+        return None, f"doc_missing:{doc.doc_id}"
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except OSError:
+        return None, f"doc_unreadable:{doc.doc_id}"
+    except UnicodeError:
+        return None, f"doc_unreadable:{doc.doc_id}"
+
+
+def render_doc_markdown(*, source: str, doc: UiDoc) -> RenderedDoc:
+    """Render Markdown to sanitized UI HTML with allowlisted doc-link behavior."""
+    token = secrets.token_urlsafe(16)
+    link_extension = _DocsLinkExtension(doc=doc, token=token)
+    md = markdown.Markdown(
+        extensions=[
+            "fenced_code",
+            "tables",
+            TocExtension(slugify=_slugify_heading, toc_depth="2-3"),
+            link_extension,
+        ],
+        output_format="html",
+    )
+    rendered = md.convert(source)
+    cleaned = bleach.Cleaner(
+        tags=_ALLOWED_TAGS,
+        attributes=_allowed_attribute,
+        protocols={"http", "https"},
+        strip=True,
+        strip_comments=True,
+    ).clean(rendered)
+    content_html = _restore_generated_doc_links(cleaned, link_extension.generated_hrefs)
+    return RenderedDoc(
+        content_html=content_html,
+        toc_html=_toc_html(md.toc_tokens),
+    )
+
+
+def normalize_fragment(fragment: str) -> str:
+    """Normalize a URL fragment according to the docs UI contract."""
+    value = fragment[1:] if fragment.startswith("#") else fragment
+    value = value.strip(" \t\r\n\f\v")
+    if not value:
+        return ""
+    return quote(value, safe="-._~")
+
+
+def _doc_status(repo_root: Path, doc: UiDoc) -> UiDocStatus:
+    source, warning = read_doc_source(repo_root, doc)
+    return UiDocStatus(doc=doc, available=source is not None, warning=warning)
+
+
+def _slugify_heading(value: str, _separator: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "section"
+
+
+def _allowed_attribute(tag: str, name: str, value: str) -> bool:
+    if tag == "a" and name in {"title", "rel"}:
+        return True
+    if tag == "a" and name == "href":
+        return _allowed_href(value)
+    if tag in _HEADING_TAGS and name == "id":
+        return True
+    return False
+
+
+def _allowed_href(value: str) -> bool:
+    if value.startswith("http://") or value.startswith("https://"):
+        return True
+    return False
+
+
+def _restore_generated_doc_links(content: str, generated_hrefs: dict[str, str]) -> str:
+    restored = content
+    for placeholder, href in generated_hrefs.items():
+        restored = restored.replace(html.escape(placeholder, quote=True), html.escape(href, quote=True))
+        restored = restored.replace(placeholder, html.escape(href, quote=True))
+    return restored
+
+
+def _toc_html(tokens: list[dict[str, Any]]) -> str:
+    items: list[str] = []
+    for token in _flatten_toc_tokens(tokens):
+        level = int(token.get("level", 0))
+        if level not in {2, 3}:
+            continue
+        anchor = str(token.get("id", ""))
+        name = str(token.get("name", ""))
+        if not anchor or not name:
+            continue
+        items.append(f'<li><a href="#{html.escape(anchor, quote=True)}">{html.escape(name)}</a></li>')
+    if not items:
+        return '<p class="muted">No section headings available.</p>'
+    return "<ul>" + "".join(items) + "</ul>"
+
+
+def _flatten_toc_tokens(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    flattened: list[dict[str, Any]] = []
+    for token in tokens:
+        flattened.append(token)
+        children = token.get("children")
+        if isinstance(children, list):
+            flattened.extend(_flatten_toc_tokens(children))
+    return flattened
+
+
+class _DocsLinkExtension(Extension):
+    """Python-Markdown extension that rewrites links before final sanitization."""
+
+    def __init__(self, *, doc: UiDoc, token: str) -> None:
+        super().__init__()
+        self.doc = doc
+        self.token = token
+        self.generated_hrefs: dict[str, str] = {}
+
+    def extendMarkdown(self, md: markdown.Markdown) -> None:  # noqa: N802 - Markdown extension API
+        md.treeprocessors.register(_DocsLinkTreeprocessor(md, extension=self), "cognirelay_docs_links", 5)
+
+
+class _DocsLinkTreeprocessor(Treeprocessor):
+    """Rewrite Markdown-generated anchors into the docs browser allowlist."""
+
+    def __init__(self, md: markdown.Markdown, *, extension: _DocsLinkExtension) -> None:
+        super().__init__(md)
+        self.extension = extension
+
+    def run(self, root: etree.Element) -> etree.Element:
+        for parent in list(root.iter()):
+            for index, child in enumerate(list(parent)):
+                if child.tag != "a":
+                    continue
+                self._rewrite_link(parent, index, child)
+        return root
+
+    def _rewrite_link(self, parent: etree.Element, index: int, link: etree.Element) -> None:
+        href = str(link.attrib.get("href", ""))
+        replacement = self._replacement_href(href)
+        if replacement is None:
+            _degrade_link(parent, index, link)
+            return
+        link.attrib["href"] = replacement
+        if replacement.startswith("http://") or replacement.startswith("https://"):
+            if not replacement.startswith(self._placeholder_prefix):
+                link.attrib["rel"] = "noreferrer"
+
+    @property
+    def _placeholder_prefix(self) -> str:
+        return f"https://cognirelay.invalid/__ui_docs__/{self.extension.token}/"
+
+    def _replacement_href(self, href: str) -> str | None:
+        split = urlsplit(href)
+        if split.scheme or split.netloc:
+            if split.scheme in {"http", "https"}:
+                return href
+            return None
+        target, fragment = urldefrag(href)
+        normalized_fragment = normalize_fragment(fragment)
+        if target == "":
+            if not normalized_fragment:
+                return None
+            return self._placeholder(f"fragment/{normalized_fragment}", f"#{normalized_fragment}")
+        normalized_path = _normalize_doc_target(self.extension.doc.path, target)
+        target_doc_id = _UI_DOC_IDS_BY_PATH.get(normalized_path)
+        if target_doc_id is None:
+            return None
+        final_href = f"/ui/docs/{target_doc_id}"
+        placeholder_suffix = f"doc/{target_doc_id}"
+        if normalized_fragment:
+            final_href = f"{final_href}#{normalized_fragment}"
+            placeholder_suffix = f"{placeholder_suffix}/{normalized_fragment}"
+        return self._placeholder(placeholder_suffix, final_href)
+
+    def _placeholder(self, suffix: str, final_href: str) -> str:
+        placeholder = self._placeholder_prefix + suffix
+        self.extension.generated_hrefs[placeholder] = final_href
+        return placeholder
+
+
+def _normalize_doc_target(source_path: str, target: str) -> str:
+    decoded = unquote(target)
+    base = posixpath.dirname(source_path)
+    joined = decoded if base == "" else posixpath.join(base, decoded)
+    normalized = posixpath.normpath(joined)
+    return "" if normalized == "." else normalized
+
+
+def _degrade_link(parent: etree.Element, index: int, link: etree.Element) -> None:
+    span = etree.Element("span")
+    span.text = "".join(link.itertext()) + " (not available in UI docs allowlist)"
+    span.tail = link.tail
+    parent[index] = span

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -31,6 +31,7 @@ from app.context.graph import derive_internal_graph_slice1
 from app.discovery import capabilities_payload, health_payload
 from app.git_manager import GitManager
 from app.models import ContextRetrieveRequest, ContinuityReadRequest
+from app.ui.docs import UI_DOCS_BY_ID, UiDoc, doc_statuses, read_doc_source, render_doc_markdown
 
 from .render import render_template
 
@@ -405,6 +406,23 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         _enforce_ui_access(request, settings)
         return _render_graph_response(settings=settings, subject_kind=subject_kind, subject_id=subject_id)
 
+    @router.get("/docs", response_class=HTMLResponse)
+    def ui_docs(request: Request) -> HTMLResponse:
+        """Render the fixed read-only documentation index."""
+        settings = get_settings()
+        _enforce_ui_access(request, settings)
+        return _docs_index_page(settings.repo_root)
+
+    @router.get("/docs/{doc_id}", response_class=HTMLResponse)
+    def ui_doc_detail(request: Request, doc_id: str) -> HTMLResponse:
+        """Render one allowlisted Markdown document."""
+        settings = get_settings()
+        _enforce_ui_access(request, settings)
+        doc = UI_DOCS_BY_ID.get(doc_id)
+        if doc is None:
+            return _docs_not_found_page()
+        return _docs_detail_page(settings.repo_root, doc)
+
     @router.get("/events")
     async def ui_events(
         request: Request,
@@ -540,6 +558,7 @@ def _page(*, title: str, current_path: str, content: str) -> HTMLResponse:
         tasks_nav_class=_nav_class(current_path.startswith("/ui/tasks")),
         retrieval_nav_class=_nav_class(current_path.startswith("/ui/context")),
         graph_nav_class=_nav_class(current_path.startswith("/ui/graph")),
+        docs_nav_class=_nav_class(current_path.startswith("/ui/docs")),
         content=content,
     )
     return HTMLResponse(html_doc)
@@ -548,6 +567,106 @@ def _page(*, title: str, current_path: str, content: str) -> HTMLResponse:
 def _nav_class(active: bool) -> str:
     """Return the nav link class for the current page."""
     return "nav-link active" if active else "nav-link"
+
+
+def _docs_index_page(repo_root: Path) -> HTMLResponse:
+    """Render the read-only docs index with fixed allowlist ordering."""
+    statuses = doc_statuses(repo_root)
+    rows: list[list[str]] = []
+    warnings: list[str] = []
+    for status in statuses:
+        doc = status.doc
+        status_label = "Available" if status.available else "Unavailable"
+        title = html.escape(doc.title)
+        if status.available:
+            title = f'<a href="/ui/docs/{html.escape(doc.doc_id, quote=True)}">{title}</a>'
+        if status.warning:
+            warnings.append(status.warning)
+        rows.append(
+            [
+                title,
+                html.escape(doc.description),
+                html.escape(doc.path),
+                html.escape(status_label),
+            ]
+        )
+    body = render_template(
+        "docs_index.html",
+        docs_table=_html_table(
+            headers=["Title", "Description", "Source path", "Status"],
+            rows=rows,
+            empty_message="No documentation entries configured.",
+        ),
+        warnings_panel=_docs_warnings_panel(warnings),
+        runtime_help_panel=_runtime_help_panel(),
+    )
+    return _page(title="Documentation", current_path="/ui/docs", content=body)
+
+
+def _docs_detail_page(repo_root: Path, doc: UiDoc) -> HTMLResponse:
+    """Render one allowlisted document, degrading if the file is unavailable."""
+    source, warning = read_doc_source(repo_root, doc)
+    status = "Available" if source is not None else "Unavailable"
+    if source is None:
+        content_html = '<p class="muted">Document content is unavailable.</p>'
+        toc_html = '<p class="muted">No section headings available.</p>'
+    else:
+        rendered = render_doc_markdown(source=source, doc=doc)
+        content_html = rendered.content_html
+        toc_html = rendered.toc_html
+    body = render_template(
+        "docs_detail.html",
+        document_rows=_definition_rows(
+            [
+                ("Title", doc.title),
+                ("Source path", doc.path),
+                ("Status", status),
+            ]
+        ),
+        document_warning=_docs_warning_line(warning),
+        toc_html=toc_html,
+        runtime_help_panel=_runtime_help_panel(),
+        content_html=content_html,
+    )
+    return _page(title=doc.title, current_path="/ui/docs", content=body)
+
+
+def _docs_not_found_page() -> HTMLResponse:
+    """Render deterministic UI 404 for unknown docs IDs."""
+    body = (
+        '<section class="panel">'
+        "<h2>Documentation Not Found</h2>"
+        '<p class="warning">The requested documentation page is not available in the UI docs allowlist.</p>'
+        '<p><a href="/ui/docs">Back to documentation index</a></p>'
+        "</section>"
+    )
+    response = _page(title="Documentation Not Found", current_path="/ui/docs", content=body)
+    response.status_code = 404
+    return response
+
+
+def _docs_warnings_panel(warnings: list[str]) -> str:
+    """Render deterministic docs warning codes when present."""
+    if not warnings:
+        return ""
+    return '<section class="panel"><h2>Warnings</h2>' + _html_list(warnings) + "</section>"
+
+
+def _docs_warning_line(warning: str | None) -> str:
+    """Render the detail warning line for degraded docs."""
+    if warning is None:
+        return ""
+    return f'<p class="warning">{html.escape(warning)}</p>'
+
+
+def _runtime_help_panel() -> str:
+    """Render plain links to existing runtime help surfaces."""
+    links = [
+        '<a href="/v1/help">Runtime help index</a>',
+        '<a href="/v1/help/onboarding">Runtime onboarding index</a>',
+        '<a href="/v1/help/limits">Validation limits index</a>',
+    ]
+    return "<section class=\"panel\"><h2>Runtime Help</h2><ul>" + "".join(f"<li>{link}</li>" for link in links) + "</ul></section>"
 
 
 def _normalize_ui_filter(value: str | None, allowed: tuple[str, ...]) -> str | None:

--- a/app/ui/templates/docs_detail.html
+++ b/app/ui/templates/docs_detail.html
@@ -1,0 +1,15 @@
+<section class="panel">
+  <h2>Document</h2>
+  ${document_rows}
+  ${document_warning}
+  <p><a href="/ui/docs">Back to documentation index</a></p>
+</section>
+<section class="panel">
+  <h2>Table of Contents</h2>
+  ${toc_html}
+</section>
+${runtime_help_panel}
+<section class="panel docs-content">
+  <h2>Content</h2>
+  ${content_html}
+</section>

--- a/app/ui/templates/docs_index.html
+++ b/app/ui/templates/docs_index.html
@@ -1,0 +1,6 @@
+<section class="panel">
+  <h2>Documentation</h2>
+  ${docs_table}
+</section>
+${warnings_panel}
+${runtime_help_panel}

--- a/app/ui/templates/layout.html
+++ b/app/ui/templates/layout.html
@@ -34,6 +34,7 @@
           <a class="${tasks_nav_class}" href="/ui/tasks">Tasks</a>
           <a class="${retrieval_nav_class}" href="/ui/context">Retrieval</a>
           <a class="${graph_nav_class}" href="/ui/graph">Graph</a>
+          <a class="${docs_nav_class}" href="/ui/docs">Docs</a>
         </nav>
         <label class="theme-control" for="theme-select">
           <span>Theme</span>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi>=0.115,<1
 uvicorn>=0.30,<1
 pydantic>=2.7,<3
 python-dotenv>=1.0,<2
+markdown>=3.6,<4
+bleach>=6,<7

--- a/tests/test_ui_docs.py
+++ b/tests/test_ui_docs.py
@@ -1,0 +1,290 @@
+"""Tests for #253 read-only documentation browser UI."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from app.ui.docs import UI_DOCS
+
+
+def _reload_ui_router():
+    """Reload config and UI router so env-controlled settings are current."""
+    import app.config as config_module
+    import app.ui.docs as ui_docs_module
+    import app.ui.router as ui_router_module
+
+    importlib.reload(config_module)
+    importlib.reload(ui_docs_module)
+    return importlib.reload(ui_router_module)
+
+
+def _reload_main_module():
+    """Reload config, UI modules, and main so UI mounting follows env."""
+    import app.config as config_module
+    import app.main as main_module
+    import app.ui.docs as ui_docs_module
+    import app.ui.router as ui_router_module
+
+    importlib.reload(config_module)
+    importlib.reload(ui_docs_module)
+    importlib.reload(ui_router_module)
+    return importlib.reload(main_module)
+
+
+def _request(path: str) -> Request:
+    """Build a localhost UI request."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "raw_path": path.encode("utf-8"),
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "http_version": "1.1",
+        }
+    )
+
+
+def _ui_response(
+    repo_root: Path,
+    *,
+    route_path: str,
+    request_path: str,
+    endpoint_kwargs: dict[str, Any] | None = None,
+) -> SimpleNamespace:
+    """Render one UI docs route directly for deterministic assertions."""
+    with patch.dict(
+        os.environ,
+        {
+            "COGNIRELAY_REPO_ROOT": str(repo_root),
+            "COGNIRELAY_AUTO_INIT_GIT": "true",
+            "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
+        },
+        clear=False,
+    ):
+        ui_router = _reload_ui_router()
+        router = ui_router.build_ui_router(app_version="test-version")
+        endpoint = next(route.endpoint for route in router.routes if route.path == route_path)
+        response = endpoint(_request(request_path), **(endpoint_kwargs or {}))
+        return SimpleNamespace(status_code=response.status_code, text=response.body.decode("utf-8"))
+
+
+def _write_allowlisted_docs(repo_root: Path, *, readme: str | None = None) -> None:
+    """Create every allowlisted doc with deterministic default content."""
+    for doc in UI_DOCS:
+        path = repo_root / doc.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = readme if doc.doc_id == "readme" and readme is not None else f"# {doc.title}\n\n## Section\n\nContent for {doc.doc_id}.\n"
+        path.write_text(content, encoding="utf-8")
+
+
+class UiDocsTests(unittest.TestCase):
+    def test_docs_index_renders_allowlist_in_exact_order_and_runtime_help(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            _write_allowlisted_docs(repo_root)
+
+            response = _ui_response(repo_root, route_path="/ui/docs", request_path="/ui/docs")
+
+        self.assertEqual(response.status_code, 200)
+        positions = [response.text.index(f"/ui/docs/{doc.doc_id}") for doc in UI_DOCS]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn('href="/v1/help">Runtime help index</a>', response.text)
+        self.assertIn('href="/v1/help/onboarding">Runtime onboarding index</a>', response.text)
+        self.assertIn('href="/v1/help/limits">Validation limits index</a>', response.text)
+        self.assertIn('href="/ui/docs">Docs</a>', response.text)
+
+    def test_each_allowlisted_doc_id_renders(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            _write_allowlisted_docs(repo_root)
+
+            for doc in UI_DOCS:
+                with self.subTest(doc_id=doc.doc_id):
+                    response = _ui_response(
+                        repo_root,
+                        route_path="/ui/docs/{doc_id}",
+                        request_path=f"/ui/docs/{doc.doc_id}",
+                        endpoint_kwargs={"doc_id": doc.doc_id},
+                    )
+                    self.assertEqual(response.status_code, 200)
+                    self.assertIn(doc.title, response.text)
+                    self.assertIn(doc.path, response.text)
+                    self.assertIn("Available", response.text)
+
+    def test_unknown_and_path_like_doc_ids_do_not_render_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            _write_allowlisted_docs(repo_root)
+            unknown = _ui_response(
+                repo_root,
+                route_path="/ui/docs/{doc_id}",
+                request_path="/ui/docs/not-allowed",
+                endpoint_kwargs={"doc_id": "not-allowed"},
+            )
+            traversal = _ui_response(
+                repo_root,
+                route_path="/ui/docs/{doc_id}",
+                request_path="/ui/docs/..%2FREADME.md",
+                endpoint_kwargs={"doc_id": "../README.md"},
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "COGNIRELAY_REPO_ROOT": str(repo_root),
+                    "COGNIRELAY_AUTO_INIT_GIT": "true",
+                    "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
+                    "COGNIRELAY_UI_ENABLED": "true",
+                },
+                clear=False,
+            ):
+                app_module = _reload_main_module()
+                slash_response = TestClient(app_module.app).get("/ui/docs/foo/bar")
+
+        self.assertEqual(unknown.status_code, 404)
+        self.assertIn("Documentation Not Found", unknown.text)
+        self.assertNotIn("README content", unknown.text)
+        self.assertEqual(traversal.status_code, 404)
+        self.assertIn("Documentation Not Found", traversal.text)
+        self.assertEqual(slash_response.status_code, 404)
+
+    def test_missing_allowlisted_file_degrades_on_index_and_detail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            _write_allowlisted_docs(repo_root)
+            (repo_root / "docs" / "mcp.md").unlink()
+
+            index = _ui_response(repo_root, route_path="/ui/docs", request_path="/ui/docs")
+            detail = _ui_response(
+                repo_root,
+                route_path="/ui/docs/{doc_id}",
+                request_path="/ui/docs/mcp",
+                endpoint_kwargs={"doc_id": "mcp"},
+            )
+
+        self.assertEqual(index.status_code, 200)
+        self.assertIn("doc_missing:mcp", index.text)
+        self.assertIn("Unavailable", index.text)
+        self.assertNotIn('href="/ui/docs/mcp"', index.text)
+        self.assertEqual(detail.status_code, 200)
+        self.assertIn("MCP Guide", detail.text)
+        self.assertIn("doc_missing:mcp", detail.text)
+        self.assertIn("Document content is unavailable.", detail.text)
+
+    def test_markdown_sanitization_code_tables_and_links(self) -> None:
+        markdown_source = """# README
+
+## Repeat!
+### Repeat?
+## Repeat!
+
+[System](docs/system-overview.md# Agent Usage )
+[Payload](docs/payload-reference.md#field/value)
+[Same](# Repeat! )
+[EmptySame](#)
+[EmptyCross](docs/mcp.md#   )
+[Unsupported](docs/reviewer-guide.md)
+[RootInject](/ui/docs/agent-onboarding)
+[External](https://example.com/a?b=1)
+[BadJs](javascript:alert(1))
+
+<script>alert("x")</script>
+<a href="/ui/docs/agent-onboarding">raw internal</a>
+<a href="file:///tmp/secret">file</a>
+<span style="color:red" onclick="alert(1)">styled</span>
+![Alt](docs/image.png)
+
+```html
+<script>safe text</script>
+```
+
+| A | B |
+|---|---|
+| 1 | 2 |
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            _write_allowlisted_docs(repo_root, readme=markdown_source)
+            response = _ui_response(
+                repo_root,
+                route_path="/ui/docs/{doc_id}",
+                request_path="/ui/docs/readme",
+                endpoint_kwargs={"doc_id": "readme"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.text[response.text.index('<section class="panel docs-content">') :]
+        self.assertIn('href="/ui/docs/system-overview#Agent%20Usage"', response.text)
+        self.assertIn('href="/ui/docs/payload-reference#field%2Fvalue"', response.text)
+        self.assertIn('href="#Repeat%21"', response.text)
+        self.assertIn('href="/ui/docs/mcp">EmptyCross</a>', response.text)
+        self.assertIn("Unsupported (not available in UI docs allowlist)", response.text)
+        self.assertIn("RootInject (not available in UI docs allowlist)", response.text)
+        self.assertIn('href="https://example.com/a?b=1" rel="noreferrer"', response.text)
+        self.assertNotIn("javascript:alert", content)
+        self.assertNotIn("<script>", content)
+        self.assertNotIn("onclick", content)
+        self.assertNotIn("style=", content)
+        self.assertNotIn("<img", content)
+        self.assertNotIn('href="/ui/docs/agent-onboarding">raw internal</a>', content)
+        self.assertNotIn("file:///tmp/secret", content)
+        self.assertIn("<pre><code>", response.text)
+        self.assertIn("&lt;script&gt;safe text&lt;/script&gt;", response.text)
+        self.assertIn("<table>", response.text)
+        self.assertIn("<thead>", response.text)
+        self.assertIn("<tbody>", response.text)
+
+    def test_heading_anchors_toc_and_read_only_page_shape(self) -> None:
+        markdown_source = """# Top
+
+## Same Heading
+### Same Heading
+#### Not In Toc
+## Same Heading
+## !!!
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            _write_allowlisted_docs(repo_root, readme=markdown_source)
+            response = _ui_response(
+                repo_root,
+                route_path="/ui/docs/{doc_id}",
+                request_path="/ui/docs/readme",
+                endpoint_kwargs={"doc_id": "readme"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('<h2 id="same-heading">Same Heading</h2>', response.text)
+        self.assertIn('<h3 id="same-heading_1">Same Heading</h3>', response.text)
+        self.assertIn('<h2 id="same-heading_2">Same Heading</h2>', response.text)
+        self.assertIn('<h2 id="section">!!!</h2>', response.text)
+        toc_start = response.text.index("<h2>Table of Contents</h2>")
+        content_start = response.text.index('<section class="panel docs-content">')
+        toc = response.text[toc_start:content_start]
+        self.assertIn('href="#same-heading">Same Heading</a>', toc)
+        self.assertIn('href="#same-heading_1">Same Heading</a>', toc)
+        self.assertIn('href="#same-heading_2">Same Heading</a>', toc)
+        self.assertIn('href="#section">!!!</a>', toc)
+        self.assertNotIn("not-in-toc", toc)
+        self.assertNotIn("<form", response.text)
+        self.assertNotIn("<button", response.text)
+        self.assertNotIn("data-live-page", response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_docs.py
+++ b/tests/test_ui_docs.py
@@ -204,6 +204,7 @@ class UiDocsTests(unittest.TestCase):
 [BadJs](javascript:alert(1))
 
 <script>alert("x")</script>
+<a href="https://example.com/raw">raw</a>
 <a href="/ui/docs/agent-onboarding">raw internal</a>
 <a href="file:///tmp/secret">file</a>
 <span style="color:red" onclick="alert(1)">styled</span>
@@ -236,12 +237,15 @@ class UiDocsTests(unittest.TestCase):
         self.assertIn("Unsupported (not available in UI docs allowlist)", response.text)
         self.assertIn("RootInject (not available in UI docs allowlist)", response.text)
         self.assertIn('href="https://example.com/a?b=1" rel="noreferrer"', response.text)
+        self.assertIn('href="https://example.com/raw" rel="noreferrer">raw</a>', response.text)
+        self.assertIn("raw internal (not available in UI docs allowlist)", response.text)
         self.assertNotIn("javascript:alert", content)
         self.assertNotIn("<script>", content)
         self.assertNotIn("onclick", content)
         self.assertNotIn("style=", content)
         self.assertNotIn("<img", content)
         self.assertNotIn('href="/ui/docs/agent-onboarding">raw internal</a>', content)
+        self.assertNotIn('href="/ui/docs/agent-onboarding"', content)
         self.assertNotIn("file:///tmp/secret", content)
         self.assertIn("<pre><code>", response.text)
         self.assertIn("&lt;script&gt;safe text&lt;/script&gt;", response.text)


### PR DESCRIPTION
Closes #253

## Summary
- Adds the read-only `/ui/docs` index route and `/ui/docs/{doc_id}` detail route for the fixed #253 documentation allowlist only: README, system overview, payload reference, API surface, MCP guide, CogniRelay CLI client, and agent onboarding.
- Renders allowlisted documents with Python-Markdown using fenced code, tables, and deterministic TOC heading anchors, then sanitizes output with Bleach. Link handling rewrites allowlisted relative doc links to `/ui/docs/{doc_id}` with normalized fragments, preserves safe http(s) external links with `rel="noreferrer"`, strips images, and degrades unsupported relative/root-relative/file/javascript/data links to non-clickable text.
- Adds compact Runtime Help panels linking directly to existing `/v1/help`, `/v1/help/onboarding`, and `/v1/help/limits` surfaces without adding new runtime help APIs or proxies.
- #236 remains open for deferred scheduling/reminder spec follow-up and other broader UI expansion work.

## Verification
- `git diff --check`
- `./.venv/bin/python -m unittest tests.test_ui_docs -v`
- `./.venv/bin/python -m unittest tests.test_ui_issue_199_slice1 -v`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`