### PR TITLE
Release v1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.6] - 2026-04-26
+
+### Fixed
+
+- Fixed standards-compatible MCP request metadata handling. CogniRelay now
+  accepts and ignores object-valued `params._meta` on `initialize`,
+  `tools/list`, `tools/call`, and runtime MCP help/reference request methods,
+  while preserving strict validation for actual tool `arguments` and domain
+  payloads.
+- Added an end-to-end MCP startup regression covering `clientInfo.title`
+  followed by `tools/list` with `params._meta`, plus runtime-help `_meta`
+  coverage and documentation updates.
+
 ## [1.4.5] - 2026-04-26
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.5", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.6", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ the [README](../README.md).
 
 ## Releases
 
-- [Latest release notes: v1.4.5](releases/v1.4.5.md)
+- [Latest release notes: v1.4.6](releases/v1.4.6.md)
+- [v1.4.5 release notes](releases/v1.4.5.md)
 - [v1.4.4 release notes](releases/v1.4.4.md)
 - [v1.4.3 release notes](releases/v1.4.3.md)
 - [v1.4.2 release notes](releases/v1.4.2.md)

--- a/docs/releases/v1.4.6.md
+++ b/docs/releases/v1.4.6.md
@@ -1,0 +1,40 @@
+# CogniRelay v1.4.6 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.6 is a focused MCP startup compatibility patch for standard
+request metadata. It fixes clients that send MCP-reserved `params._meta` during
+startup or request-method calls.
+
+## Highlights
+
+- `tools/list` now accepts object-valued `params._meta` and returns the tool
+  catalog instead of failing with `unexpected tools/list param`.
+- `initialize`, `tools/list`, `tools/call`, and runtime MCP help/reference
+  request methods now accept and ignore object-valued `params._meta`.
+- Actual tool `arguments` remain strict application payloads. `_meta` inside
+  tool arguments is not treated as request metadata.
+- The regression suite now replays the previously failing startup path:
+  `initialize` with `clientInfo.title`, followed by `tools/list` with
+  `params._meta`.
+
+## Compatibility Notes
+
+- Supported MCP protocol versions remain `2025-06-18` and `2025-11-25`.
+- `clientInfo` implementation metadata compatibility from v1.4.5 is preserved.
+- Non-object `params._meta` fails deterministically with `-32602 Invalid params`.
+- Unknown non-metadata request params still fail deterministically.
+- No MCP tool schema, HTTP route, schedule, graph, continuity, or UI response
+  shape changed.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary
- Bump runtime app version to 1.4.6.
- Add v1.4.6 changelog entry for standards-compatible MCP params._meta request metadata.
- Add v1.4.6 release notes and update docs index latest release link.

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app tests tools
- ./.venv/bin/python - <<'PY' ... app.version == 1.4.6 ... PY
- ./.venv/bin/python -m unittest discover -s tests -v (2195 tests OK)
