### PR TITLE
Release v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-04-26
+
+### Fixed
+
+- Restored MCP startup compatibility for Codex clients that initialize with
+  protocol version `2025-06-18` while preserving support for the preferred
+  `2025-11-25` MCP protocol version.
+- Updated MCP descriptors and documentation to advertise both supported
+  initialize protocol versions and keep `2025-11-25` as the preferred/latest
+  version.
+
 ## [1.4.2] - 2026-04-26
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.2", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.3", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ the [README](../README.md).
 
 ## Releases
 
-- [Latest release notes: v1.4.2](releases/v1.4.2.md)
+- [Latest release notes: v1.4.3](releases/v1.4.3.md)
+- [v1.4.2 release notes](releases/v1.4.2.md)
 - [v1.4.1 release notes](releases/v1.4.1.md)
 - [v1.4.0 release notes](releases/v1.4.0.md)
 - [Changelog](https://github.com/stef-k/CogniRelay/blob/main/CHANGELOG.md)

--- a/docs/releases/v1.4.3.md
+++ b/docs/releases/v1.4.3.md
@@ -1,0 +1,38 @@
+# CogniRelay v1.4.3 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.3 is a focused patch release for MCP startup compatibility
+with currently deployed Codex clients.
+
+## Highlights
+
+- MCP `initialize` now accepts both protocol versions `2025-06-18` and
+  `2025-11-25`.
+- Successful MCP initialization echoes the accepted client-requested protocol
+  version, so older compatible clients can complete startup.
+- Unknown protocol versions still fail deterministically with
+  `Unsupported protocol version` and a supported-version list.
+- `/.well-known/mcp.json`, discovery metadata, and MCP docs now advertise both
+  supported initialize protocol versions while keeping `2025-11-25` as the
+  preferred/latest version.
+
+## Compatibility Notes
+
+- No MCP tool, JSON-RPC method, HTTP route, schedule, graph, continuity, or UI
+  response shape changed outside MCP initialize protocol negotiation metadata.
+- The bounded MCP posture remains intact: `initialize`,
+  `notifications/initialized`, `ping`, `tools/list`, `tools/call`, and the
+  existing post-bootstrap help/reference request methods are unchanged.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary

- bump runtime version to 1.4.3
- add v1.4.3 changelog and release notes for #277 MCP protocol compatibility
- update docs index latest-release link to v1.4.3

## Verification

- git diff --check
- ./.venv/bin/python -m ruff check app tests tools
- ./.venv/bin/python -m unittest tests.test_discovery tests.test_mcp_rpc -v
- ./.venv/bin/python -m unittest discover -s tests -v (2191 tests)
