### PR TITLE
Add documentation index for GitHub Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,28 +17,23 @@ coordination surfaces without access to the owner's continuity capsules.
 For the full product introduction, installation notes, and feature summary, see
 the [README](../README.md).
 
-## Start Here
+## Documentation
 
-- [Agent Onboarding](agent-onboarding.md): practical integration guide for
-  cold-start and already-running agents.
 - [System Overview](system-overview.md): implemented product shape, runtime
   model, and agent usage guidance.
-- [Payload Reference](payload-reference.md): continuity capsule structure,
-  request/response schemas, and field constraints.
+- [Agent Onboarding](agent-onboarding.md): practical integration guide for
+  cold-start and already-running agents.
 - [API Surface](api-surface.md): currently implemented HTTP behavior grouped by
   domain.
 - [MCP Guide](mcp.md): MCP bootstrap flow, request methods, and tool mapping.
-
-## Additional References
-
+- [Payload Reference](payload-reference.md): continuity capsule structure,
+  request/response schemas, and field constraints.
 - [CogniRelay Client](cognirelay-client.md): stdlib-only command-line tool for
   continuity read, upsert, and token hashing.
 - [Reviewer Guide](reviewer-guide.md): system thesis, boundaries, recovery
   model, and authority limits.
 - [External References and Case Studies](external-references.md): external
   experiments, usage notes, and scoped collaboration/evaluation references.
-- [MCP Convergence Audit](mcp-216-convergence-audit.md): historical MCP
-  convergence audit for issue #216.
 
 ## Releases
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# CogniRelay Documentation
+
+CogniRelay is a self-hosted continuity and collaboration substrate for
+autonomous agents with bounded, recoverable memory. It uses a local git
+repository as durable state, exposes a machine-first FastAPI interface, stores
+content as Markdown and JSON/JSONL, and keeps dependencies minimal.
+
+CogniRelay is not a Git forge or a full orchestration framework. It is
+infrastructure for memory, retrieval, messaging, coordination, and continuity
+preservation across context-window resets. It is agent-agnostic: any runtime
+that can call the HTTP or MCP surfaces can use it.
+
+The default deployment model is one owner-agent per CogniRelay instance.
+Collaborating peers can receive narrower API tokens and interact through
+coordination surfaces without access to the owner's continuity capsules.
+
+For the full product introduction, installation notes, and feature summary, see
+the [README](../README.md).
+
+## Start Here
+
+- [Agent Onboarding](agent-onboarding.md): practical integration guide for
+  cold-start and already-running agents.
+- [System Overview](system-overview.md): implemented product shape, runtime
+  model, and agent usage guidance.
+- [Payload Reference](payload-reference.md): continuity capsule structure,
+  request/response schemas, and field constraints.
+- [API Surface](api-surface.md): currently implemented HTTP behavior grouped by
+  domain.
+- [MCP Guide](mcp.md): MCP bootstrap flow, request methods, and tool mapping.
+
+## Additional References
+
+- [CogniRelay Client](cognirelay-client.md): stdlib-only command-line tool for
+  continuity read, upsert, and token hashing.
+- [Reviewer Guide](reviewer-guide.md): system thesis, boundaries, recovery
+  model, and authority limits.
+- [External References and Case Studies](external-references.md): external
+  experiments, usage notes, and scoped collaboration/evaluation references.
+- [MCP Convergence Audit](mcp-216-convergence-audit.md): historical MCP
+  convergence audit for issue #216.
+
+## Releases
+
+- [Latest release notes: v1.4.1](releases/v1.4.1.md)
+- [v1.4.0 release notes](releases/v1.4.0.md)
+- [Changelog](../CHANGELOG.md)
+- [GitHub releases](https://github.com/stef-k/CogniRelay/releases)


### PR DESCRIPTION
## Summary
- add docs/index.md as a lightweight GitHub Pages entry point
- include a short README-derived product introduction
- link to canonical docs, latest release notes, changelog, and GitHub releases

## Verification
- git diff --check
- local link existence check for relative docs/index.md links

## Notes
- No runtime, API, release, or test behavior changes.