### PR TITLE
Prepare v1.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-04-26
+
+### Fixed
+
+- Redacted raw `context.retrieve` task text from durable `context_retrieve`
+  audit events. Audit rows now keep deterministic `task_hash` and
+  `task_length_bytes` metadata while preserving `count` and
+  `continuity_selectors`.
+- Fixed the `/ui/docs` browser so it reads shipped application documentation
+  from the application source/docs root instead of the configured data repo
+  root.
+
 ## [1.4.1] - 2026-04-26
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.1", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.2", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ the [README](../README.md).
 
 ## Releases
 
-- [Latest release notes: v1.4.1](releases/v1.4.1.md)
+- [Latest release notes: v1.4.2](releases/v1.4.2.md)
+- [v1.4.1 release notes](releases/v1.4.1.md)
 - [v1.4.0 release notes](releases/v1.4.0.md)
 - [Changelog](../CHANGELOG.md)
 - [GitHub releases](https://github.com/stef-k/CogniRelay/releases)

--- a/docs/releases/v1.4.2.md
+++ b/docs/releases/v1.4.2.md
@@ -1,0 +1,38 @@
+# CogniRelay v1.4.2 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.2 is a focused patch release for two post-v1.4.1 fixes:
+durable audit redaction for context retrieval and shipped-doc rendering in the
+operator UI documentation browser.
+
+## Highlights
+
+- `context.retrieve` audit events no longer persist raw task text or task-text
+  prefixes in durable `logs/api_audit.jsonl` rows.
+- Context retrieval audit rows now record deterministic `task_hash` and
+  `task_length_bytes` metadata while preserving result counts and loaded
+  continuity selectors.
+- `/ui/docs` now reads the allowlisted documentation shipped with the running
+  application checkout instead of looking for those files in the configured
+  data repository.
+
+## Compatibility Notes
+
+- No `POST /v1/context/retrieve` request or response shape changed.
+- Retrieval ranking, continuity behavior, graph context, schedule context, MCP
+  protocol behavior, and operator UI routes are unchanged.
+- The audit detail shape for `context_retrieve` changed intentionally:
+  `detail.task` was removed and replaced by safe hash/length metadata.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary
- Bump runtime version to `1.4.2`.
- Add `v1.4.2` changelog entry and release notes.
- Update docs index to point to the latest `v1.4.2` release notes.

## Release Notes
This patch release covers the two post-v1.4.1 fixes already merged to main:
- #270 redacts raw `context.retrieve` task text from durable audit logs.
- #271 fixes `/ui/docs` source-root resolution so shipped docs render outside the data repo.

## Verification
- `git diff --check`
- `./.venv/bin/python - <<'PY' ... assert app.version == "1.4.2"`
- `./.venv/bin/python -m ruff check app tests tools`
- `./.venv/bin/python -m unittest discover -s tests -v` ran 2189 tests, OK
