### PR TITLE
Add Primer dark GitHub Pages theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-primer
+title: CogniRelay
+description: Self-hosted continuity and collaboration substrate for autonomous agents.

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,70 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+body {
+  background: #0d1117;
+  color: #c9d1d9;
+}
+
+.markdown-body {
+  background: #0d1117;
+  color: #c9d1d9;
+}
+
+.markdown-body a {
+  color: #58a6ff;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  color: #f0f6fc;
+  border-bottom-color: #30363d;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  background: #161b22;
+  color: #e6edf3;
+}
+
+.markdown-body pre {
+  background: #161b22;
+  border: 1px solid #30363d;
+}
+
+.markdown-body pre code {
+  background: transparent;
+}
+
+.markdown-body table tr {
+  background: #0d1117;
+  border-top-color: #30363d;
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background: #161b22;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  border-color: #30363d;
+}
+
+.markdown-body blockquote {
+  color: #8b949e;
+  border-left-color: #30363d;
+}
+
+.markdown-body hr {
+  background-color: #30363d;
+}
+
+.markdown-body img {
+  background-color: transparent;
+}


### PR DESCRIPTION
## Summary
- add docs/_config.yml using jekyll-theme-primer
- add minimal dark CSS overrides for GitHub Pages Markdown rendering

## Verification
- git diff --check

## Notes
- Docs-only GitHub Pages presentation change. No runtime/API behavior changes.