### PR TITLE
Release v1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-04-26
+
 ### Fixed
 
 - Fixed Codex MCP startup compatibility when clients call `tools/list`

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.3", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.4", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ the [README](../README.md).
 
 ## Releases
 
-- [Latest release notes: v1.4.3](releases/v1.4.3.md)
+- [Latest release notes: v1.4.4](releases/v1.4.4.md)
+- [v1.4.3 release notes](releases/v1.4.3.md)
 - [v1.4.2 release notes](releases/v1.4.2.md)
 - [v1.4.1 release notes](releases/v1.4.1.md)
 - [v1.4.0 release notes](releases/v1.4.0.md)

--- a/docs/releases/v1.4.4.md
+++ b/docs/releases/v1.4.4.md
@@ -1,0 +1,38 @@
+# CogniRelay v1.4.4 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.4 is a focused patch release for Codex MCP startup
+compatibility after the v1.4.3 protocol-version bridge.
+
+## Highlights
+
+- MCP sessions are now ready for request methods immediately after a successful
+  `initialize`.
+- Codex clients that call `tools/list` right after `initialize`, without first
+  sending `notifications/initialized`, can complete startup.
+- `notifications/initialized` remains accepted after `initialize`, so clients
+  that send the notification keep working.
+
+## Compatibility Notes
+
+- MCP protocol-version compatibility from v1.4.3 is preserved:
+  `initialize` accepts `2025-06-18` and `2025-11-25`.
+- Unsupported or malformed `initialize` requests still do not mark a session
+  ready.
+- Request methods before any successful `initialize` still fail with the
+  existing not-initialized behavior.
+- No MCP tool schema, HTTP route, schedule, graph, continuity, or UI response
+  shape changed.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary

- bump runtime version to 1.4.4
- move the #280 MCP startup-ready fix from Unreleased into the v1.4.4 changelog section
- add v1.4.4 release notes and update the docs index latest-release link

## Verification

- git diff --check
- ./.venv/bin/python -m ruff check app tests tools
- ./.venv/bin/python -m unittest tests.test_mcp_216_slice2_runtime tests.test_mcp_rpc -v
- ./.venv/bin/python -m unittest discover -s tests -v (2191 tests)
