### PR TITLE
Release v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.5] - 2026-04-26
+
+### Fixed
+
+- Fixed standards-compatible MCP startup for clients that include optional
+  `clientInfo` implementation metadata such as `title`, `description`,
+  `websiteUrl`, or `icons` in `initialize`. CogniRelay now accepts those
+  standard metadata fields for both supported protocol versions while
+  preserving strict validation for unsupported initialize parameters.
+- Updated MCP documentation, API surface notes, convergence audit text, runtime
+  MCP error help, and regression coverage so the fix is agent-agnostic rather
+  than Codex-specific.
+
 ## [1.4.4] - 2026-04-26
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.4", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.5", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ the [README](../README.md).
 
 ## Releases
 
-- [Latest release notes: v1.4.4](releases/v1.4.4.md)
+- [Latest release notes: v1.4.5](releases/v1.4.5.md)
+- [v1.4.4 release notes](releases/v1.4.4.md)
 - [v1.4.3 release notes](releases/v1.4.3.md)
 - [v1.4.2 release notes](releases/v1.4.2.md)
 - [v1.4.1 release notes](releases/v1.4.1.md)

--- a/docs/releases/v1.4.5.md
+++ b/docs/releases/v1.4.5.md
@@ -1,0 +1,38 @@
+# CogniRelay v1.4.5 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.5 is a focused MCP startup compatibility patch. It fixes
+standards-compatible clients whose `initialize` request includes optional
+`clientInfo` implementation metadata.
+
+## Highlights
+
+- `initialize` now accepts standard MCP implementation metadata fields under
+  `clientInfo`: `title`, `description`, `websiteUrl`, and `icons`.
+- The exact observed Codex startup payload with `clientInfo.title` now succeeds.
+- The compatibility fix is not Codex-specific; it applies to the supported MCP
+  protocol versions `2025-06-18` and `2025-11-25`.
+- Immediate `tools/list` after successful `initialize` remains supported.
+
+## Compatibility Notes
+
+- Top-level `initialize.params` remains strict: `protocolVersion`,
+  `capabilities`, and `clientInfo`.
+- `clientInfo.name` remains required when `clientInfo` is present.
+- Unknown `clientInfo` fields still fail deterministically with
+  `-32602 Invalid params`.
+- No MCP tool schema, HTTP route, schedule, graph, continuity, or UI response
+  shape changed.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary
- Bump runtime app version to 1.4.5.
- Add v1.4.5 changelog entry for standards-compatible MCP clientInfo implementation metadata.
- Add v1.4.5 release notes and update docs index latest release link.

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app tests tools
- ./.venv/bin/python - <<'PY' ... app.version == 1.4.5 ... PY
- ./.venv/bin/python -m unittest discover -s tests -v (2193 tests OK)
