### PR TITLE
Fix UI docs source root

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -73,6 +73,7 @@ class Settings:
     git_author_email: str
     tokens: Dict[str, PeerToken]
     audit_log_enabled: bool
+    docs_source_root: Path = Path(__file__).resolve().parents[1]
     require_signed_ingress: bool = False
     ui_enabled: bool = False
     ui_require_localhost: bool = True
@@ -193,6 +194,11 @@ def _env_first(*names: str, default: str | None = None) -> str | None:
         if value is not None:
             return value
     return default
+
+
+def _default_docs_source_root() -> Path:
+    """Return the application checkout root that contains shipped UI docs."""
+    return Path(__file__).resolve().parents[1]
 
 
 def sha256_token(token: str) -> str:
@@ -425,6 +431,13 @@ def get_settings(force_reload: bool = False) -> Settings:
             repo_root,
         )
 
+    docs_source_root_raw = _env_first("COGNIRELAY_DOCS_SOURCE_ROOT")
+    docs_source_root = (
+        Path(docs_source_root_raw).expanduser().resolve()
+        if docs_source_root_raw
+        else _default_docs_source_root()
+    )
+
     key_store_raw = _env_first(
         "COGNIRELAY_KEY_STORE_PATH",
         "AMR_KEY_STORE_PATH",
@@ -438,6 +451,7 @@ def get_settings(force_reload: bool = False) -> Settings:
         git_author_email=_env_first("COGNIRELAY_GIT_AUTHOR_EMAIL", "AMR_GIT_AUTHOR_EMAIL", default="bot@example.local") or "bot@example.local",
         tokens=_merge_tokens(repo_root),
         audit_log_enabled=_parse_bool(_env_first("COGNIRELAY_AUDIT_LOG_ENABLED", "AMR_AUDIT_LOG_ENABLED"), True),
+        docs_source_root=docs_source_root,
         require_signed_ingress=_parse_bool(_env_first("COGNIRELAY_REQUIRE_SIGNED_INGRESS", "AMR_REQUIRE_SIGNED_INGRESS"), False),
         ui_enabled=_parse_bool(_env_first("COGNIRELAY_UI_ENABLED"), False),
         ui_require_localhost=_parse_bool(_env_first("COGNIRELAY_UI_REQUIRE_LOCALHOST"), True),

--- a/app/ui/router.py
+++ b/app/ui/router.py
@@ -425,7 +425,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         """Render the fixed read-only documentation index."""
         settings = get_settings()
         _enforce_ui_access(request, settings)
-        return _docs_index_page(settings.repo_root)
+        return _docs_index_page(settings.docs_source_root)
 
     @router.get("/docs/{doc_id}", response_class=HTMLResponse)
     def ui_doc_detail(request: Request, doc_id: str) -> HTMLResponse:
@@ -435,7 +435,7 @@ def build_ui_router(*, app_version: str) -> APIRouter:
         doc = UI_DOCS_BY_ID.get(doc_id)
         if doc is None:
             return _docs_not_found_page()
-        return _docs_detail_page(settings.repo_root, doc)
+        return _docs_detail_page(settings.docs_source_root, doc)
 
     @router.get("/events")
     async def ui_events(

--- a/tests/test_ui_docs.py
+++ b/tests/test_ui_docs.py
@@ -64,18 +64,18 @@ def _ui_response(
     *,
     route_path: str,
     request_path: str,
+    docs_source_root: Path | None = None,
     endpoint_kwargs: dict[str, Any] | None = None,
 ) -> SimpleNamespace:
     """Render one UI docs route directly for deterministic assertions."""
-    with patch.dict(
-        os.environ,
-        {
-            "COGNIRELAY_REPO_ROOT": str(repo_root),
-            "COGNIRELAY_AUTO_INIT_GIT": "true",
-            "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
-        },
-        clear=False,
-    ):
+    env = {
+        "COGNIRELAY_REPO_ROOT": str(repo_root),
+        "COGNIRELAY_AUTO_INIT_GIT": "true",
+        "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
+    }
+    if docs_source_root is not None:
+        env["COGNIRELAY_DOCS_SOURCE_ROOT"] = str(docs_source_root)
+    with patch.dict(os.environ, env, clear=False):
         ui_router = _reload_ui_router()
         router = ui_router.build_ui_router(app_version="test-version")
         endpoint = next(route.endpoint for route in router.routes if route.path == route_path)
@@ -93,12 +93,45 @@ def _write_allowlisted_docs(repo_root: Path, *, readme: str | None = None) -> No
 
 
 class UiDocsTests(unittest.TestCase):
+    def test_docs_use_default_app_source_root_when_data_repo_is_separate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            env = {
+                "COGNIRELAY_REPO_ROOT": str(repo_root),
+                "COGNIRELAY_AUTO_INIT_GIT": "true",
+                "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
+            }
+            with patch.dict(os.environ, env, clear=False):
+                os.environ.pop("COGNIRELAY_DOCS_SOURCE_ROOT", None)
+                ui_router = _reload_ui_router()
+                router = ui_router.build_ui_router(app_version="test-version")
+                index_endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/docs")
+                detail_endpoint = next(route.endpoint for route in router.routes if route.path == "/ui/docs/{doc_id}")
+
+                index = index_endpoint(_request("/ui/docs"))
+                detail = detail_endpoint(_request("/ui/docs/readme"), doc_id="readme")
+
+        index_text = index.body.decode("utf-8")
+        detail_text = detail.body.decode("utf-8")
+        self.assertEqual(index.status_code, 200)
+        self.assertEqual(detail.status_code, 200)
+        self.assertNotIn("doc_missing:readme", index_text)
+        self.assertIn('href="/ui/docs/readme"', index_text)
+        self.assertIn('<h1 id="cognirelay">CogniRelay</h1>', detail_text)
+        self.assertIn("Self-hosted continuity", detail_text)
+
     def test_docs_index_renders_allowlist_in_exact_order_and_runtime_help(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            _write_allowlisted_docs(repo_root)
+            docs_source_root = repo_root / "app"
+            _write_allowlisted_docs(docs_source_root)
 
-            response = _ui_response(repo_root, route_path="/ui/docs", request_path="/ui/docs")
+            response = _ui_response(
+                repo_root,
+                route_path="/ui/docs",
+                request_path="/ui/docs",
+                docs_source_root=docs_source_root,
+            )
 
         self.assertEqual(response.status_code, 200)
         positions = [response.text.index(f"/ui/docs/{doc.doc_id}") for doc in UI_DOCS]
@@ -111,7 +144,8 @@ class UiDocsTests(unittest.TestCase):
     def test_each_allowlisted_doc_id_renders(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            _write_allowlisted_docs(repo_root)
+            docs_source_root = repo_root / "app"
+            _write_allowlisted_docs(docs_source_root)
 
             for doc in UI_DOCS:
                 with self.subTest(doc_id=doc.doc_id):
@@ -119,6 +153,7 @@ class UiDocsTests(unittest.TestCase):
                         repo_root,
                         route_path="/ui/docs/{doc_id}",
                         request_path=f"/ui/docs/{doc.doc_id}",
+                        docs_source_root=docs_source_root,
                         endpoint_kwargs={"doc_id": doc.doc_id},
                     )
                     self.assertEqual(response.status_code, 200)
@@ -129,17 +164,20 @@ class UiDocsTests(unittest.TestCase):
     def test_unknown_and_path_like_doc_ids_do_not_render_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            _write_allowlisted_docs(repo_root)
+            docs_source_root = repo_root / "app"
+            _write_allowlisted_docs(docs_source_root)
             unknown = _ui_response(
                 repo_root,
                 route_path="/ui/docs/{doc_id}",
                 request_path="/ui/docs/not-allowed",
+                docs_source_root=docs_source_root,
                 endpoint_kwargs={"doc_id": "not-allowed"},
             )
             traversal = _ui_response(
                 repo_root,
                 route_path="/ui/docs/{doc_id}",
                 request_path="/ui/docs/..%2FREADME.md",
+                docs_source_root=docs_source_root,
                 endpoint_kwargs={"doc_id": "../README.md"},
             )
 
@@ -147,6 +185,7 @@ class UiDocsTests(unittest.TestCase):
                 os.environ,
                 {
                     "COGNIRELAY_REPO_ROOT": str(repo_root),
+                    "COGNIRELAY_DOCS_SOURCE_ROOT": str(docs_source_root),
                     "COGNIRELAY_AUTO_INIT_GIT": "true",
                     "COGNIRELAY_AUDIT_LOG_ENABLED": "false",
                     "COGNIRELAY_UI_ENABLED": "true",
@@ -166,14 +205,21 @@ class UiDocsTests(unittest.TestCase):
     def test_missing_allowlisted_file_degrades_on_index_and_detail(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            _write_allowlisted_docs(repo_root)
-            (repo_root / "docs" / "mcp.md").unlink()
+            docs_source_root = repo_root / "app"
+            _write_allowlisted_docs(docs_source_root)
+            (docs_source_root / "docs" / "mcp.md").unlink()
 
-            index = _ui_response(repo_root, route_path="/ui/docs", request_path="/ui/docs")
+            index = _ui_response(
+                repo_root,
+                route_path="/ui/docs",
+                request_path="/ui/docs",
+                docs_source_root=docs_source_root,
+            )
             detail = _ui_response(
                 repo_root,
                 route_path="/ui/docs/{doc_id}",
                 request_path="/ui/docs/mcp",
+                docs_source_root=docs_source_root,
                 endpoint_kwargs={"doc_id": "mcp"},
             )
 
@@ -220,11 +266,13 @@ class UiDocsTests(unittest.TestCase):
 """
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            _write_allowlisted_docs(repo_root, readme=markdown_source)
+            docs_source_root = repo_root / "app"
+            _write_allowlisted_docs(docs_source_root, readme=markdown_source)
             response = _ui_response(
                 repo_root,
                 route_path="/ui/docs/{doc_id}",
                 request_path="/ui/docs/readme",
+                docs_source_root=docs_source_root,
                 endpoint_kwargs={"doc_id": "readme"},
             )
 
@@ -264,11 +312,13 @@ class UiDocsTests(unittest.TestCase):
 """
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
-            _write_allowlisted_docs(repo_root, readme=markdown_source)
+            docs_source_root = repo_root / "app"
+            _write_allowlisted_docs(docs_source_root, readme=markdown_source)
             response = _ui_response(
                 repo_root,
                 route_path="/ui/docs/{doc_id}",
                 request_path="/ui/docs/readme",
+                docs_source_root=docs_source_root,
                 endpoint_kwargs={"doc_id": "readme"},
             )
 


### PR DESCRIPTION
## Summary
- Read shipped `/ui/docs` content from the application docs/source root instead of the continuity data repo.
- Keep non-docs UI views on `settings.repo_root`.
- Add regression coverage for separated data repo and docs source roots.

Closes #271

## Verification
- `git diff --check`
- `./.venv/bin/python -m unittest tests/test_ui_docs.py -v`
- `./.venv/bin/python -m unittest tests/test_ui_issue_199_slice1.py tests/test_ui_issue_260_schedule.py -v`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v`
