### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-04-25
+
+### Added
+
+- Added a bounded runtime onboarding/help surface so agents can discover
+  startup rules, operational guidance, validation limits, and shipped route
+  identifiers without preloading the repository documentation.
+- Added derived graph context to agent-facing runtime paths: `context.retrieve`
+  now returns bounded `bundle.graph_context`, and startup `continuity.read`
+  returns top-level `graph_summary` after the base read succeeds.
+- Added SQLite-backed one-shot schedule reminders and task nudges with HTTP
+  and MCP create/read/list/update/acknowledge/retire surfaces, UTC-only
+  timestamps, pull-based due evaluation, and scoped `schedule_context` in
+  startup/context orientation responses.
+- Added read-only operator UI pages for graph inspection, task-centric
+  inspection, context retrieval inspection, documentation browsing, and
+  schedule/reminder inspection.
+
+### Changed
+
+- Reworked `docs/agent-onboarding.md` into the single concise bootstrap and
+  operating manual for agents, with reference detail kept in the payload/API/MCP
+  docs and runtime help surfaces.
+- Synchronized payload reference, API surface, MCP docs, runtime help,
+  discovery descriptors, capabilities, and UI docs with the post-#218 runtime
+  feature set.
+- Expanded discovery/capability metadata to advertise graph context, startup
+  graph summaries, schedule reminders, and the current operator UI surfaces.
+
+### Fixed
+
+- Corrected stale documentation and runtime help claims around continuity field
+  limits, help payload examples, MCP anchors, graph availability, and schedule
+  availability.
+- Hardened graph runtime integration so graph derivation is bounded,
+  auth/path-aware, degraded-safe, and never persisted into continuity capsules.
+- Hardened schedule storage and MCP behavior around SQLite failures,
+  idempotency, validation error mapping, malformed rows, and generated database
+  artifacts.
+
 ## [1.3.1] - 2026-04-17
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.3.1", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.0", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/releases/v1.4.0.md
+++ b/docs/releases/v1.4.0.md
@@ -1,0 +1,48 @@
+# CogniRelay v1.4.0 Release Notes
+
+Release date: 2026-04-25
+
+CogniRelay v1.4.0 completes the post-#218/#236 roadmap. The release turns the
+post-hardening work into shipped agent-facing runtime surfaces, stronger
+operator inspection tools, and coherent docs/help/discovery metadata.
+
+## Highlights
+
+- **Runtime onboarding and help:** agents can discover onboarding sections,
+  startup guidance, route identifiers, validation limits, and help topics
+  through bounded HTTP and MCP help surfaces.
+- **Agent-facing derived graph context:** `context.retrieve` now includes
+  bounded `bundle.graph_context` by default, and startup `continuity.read`
+  includes a compact top-level `graph_summary` after the base read succeeds.
+- **One-shot schedules and reminders:** the new SQLite-backed schedule store
+  supports reminders and task nudges through HTTP and MCP, with UTC-only
+  timestamps, pull-based due evaluation, and scoped `schedule_context` in
+  startup and context orientation responses.
+- **Expanded read-only operator UI:** the local UI now includes graph, task,
+  context retrieval, documentation, and schedule inspection pages, in addition
+  to the continuity-oriented surfaces.
+- **Coherent docs and discovery:** payload reference, API docs, MCP docs,
+  onboarding, runtime help, discovery descriptors, capabilities, and the UI docs
+  browser now describe the same shipped behavior.
+
+## Compatibility Notes
+
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`). New feature keys were added without changing the schema.
+- The durable continuity capsule write cap remains 20 KB. Graph and schedule
+  information are derived response adjuncts, not stored capsule data.
+- Schedule reminders are one-shot only in this release. Recurrence, background
+  scheduler loops, SSE/push delivery, arbitrary command execution, webhooks, and
+  automatic task/continuity mutation remain out of scope.
+- Non-startup `continuity.read` remains graph-free by default. Startup reads
+  receive `graph_summary`; context retrieval receives `bundle.graph_context`.
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary
- bump runtime app version to 1.4.0
- add CHANGELOG entry for v1.4.0
- add release notes at docs/releases/v1.4.0.md

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app tests tools
- ./.venv/bin/python -m unittest tests.test_179_capabilities_v1 -v
- ./.venv/bin/python -m unittest discover -s tests -v

## Notes
- GET /v1/capabilities version remains the capability schema version ("1").
- No runtime behavior changes beyond the FastAPI app version bump.