### PR TITLE
Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-04-26
+
+### Fixed
+
+- Clarified agent onboarding and runtime help examples for thread-scoped
+  `context.retrieve` calls so cold-start agents use `subject_kind="thread"`
+  plus `subject_id`, not a top-level `thread_id`, for primary retrieval
+  scoping.
+- Clarified schedule due-inspection examples for explicit `thread_id` filters
+  and subject tuple filters while preserving the existing MCP `system.tool_usage`
+  compact response shape.
+
 ## [1.4.0] - 2026-04-25
 
 ### Added

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.0", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.1", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/releases/v1.4.1.md
+++ b/docs/releases/v1.4.1.md
@@ -1,0 +1,35 @@
+# CogniRelay v1.4.1 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.1 is a focused patch release for the agent onboarding and
+runtime help surfaces introduced in v1.4.0.
+
+## Highlights
+
+- Clarified the thread-scoped `context.retrieve` example so agents use
+  `subject_kind="thread"` plus `subject_id` for primary retrieval scoping.
+- Clarified that top-level `thread_id` is valid for task and schedule lookup
+  examples, but not for primary `context.retrieve` scoping.
+- Added explicit due schedule inspection examples for both `thread_id` filters
+  and `subject_kind=thread` plus `subject_id` filters.
+- Kept MCP `system.tool_usage` on its existing compact response shape while
+  improving the summary guidance.
+
+## Compatibility Notes
+
+- No runtime API behavior changed.
+- No MCP protocol shape changed.
+- No schedule, graph, continuity, UI, or route semantics changed.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary
- bump runtime app version to 1.4.1
- add CHANGELOG entry for v1.4.1
- add release notes at docs/releases/v1.4.1.md

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app tests tools
- ./.venv/bin/python -m unittest tests/test_help_214_slice1.py tests/test_help_243_runtime_onboarding_limits.py tests/test_mcp_216_slice3_help.py tests/test_mcp_243_runtime_onboarding_limits.py -v
- ./.venv/bin/python -m unittest discover -s tests -v

## Notes
- Patch release for #264 onboarding/runtime help selector clarification.
- GET /v1/capabilities version remains the capability schema version ("1").
- No runtime API behavior or MCP protocol shape changes.