### PR TITLE
Fix GitHub Pages dark code block styling

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -33,13 +33,27 @@ body {
   color: #e6edf3;
 }
 
+.markdown-body .highlighter-rouge,
+.markdown-body .highlight {
+  background: #161b22;
+  color: #e6edf3;
+}
+
 .markdown-body pre {
   background: #161b22;
+  color: #e6edf3;
   border: 1px solid #30363d;
+}
+
+.markdown-body pre.highlight,
+.markdown-body .highlight pre {
+  background: #161b22;
+  color: #e6edf3;
 }
 
 .markdown-body pre code {
   background: transparent;
+  color: inherit;
 }
 
 .markdown-body table tr {


### PR DESCRIPTION
## Summary
- Add explicit dark-theme overrides for Rouge/Jekyll fenced code block wrappers
- Ensure generated highlighter wrappers, pre.highlight, and nested code inherit dark background/text colors

## Verification
- git diff --check