### PR TITLE
Fix GitHub Pages changelog link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,5 +40,5 @@ the [README](../README.md).
 - [Latest release notes: v1.4.2](releases/v1.4.2.md)
 - [v1.4.1 release notes](releases/v1.4.1.md)
 - [v1.4.0 release notes](releases/v1.4.0.md)
-- [Changelog](../CHANGELOG.md)
+- [Changelog](https://github.com/stef-k/CogniRelay/blob/main/CHANGELOG.md)
 - [GitHub releases](https://github.com/stef-k/CogniRelay/releases)


### PR DESCRIPTION
## Summary
- Replace the Pages-relative changelog link with the GitHub-rendered root CHANGELOG.md link.
- Avoid a 404 when Pages is published from the /docs root.

## Verification
- git diff --check