### PR TITLE
Add last-mile adapter kit for agent-authored continuity

### DIFF
--- a/agent-assets/README.md
+++ b/agent-assets/README.md
@@ -1,0 +1,10 @@
+# CogniRelay Agent Assets
+
+This directory contains copyable integration assets for agent runtimes that use CogniRelay continuity.
+
+- `skills/cognirelay-continuity-authoring/SKILL.md`: agent-facing continuity authoring guidance.
+- `hooks/cognirelay_retrieval_hook.py`: read-only startup and optional context retrieval hook.
+- `hooks/cognirelay_continuity_save_hook.py`: facts, template, dry-run, write, readback, and doctor hook.
+- `hooks/README.md`: hook configuration, invocation, stdout, and exit-code contract.
+
+CogniRelay is the continuity substrate. The running agent authors semantic continuity fields; hooks gather facts, provide scaffolds, validate, write explicit payloads, and read back stored state.

--- a/agent-assets/hooks/README.md
+++ b/agent-assets/hooks/README.md
@@ -1,0 +1,77 @@
+# CogniRelay Hooks
+
+These hooks are copyable Python 3 scripts for generic agent-runtime integration. They use only the Python standard library and emit one JSON object to stdout for normal operation. Human/debug logs belong on stderr.
+
+## Configuration
+
+Required by CLI flag or environment for networked modes:
+
+- `COGNIRELAY_BASE_URL`
+- `COGNIRELAY_TOKEN`
+
+Subject values are required for retrieval and may be used by `facts`, `template`, `readback`, and `doctor`:
+
+- `COGNIRELAY_SUBJECT_KIND`
+- `COGNIRELAY_SUBJECT_ID`
+
+Optional:
+
+- `COGNIRELAY_RETRIEVAL_TASK`
+- `COGNIRELAY_CONTEXT_RETRIEVE`
+- `COGNIRELAY_TIMEOUT_SECONDS`
+
+CLI flags override environment variables. `--no-context-retrieve` wins over all context-retrieve enablement.
+
+## Retrieval
+
+```bash
+python agent-assets/hooks/cognirelay_retrieval_hook.py \
+  --base-url http://127.0.0.1:8000 \
+  --token "$COGNIRELAY_TOKEN" \
+  --subject-kind thread \
+  --subject-id issue-289 \
+  --context-retrieve \
+  --task "Continue issue 289"
+```
+
+The retrieval hook is read-only. It calls `POST /v1/continuity/read` with `view="startup"` and `allow_fallback=true`, then optionally calls `POST /v1/context/retrieve` when enabled and a non-empty task is present.
+
+## Save
+
+```bash
+python agent-assets/hooks/cognirelay_continuity_save_hook.py facts --subject-kind thread --subject-id issue-289
+python agent-assets/hooks/cognirelay_continuity_save_hook.py template --subject-kind thread --subject-id issue-289
+python agent-assets/hooks/cognirelay_continuity_save_hook.py dry-run --input payload.json
+python agent-assets/hooks/cognirelay_continuity_save_hook.py write --input payload.json
+python agent-assets/hooks/cognirelay_continuity_save_hook.py readback --subject-kind thread --subject-id issue-289
+python agent-assets/hooks/cognirelay_continuity_save_hook.py doctor --subject-kind thread --subject-id issue-289
+```
+
+Use `--input -` for stdin payloads in `dry-run` and `write`.
+
+`dry-run` is local-only by default and does not contact CogniRelay. `--server-compare` is intentionally unsupported in this shipped hook until implemented by a future slice.
+
+## Stdout Envelope
+
+Success or degraded success:
+
+```json
+{"ok": true, "mode": "dry-run", "warnings": [], "errors": [], "result": {}}
+```
+
+Failure:
+
+```json
+{"ok": false, "mode": "dry-run", "warnings": [], "errors": [{"code": "validation", "message": "Invalid input."}], "result": {}}
+```
+
+Exit codes:
+
+- `0`: success or degraded success with warnings
+- `2`: usage, config, input validation, placeholder rejection, or unsupported offline mode
+- `3`: transport failure without an HTTP response
+- `4`: HTTP response received outside the expected success range
+
+## Local Glue Boundary
+
+Local glue supplies base URL, token, subject identity, task text, and any runtime-specific file/stdin wiring. The hook never prints the token and never creates schedules, mutates tasks, acknowledges schedules, or infers continuity semantics. The agent authors semantic fields explicitly.

--- a/agent-assets/hooks/cognirelay_continuity_save_hook.py
+++ b/agent-assets/hooks/cognirelay_continuity_save_hook.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""CogniRelay continuity save helper hook."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+HELP_LINKS = {
+    "onboarding": "/v1/help/onboarding",
+    "last_mile_topic": "/v1/help/topics/last-mile-adapter",
+    "continuity_read_tool": "/v1/help/tools/continuity.read",
+    "continuity_upsert_tool": "/v1/help/tools/continuity.upsert",
+    "context_retrieve_tool": "/v1/help/tools/context.retrieve",
+    "limits_index": "/v1/help/limits",
+}
+
+SEMANTIC_PREFIXES = (
+    "/capsule/continuity",
+    "/capsule/stable_preferences",
+    "/capsule/thread_descriptor",
+    "/capsule/source",
+    "/capsule/attention_policy",
+    "/capsule/canonical_sources",
+    "/capsule/metadata",
+    "/session_end_snapshot",
+)
+EXCLUDED_DIFF_PREFIXES = (
+    "/subject_kind",
+    "/subject_id",
+    "/merge_mode",
+    "/capsule/schema_version",
+    "/capsule/subject_kind",
+    "/capsule/subject_id",
+    "/capsule/updated_at",
+    "/capsule/verified_at",
+    "/capsule/confidence",
+)
+PLACEHOLDER_RE = re.compile(r"\b(?:TODO|TBD|PLACEHOLDER|FILL ME|REPLACE ME)\b", re.IGNORECASE)
+BRACKET_PLACEHOLDER_RE = re.compile(r"^(?:<[^<>]+>|\[[^\[\]]+\])$")
+
+
+def envelope(ok: bool, mode: str, result: dict[str, Any] | None = None, errors: list[dict[str, str]] | None = None, warnings: list[Any] | None = None) -> dict[str, Any]:
+    return {"ok": ok, "mode": mode, "warnings": warnings or [], "errors": errors or [], "result": result or {}}
+
+
+def emit(payload: dict[str, Any], code: int) -> int:
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return code
+
+
+def pointer(parts: list[str]) -> str:
+    return "/" + "/".join(part.replace("~", "~0").replace("/", "~1") for part in parts)
+
+
+def under_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
+    return any(path == prefix or path.startswith(f"{prefix}/") for prefix in prefixes)
+
+
+def read_input(path: str) -> Any:
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    return json.loads(raw)
+
+
+def post_json(base_url: str, token: str, path: str, payload: dict[str, Any], timeout: float) -> tuple[int, dict[str, Any]]:
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = response.read().decode("utf-8")
+        return response.status, json.loads(body) if body else {}
+
+
+def current_git_facts() -> dict[str, str]:
+    facts: dict[str, str] = {}
+    for key, cmd in {
+        "branch": ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        "head": ["git", "rev-parse", "HEAD"],
+    }.items():
+        try:
+            completed = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=2)
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if completed.returncode == 0:
+            facts[key] = completed.stdout.strip()
+    return facts
+
+
+def template_payload(subject_kind: str, subject_id: str) -> dict[str, Any]:
+    subject_kind = subject_kind or "thread"
+    subject_id = subject_id or "<agent-authored-subject-id>"
+    timestamp = "<UTC-timestamp-filled-by-agent-or-local-glue>"
+    return {
+        "subject_kind": subject_kind,
+        "subject_id": subject_id,
+        "merge_mode": "preserve",
+        "capsule": {
+            "schema_version": "1.1",
+            "subject_kind": subject_kind,
+            "subject_id": subject_id,
+            "updated_at": timestamp,
+            "verified_at": timestamp,
+            "continuity": {
+                "top_priorities": ["<agent-authored-priority>"],
+                "active_concerns": [],
+                "active_constraints": ["<agent-authored-constraint>"],
+                "open_loops": ["<agent-authored-open-loop>"],
+                "drift_signals": [],
+                "stance_summary": "<agent-authored-stance-summary>",
+                "negative_decisions": [],
+                "rationale_entries": [],
+                "retrieval_hints": {"must_include": [], "load_next": [], "avoid": []},
+            },
+            "source": {"producer": "<agent-authored-or-adapter-identifier>", "update_reason": "manual", "inputs": []},
+            "confidence": {"continuity": 0.8, "relationship_model": 0.5},
+        },
+    }
+
+
+def validate_payload_shape(payload: Any) -> list[dict[str, str]]:
+    errors: list[dict[str, str]] = []
+    if not isinstance(payload, dict):
+        return [{"code": "invalid_input", "message": "Input must be a JSON object."}]
+    for field in ("subject_kind", "subject_id", "capsule"):
+        if field not in payload:
+            errors.append({"code": "invalid_input", "message": f"Missing required field {field}.", "field": field})
+    if "capsule" in payload and not isinstance(payload["capsule"], dict):
+        errors.append({"code": "invalid_input", "message": "capsule must be an object.", "field": "capsule"})
+    return errors
+
+
+def placeholder_errors(value: Any, parts: list[str] | None = None) -> list[dict[str, str]]:
+    parts = parts or []
+    path = pointer(parts) if parts else ""
+    errors: list[dict[str, str]] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            errors.extend(placeholder_errors(child, [*parts, str(key)]))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            errors.extend(placeholder_errors(child, [*parts, str(index)]))
+    elif isinstance(value, str) and under_prefix(path, SEMANTIC_PREFIXES):
+        stripped = value.strip()
+        if not stripped:
+            errors.append({"code": "placeholder_rejected", "message": "Empty semantic string is not allowed.", "field": path})
+        elif PLACEHOLDER_RE.search(stripped) or BRACKET_PLACEHOLDER_RE.match(stripped):
+            errors.append({"code": "placeholder_rejected", "message": "Unresolved placeholder or TODO marker is not allowed.", "field": path})
+    return errors
+
+
+def write_semantic_requirements(payload: dict[str, Any]) -> list[dict[str, str]]:
+    continuity = payload.get("capsule", {}).get("continuity", {})
+    if not isinstance(continuity, dict):
+        return [{"code": "invalid_input", "message": "capsule.continuity must be an object.", "field": "capsule.continuity"}]
+    errors: list[dict[str, str]] = []
+    stance = continuity.get("stance_summary")
+    if not isinstance(stance, str) or not stance.strip():
+        errors.append({"code": "invalid_input", "message": "stance_summary must be non-empty.", "field": "capsule.continuity.stance_summary"})
+    hints = continuity.get("retrieval_hints", {})
+    carriers = [
+        continuity.get("top_priorities"),
+        continuity.get("open_loops"),
+        continuity.get("active_constraints"),
+        continuity.get("negative_decisions"),
+        continuity.get("rationale_entries"),
+        hints.get("must_include") if isinstance(hints, dict) else None,
+        hints.get("load_next") if isinstance(hints, dict) else None,
+    ]
+    if not any(non_empty_carrier(carrier) for carrier in carriers):
+        errors.append({"code": "invalid_input", "message": "At least one semantic update carrier must be non-empty.", "field": "capsule.continuity"})
+    return errors
+
+
+def non_empty_carrier(value: Any) -> bool:
+    if isinstance(value, list):
+        return any(bool(item.strip()) if isinstance(item, str) else item not in (None, {}, []) for item in value)
+    return bool(value)
+
+
+def flatten(value: Any, parts: list[str] | None = None) -> list[tuple[str, Any]]:
+    parts = parts or []
+    path = pointer(parts) if parts else ""
+    if isinstance(value, dict):
+        items: list[tuple[str, Any]] = []
+        for key in sorted(value):
+            items.extend(flatten(value[key], [*parts, str(key)]))
+        return items
+    if isinstance(value, list):
+        items = []
+        for index, child in enumerate(value):
+            items.extend(flatten(child, [*parts, str(index)]))
+        return items
+    return [(path, value)]
+
+
+def semantic_diff(payload: dict[str, Any]) -> dict[str, Any]:
+    added = []
+    for path, value in flatten(payload):
+        if under_prefix(path, SEMANTIC_PREFIXES) and not under_prefix(path, EXCLUDED_DIFF_PREFIXES):
+            if value not in ("", [], {}, None):
+                added.append({"path": path, "after": value})
+    added.sort(key=lambda item: item["path"])
+    return {"current_available": False, "added": added, "removed": [], "changed": []}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate, write, and read back CogniRelay continuity payloads.")
+    parser.add_argument("mode", choices=["facts", "template", "dry-run", "write", "readback", "doctor"])
+    parser.add_argument("--base-url")
+    parser.add_argument("--token")
+    parser.add_argument("--subject-kind", choices=["thread", "task", "user", "peer"])
+    parser.add_argument("--subject-id")
+    parser.add_argument("--input")
+    parser.add_argument("--timeout", type=float)
+    parser.add_argument("--server-compare", action="store_true")
+    return parser
+
+
+def network_config(args: argparse.Namespace) -> tuple[str, str, float]:
+    base_url = (args.base_url or os.getenv("COGNIRELAY_BASE_URL") or "").rstrip("/")
+    token = args.token or os.getenv("COGNIRELAY_TOKEN") or ""
+    timeout = args.timeout if args.timeout is not None else float(os.getenv("COGNIRELAY_TIMEOUT_SECONDS", "10"))
+    return base_url, token, timeout
+
+
+def readback(mode: str, args: argparse.Namespace) -> int:
+    base_url, token, timeout = network_config(args)
+    subject_kind = args.subject_kind or os.getenv("COGNIRELAY_SUBJECT_KIND") or ""
+    subject_id = args.subject_id or os.getenv("COGNIRELAY_SUBJECT_ID") or ""
+    if not base_url or not token:
+        return emit(envelope(False, mode, errors=[{"code": "missing_config", "message": "Missing CogniRelay base URL or token."}]), 2)
+    if not subject_kind or not subject_id:
+        return emit(envelope(False, mode, errors=[{"code": "missing_subject", "message": "Missing subject kind or subject id.", "field": "subject"}]), 2)
+    try:
+        status, response = post_json(base_url, token, "/v1/continuity/read", {"subject_kind": subject_kind, "subject_id": subject_id, "view": "startup", "allow_fallback": True}, timeout)
+        if status < 200 or status >= 300:
+            return emit(envelope(False, mode, result={"status": status}, errors=[{"code": "http_error", "message": "Continuity read returned an unsuccessful status."}]), 4)
+        return emit(envelope(True, mode, result={"readback": response, "trust_signals": response.get("trust_signals", {}), "recovery_warnings": response.get("recovery_warnings", [])}), 0)
+    except urllib.error.HTTPError as exc:
+        return emit(envelope(False, mode, result={"status": exc.code}, errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status."}]), 4)
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+        print(f"CogniRelay save-hook transport failure: {exc.__class__.__name__}", file=sys.stderr)
+        return emit(envelope(False, mode, errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    mode = args.mode
+    subject_kind = args.subject_kind or os.getenv("COGNIRELAY_SUBJECT_KIND") or ""
+    subject_id = args.subject_id or os.getenv("COGNIRELAY_SUBJECT_ID") or ""
+
+    if mode == "facts":
+        result = {
+            "subject": {"kind": subject_kind or None, "id": subject_id or None},
+            "config": {
+                "base_url_present": bool(args.base_url or os.getenv("COGNIRELAY_BASE_URL")),
+                "token_present": bool(args.token or os.getenv("COGNIRELAY_TOKEN")),
+            },
+            "mechanical_facts": {"utc_now": datetime.now(UTC).isoformat().replace("+00:00", "Z"), "git": current_git_facts()},
+            "help_links": HELP_LINKS,
+        }
+        return emit(envelope(True, mode, result=result), 0)
+    if mode == "template":
+        return emit(envelope(True, mode, result={"payload": template_payload(subject_kind, subject_id)}), 0)
+    if mode in {"readback", "doctor"}:
+        return readback(mode, args)
+    if mode in {"dry-run", "write"}:
+        if args.server_compare:
+            return emit(envelope(False, mode, result={"diff": {"current_available": False, "added": [], "removed": [], "changed": []}}, errors=[{"code": "server_compare_not_implemented", "message": "Server compare is not implemented by this hook."}]), 2)
+        if not args.input:
+            return emit(envelope(False, mode, errors=[{"code": "missing_input", "message": "--input PATH|- is required.", "field": "input"}]), 2)
+        try:
+            payload = read_input(args.input)
+        except (OSError, json.JSONDecodeError) as exc:
+            return emit(envelope(False, mode, errors=[{"code": "invalid_input", "message": f"Could not read input payload: {exc.__class__.__name__}", "field": "input"}]), 2)
+        errors = validate_payload_shape(payload)
+        if not errors:
+            errors.extend(placeholder_errors(payload))
+            errors.extend(write_semantic_requirements(payload))
+        diff = semantic_diff(payload) if isinstance(payload, dict) else {"current_available": False, "added": [], "removed": [], "changed": []}
+        if errors:
+            return emit(envelope(False, mode, result={"valid": False, "diff": diff, "placeholder_errors": errors}, errors=errors), 2)
+        if mode == "dry-run":
+            return emit(envelope(True, mode, result={"valid": True, "diff": diff, "placeholder_errors": []}), 0)
+        base_url, token, timeout = network_config(args)
+        if not base_url or not token:
+            return emit(envelope(False, mode, errors=[{"code": "missing_config", "message": "Missing CogniRelay base URL or token."}]), 2)
+        try:
+            status, response = post_json(base_url, token, "/v1/continuity/upsert", payload, timeout)
+            if status < 200 or status >= 300:
+                return emit(envelope(False, mode, result={"status": status}, errors=[{"code": "http_error", "message": "Continuity upsert returned an unsuccessful status."}]), 4)
+            result = {"upsert_response": response}
+            return emit(envelope(True, mode, result=result), 0)
+        except urllib.error.HTTPError as exc:
+            return emit(envelope(False, mode, result={"status": exc.code}, errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status."}]), 4)
+        except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+            print(f"CogniRelay write transport failure: {exc.__class__.__name__}", file=sys.stderr)
+            return emit(envelope(False, mode, errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)
+    return emit(envelope(False, mode, errors=[{"code": "invalid_mode", "message": "Unsupported mode."}]), 2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-assets/hooks/cognirelay_continuity_save_hook.py
+++ b/agent-assets/hooks/cognirelay_continuity_save_hook.py
@@ -24,6 +24,8 @@ HELP_LINKS = {
     "limits_index": "/v1/help/limits",
 }
 
+MODES = ("facts", "template", "dry-run", "write", "readback", "doctor")
+
 SEMANTIC_PREFIXES = (
     "/capsule/continuity",
     "/capsule/stable_preferences",
@@ -48,6 +50,26 @@ EXCLUDED_DIFF_PREFIXES = (
 PLACEHOLDER_RE = re.compile(r"\b(?:TODO|TBD|PLACEHOLDER|FILL ME|REPLACE ME)\b", re.IGNORECASE)
 BRACKET_PLACEHOLDER_RE = re.compile(r"^(?:<[^<>]+>|\[[^\[\]]+\])$")
 UTC_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
+
+
+class InvalidArgsError(Exception):
+    """Raised when argparse should emit the hook JSON failure envelope."""
+
+    def __init__(self, message: str, field: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.field = field
+
+
+class HookArgumentParser(argparse.ArgumentParser):
+    """Argument parser that preserves --help and defers errors to JSON output."""
+
+    def error(self, message: str) -> None:
+        field = None
+        if message.startswith("argument "):
+            target = message.split(":", 1)[0].removeprefix("argument ")
+            field = target.removeprefix("--").replace("-", "_")
+        raise InvalidArgsError(message, field)
 
 
 def envelope(ok: bool, mode: str, result: dict[str, Any] | None = None, errors: list[dict[str, str]] | None = None, warnings: list[Any] | None = None) -> dict[str, Any]:
@@ -82,6 +104,33 @@ def post_json(base_url: str, token: str, path: str, payload: dict[str, Any], tim
     with urllib.request.urlopen(request, timeout=timeout) as response:
         body = response.read().decode("utf-8")
         return response.status, json.loads(body) if body else {}
+
+
+def redact_token(value: Any, token: str) -> Any:
+    if not token:
+        return value
+    if isinstance(value, dict):
+        return {key: redact_token(child, token) for key, child in value.items()}
+    if isinstance(value, list):
+        return [redact_token(child, token) for child in value]
+    if isinstance(value, str):
+        return value.replace(token, "[REDACTED]")
+    return value
+
+
+def bounded_current_state(value: dict[str, Any], token: str, max_chars: int = 6000) -> dict[str, Any]:
+    redacted = redact_token(value, token)
+    encoded = json.dumps(redacted, sort_keys=True, separators=(",", ":"))
+    if len(encoded) <= max_chars:
+        return redacted
+    return {"truncated": True, "json": encoded[:max_chars]}
+
+
+def http_error_result(exc: urllib.error.HTTPError) -> dict[str, Any]:
+    result: dict[str, Any] = {"status": exc.code}
+    if exc.reason:
+        result["reason"] = str(exc.reason)[:120]
+    return result
 
 
 def current_git_facts() -> dict[str, str]:
@@ -236,8 +285,8 @@ def semantic_diff(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Validate, write, and read back CogniRelay continuity payloads.")
-    parser.add_argument("mode", choices=["facts", "template", "dry-run", "write", "readback", "doctor"])
+    parser = HookArgumentParser(description="Validate, write, and read back CogniRelay continuity payloads.")
+    parser.add_argument("mode", choices=MODES)
     parser.add_argument("--base-url")
     parser.add_argument("--token")
     parser.add_argument("--subject-kind", choices=["thread", "task", "user", "peer"])
@@ -285,30 +334,67 @@ def readback(mode: str, args: argparse.Namespace) -> int:
             return emit(envelope(False, mode, result={"status": status}, errors=[{"code": "http_error", "message": "Continuity read returned an unsuccessful status."}]), 4)
         return emit(envelope(True, mode, result={"readback": response, "trust_signals": response.get("trust_signals", {}), "recovery_warnings": response.get("recovery_warnings", [])}), 0)
     except urllib.error.HTTPError as exc:
-        return emit(envelope(False, mode, result={"status": exc.code}, errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status."}]), 4)
+        return emit(envelope(False, mode, result=http_error_result(exc), errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status. Response body omitted."}]), 4)
     except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
         print(f"CogniRelay save-hook transport failure: {exc.__class__.__name__}", file=sys.stderr)
         return emit(envelope(False, mode, errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)
 
 
+def best_known_mode(argv: list[str] | None) -> str:
+    values = sys.argv[1:] if argv is None else argv
+    return values[0] if values and values[0] in MODES else "unknown"
+
+
+def facts_result(args: argparse.Namespace, subject_kind: str, subject_id: str) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    base_url, token, timeout, timeout_error = network_config(args)
+    result = {
+        "subject": {"kind": subject_kind or None, "id": subject_id or None},
+        "config": {
+            "base_url_present": bool(args.base_url or os.getenv("COGNIRELAY_BASE_URL")),
+            "token_present": bool(args.token or os.getenv("COGNIRELAY_TOKEN")),
+        },
+        "mechanical_facts": {"utc_now": datetime.now(UTC).isoformat().replace("+00:00", "Z"), "git": current_git_facts()},
+        "help_links": HELP_LINKS,
+    }
+    warnings: list[dict[str, str]] = []
+    if timeout_error is not None:
+        warnings.append({"code": "current_state_unavailable", "message": "Current state read skipped because timeout configuration is invalid.", "field": "timeout"})
+        return result, warnings
+    if not base_url or not token or not subject_kind or not subject_id:
+        warnings.append({"code": "missing_config_for_current_state", "message": "Current state read skipped because base URL, token, subject kind, or subject id is missing."})
+        return result, warnings
+    try:
+        _status, response = post_json(
+            base_url,
+            token,
+            "/v1/continuity/read",
+            {"subject_kind": subject_kind, "subject_id": subject_id, "view": "startup", "allow_fallback": True},
+            timeout,
+        )
+        result["current_state"] = bounded_current_state(response, token)
+    except urllib.error.HTTPError as exc:
+        warnings.append({"code": "current_state_unavailable", "message": "Current state read returned an unsuccessful status. Response body omitted.", "field": str(exc.code)})
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
+        warnings.append({"code": "current_state_unavailable", "message": "No usable current state HTTP response was received."})
+    return result, warnings
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except InvalidArgsError as exc:
+        error = {"code": "invalid_args", "message": exc.message}
+        if exc.field:
+            error["field"] = exc.field
+        return emit(envelope(False, best_known_mode(argv), errors=[error]), 2)
     mode = args.mode
     subject_kind = args.subject_kind or os.getenv("COGNIRELAY_SUBJECT_KIND") or ""
     subject_id = args.subject_id or os.getenv("COGNIRELAY_SUBJECT_ID") or ""
 
     if mode == "facts":
-        result = {
-            "subject": {"kind": subject_kind or None, "id": subject_id or None},
-            "config": {
-                "base_url_present": bool(args.base_url or os.getenv("COGNIRELAY_BASE_URL")),
-                "token_present": bool(args.token or os.getenv("COGNIRELAY_TOKEN")),
-            },
-            "mechanical_facts": {"utc_now": datetime.now(UTC).isoformat().replace("+00:00", "Z"), "git": current_git_facts()},
-            "help_links": HELP_LINKS,
-        }
-        return emit(envelope(True, mode, result=result), 0)
+        result, warnings = facts_result(args, subject_kind, subject_id)
+        return emit(envelope(True, mode, result=result, warnings=warnings), 0)
     if mode == "template":
         return emit(envelope(True, mode, result={"payload": template_payload(subject_kind, subject_id)}), 0)
     if mode in {"readback", "doctor"}:
@@ -352,7 +438,7 @@ def main(argv: list[str] | None = None) -> int:
             result = {"upsert_response": response}
             return emit(envelope(True, mode, result=result), 0)
         except urllib.error.HTTPError as exc:
-            return emit(envelope(False, mode, result={"status": exc.code}, errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status."}]), 4)
+            return emit(envelope(False, mode, result=http_error_result(exc), errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status. Response body omitted."}]), 4)
         except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
             print(f"CogniRelay write transport failure: {exc.__class__.__name__}", file=sys.stderr)
             return emit(envelope(False, mode, errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)

--- a/agent-assets/hooks/cognirelay_continuity_save_hook.py
+++ b/agent-assets/hooks/cognirelay_continuity_save_hook.py
@@ -127,10 +127,23 @@ def bounded_current_state(value: dict[str, Any], token: str, max_chars: int = 60
 
 
 def http_error_result(exc: urllib.error.HTTPError) -> dict[str, Any]:
-    result: dict[str, Any] = {"status": exc.code}
-    if exc.reason:
-        result["reason"] = str(exc.reason)[:120]
-    return result
+    return {"status": exc.code}
+
+
+def response_subject_match(response: dict[str, Any], subject_kind: str, subject_id: str) -> tuple[bool | None, dict[str, str] | None]:
+    response_kind = response.get("subject_kind")
+    response_id = response.get("subject_id")
+    subject = response.get("subject")
+    if isinstance(subject, dict):
+        response_kind = response_kind if isinstance(response_kind, str) else subject.get("kind")
+        response_id = response_id if isinstance(response_id, str) else subject.get("id")
+    capsule = response.get("capsule")
+    if isinstance(capsule, dict):
+        response_kind = response_kind if isinstance(response_kind, str) else capsule.get("subject_kind")
+        response_id = response_id if isinstance(response_id, str) else capsule.get("subject_id")
+    if not isinstance(response_kind, str) or not isinstance(response_id, str):
+        return None, {"code": "expected_subject_match_unavailable", "message": "Readback response did not include enough subject information."}
+    return response_kind == subject_kind and response_id == subject_id, None
 
 
 def current_git_facts() -> dict[str, str]:
@@ -332,9 +345,24 @@ def readback(mode: str, args: argparse.Namespace) -> int:
         status, response = post_json(base_url, token, "/v1/continuity/read", {"subject_kind": subject_kind, "subject_id": subject_id, "view": "startup", "allow_fallback": True}, timeout)
         if status < 200 or status >= 300:
             return emit(envelope(False, mode, result={"status": status}, errors=[{"code": "http_error", "message": "Continuity read returned an unsuccessful status."}]), 4)
-        return emit(envelope(True, mode, result={"readback": response, "trust_signals": response.get("trust_signals", {}), "recovery_warnings": response.get("recovery_warnings", [])}), 0)
+        expected_subject_matched, match_warning = response_subject_match(response, subject_kind, subject_id)
+        warnings = [match_warning] if match_warning is not None else []
+        return emit(
+            envelope(
+                True,
+                mode,
+                result={
+                    "readback": response,
+                    "trust_signals": response.get("trust_signals", {}),
+                    "recovery_warnings": response.get("recovery_warnings", []),
+                    "expected_subject_matched": expected_subject_matched,
+                },
+                warnings=warnings,
+            ),
+            0,
+        )
     except urllib.error.HTTPError as exc:
-        return emit(envelope(False, mode, result=http_error_result(exc), errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status. Response body omitted."}]), 4)
+        return emit(envelope(False, mode, result=http_error_result(exc), errors=[{"code": "http_error", "message": "HTTP request failed."}]), 4)
     except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
         print(f"CogniRelay save-hook transport failure: {exc.__class__.__name__}", file=sys.stderr)
         return emit(envelope(False, mode, errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)
@@ -438,7 +466,7 @@ def main(argv: list[str] | None = None) -> int:
             result = {"upsert_response": response}
             return emit(envelope(True, mode, result=result), 0)
         except urllib.error.HTTPError as exc:
-            return emit(envelope(False, mode, result=http_error_result(exc), errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status. Response body omitted."}]), 4)
+            return emit(envelope(False, mode, result=http_error_result(exc), errors=[{"code": "http_error", "message": "HTTP request failed."}]), 4)
         except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
             print(f"CogniRelay write transport failure: {exc.__class__.__name__}", file=sys.stderr)
             return emit(envelope(False, mode, errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)

--- a/agent-assets/hooks/cognirelay_continuity_save_hook.py
+++ b/agent-assets/hooks/cognirelay_continuity_save_hook.py
@@ -47,6 +47,7 @@ EXCLUDED_DIFF_PREFIXES = (
 )
 PLACEHOLDER_RE = re.compile(r"\b(?:TODO|TBD|PLACEHOLDER|FILL ME|REPLACE ME)\b", re.IGNORECASE)
 BRACKET_PLACEHOLDER_RE = re.compile(r"^(?:<[^<>]+>|\[[^\[\]]+\])$")
+UTC_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$")
 
 
 def envelope(ok: bool, mode: str, result: dict[str, Any] | None = None, errors: list[dict[str, str]] | None = None, warnings: list[Any] | None = None) -> dict[str, Any]:
@@ -141,6 +142,25 @@ def validate_payload_shape(payload: Any) -> list[dict[str, str]]:
     return errors
 
 
+def timestamp_errors(payload: dict[str, Any]) -> list[dict[str, str]]:
+    errors: list[dict[str, str]] = []
+    capsule = payload.get("capsule", {})
+    if not isinstance(capsule, dict):
+        return errors
+    for key in ("updated_at", "verified_at"):
+        path = f"/capsule/{key}"
+        value = capsule.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append({"code": "invalid_input", "message": "Timestamp must be a non-empty UTC string.", "field": path})
+            continue
+        stripped = value.strip()
+        if PLACEHOLDER_RE.search(stripped) or BRACKET_PLACEHOLDER_RE.match(stripped):
+            errors.append({"code": "placeholder_rejected", "message": "Timestamp placeholder is not allowed.", "field": path})
+        elif not UTC_TIMESTAMP_RE.match(stripped):
+            errors.append({"code": "invalid_input", "message": "Timestamp must use UTC Z format.", "field": path})
+    return errors
+
+
 def placeholder_errors(value: Any, parts: list[str] | None = None) -> list[dict[str, str]]:
     parts = parts or []
     path = pointer(parts) if parts else ""
@@ -228,17 +248,33 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def network_config(args: argparse.Namespace) -> tuple[str, str, float]:
-    base_url = (args.base_url or os.getenv("COGNIRELAY_BASE_URL") or "").rstrip("/")
+def normalize_base_url(value: str) -> str:
+    return value[:-1] if value.endswith("/") else value
+
+
+def resolve_timeout(value: float | None) -> tuple[float, dict[str, str] | None]:
+    if value is not None:
+        return value, None
+    raw = os.getenv("COGNIRELAY_TIMEOUT_SECONDS", "10")
+    try:
+        return float(raw), None
+    except ValueError:
+        return 0.0, {"code": "invalid_config", "message": "Timeout must be numeric seconds.", "field": "timeout"}
+
+
+def network_config(args: argparse.Namespace) -> tuple[str, str, float, dict[str, str] | None]:
+    base_url = normalize_base_url(args.base_url or os.getenv("COGNIRELAY_BASE_URL") or "")
     token = args.token or os.getenv("COGNIRELAY_TOKEN") or ""
-    timeout = args.timeout if args.timeout is not None else float(os.getenv("COGNIRELAY_TIMEOUT_SECONDS", "10"))
-    return base_url, token, timeout
+    timeout, timeout_error = resolve_timeout(args.timeout)
+    return base_url, token, timeout, timeout_error
 
 
 def readback(mode: str, args: argparse.Namespace) -> int:
-    base_url, token, timeout = network_config(args)
+    base_url, token, timeout, timeout_error = network_config(args)
     subject_kind = args.subject_kind or os.getenv("COGNIRELAY_SUBJECT_KIND") or ""
     subject_id = args.subject_id or os.getenv("COGNIRELAY_SUBJECT_ID") or ""
+    if timeout_error is not None:
+        return emit(envelope(False, mode, errors=[timeout_error]), 2)
     if not base_url or not token:
         return emit(envelope(False, mode, errors=[{"code": "missing_config", "message": "Missing CogniRelay base URL or token."}]), 2)
     if not subject_kind or not subject_id:
@@ -279,7 +315,15 @@ def main(argv: list[str] | None = None) -> int:
         return readback(mode, args)
     if mode in {"dry-run", "write"}:
         if args.server_compare:
-            return emit(envelope(False, mode, result={"diff": {"current_available": False, "added": [], "removed": [], "changed": []}}, errors=[{"code": "server_compare_not_implemented", "message": "Server compare is not implemented by this hook."}]), 2)
+            return emit(
+                envelope(
+                    False,
+                    mode,
+                    result={"diff": {"current_available": False, "added": [], "removed": [], "changed": []}},
+                    errors=[{"code": "server_compare_not_implemented", "message": "Server compare is not implemented by this hook."}],
+                ),
+                2,
+            )
         if not args.input:
             return emit(envelope(False, mode, errors=[{"code": "missing_input", "message": "--input PATH|- is required.", "field": "input"}]), 2)
         try:
@@ -288,6 +332,7 @@ def main(argv: list[str] | None = None) -> int:
             return emit(envelope(False, mode, errors=[{"code": "invalid_input", "message": f"Could not read input payload: {exc.__class__.__name__}", "field": "input"}]), 2)
         errors = validate_payload_shape(payload)
         if not errors:
+            errors.extend(timestamp_errors(payload))
             errors.extend(placeholder_errors(payload))
             errors.extend(write_semantic_requirements(payload))
         diff = semantic_diff(payload) if isinstance(payload, dict) else {"current_available": False, "added": [], "removed": [], "changed": []}
@@ -295,7 +340,9 @@ def main(argv: list[str] | None = None) -> int:
             return emit(envelope(False, mode, result={"valid": False, "diff": diff, "placeholder_errors": errors}, errors=errors), 2)
         if mode == "dry-run":
             return emit(envelope(True, mode, result={"valid": True, "diff": diff, "placeholder_errors": []}), 0)
-        base_url, token, timeout = network_config(args)
+        base_url, token, timeout, timeout_error = network_config(args)
+        if timeout_error is not None:
+            return emit(envelope(False, mode, errors=[timeout_error]), 2)
         if not base_url or not token:
             return emit(envelope(False, mode, errors=[{"code": "missing_config", "message": "Missing CogniRelay base URL or token."}]), 2)
         try:

--- a/agent-assets/hooks/cognirelay_retrieval_hook.py
+++ b/agent-assets/hooks/cognirelay_retrieval_hook.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Read-only CogniRelay startup/context retrieval hook."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+def envelope(ok: bool, mode: str, result: dict[str, Any] | None = None, errors: list[dict[str, str]] | None = None, warnings: list[Any] | None = None) -> dict[str, Any]:
+    return {"ok": ok, "mode": mode, "warnings": warnings or [], "errors": errors or [], "result": result or {}}
+
+
+def emit(payload: dict[str, Any], code: int) -> int:
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    return code
+
+
+def post_json(base_url: str, token: str, path: str, payload: dict[str, Any], timeout: float) -> tuple[int, dict[str, Any]]:
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        body = response.read().decode("utf-8")
+        return response.status, json.loads(body) if body else {}
+
+
+def env_bool(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Read CogniRelay startup continuity and optional bounded context.")
+    parser.add_argument("--base-url")
+    parser.add_argument("--token")
+    parser.add_argument("--subject-kind", choices=["thread", "task", "user", "peer"])
+    parser.add_argument("--subject-id")
+    parser.add_argument("--task")
+    parser.add_argument("--context-retrieve", action="store_true")
+    parser.add_argument("--no-context-retrieve", action="store_true")
+    parser.add_argument("--timeout", type=float)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    base_url = (args.base_url or os.getenv("COGNIRELAY_BASE_URL") or "").rstrip("/")
+    token = args.token or os.getenv("COGNIRELAY_TOKEN") or ""
+    subject_kind = args.subject_kind or os.getenv("COGNIRELAY_SUBJECT_KIND") or ""
+    subject_id = args.subject_id or os.getenv("COGNIRELAY_SUBJECT_ID") or ""
+    task = args.task if args.task is not None else os.getenv("COGNIRELAY_RETRIEVAL_TASK", "")
+    timeout = args.timeout if args.timeout is not None else float(os.getenv("COGNIRELAY_TIMEOUT_SECONDS", "10"))
+    context_enabled = (args.context_retrieve or env_bool(os.getenv("COGNIRELAY_CONTEXT_RETRIEVE"))) and not args.no_context_retrieve
+
+    if not base_url:
+        return emit(envelope(False, "retrieval", errors=[{"code": "missing_config", "message": "Missing CogniRelay base URL.", "field": "base_url"}]), 2)
+    if not token:
+        return emit(envelope(False, "retrieval", errors=[{"code": "missing_config", "message": "Missing CogniRelay token.", "field": "token"}]), 2)
+    if not subject_kind or not subject_id:
+        field = "subject" if not subject_kind and not subject_id else ("subject_kind" if not subject_kind else "subject_id")
+        return emit(envelope(False, "retrieval", errors=[{"code": "missing_subject", "message": "Missing subject kind or subject id.", "field": field}]), 2)
+
+    read_payload = {"subject_kind": subject_kind, "subject_id": subject_id, "view": "startup", "allow_fallback": True}
+    try:
+        read_status, startup = post_json(base_url, token, "/v1/continuity/read", read_payload, timeout)
+        if read_status < 200 or read_status >= 300:
+            return emit(envelope(False, "retrieval", result={"status": read_status}, errors=[{"code": "http_error", "message": "Continuity read returned an unsuccessful status."}]), 4)
+        result: dict[str, Any] = {"startup": startup}
+        if context_enabled and task.strip():
+            context_payload = {"task": task, "subject_kind": subject_kind, "subject_id": subject_id}
+            context_status, context = post_json(base_url, token, "/v1/context/retrieve", context_payload, timeout)
+            if context_status < 200 or context_status >= 300:
+                return emit(envelope(False, "retrieval", result={"startup": startup, "status": context_status}, errors=[{"code": "http_error", "message": "Context retrieve returned an unsuccessful status."}]), 4)
+            result["context"] = context
+        return emit(envelope(True, "retrieval", result=result), 0)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        result = {"status": exc.code}
+        if body:
+            result["body"] = body
+        return emit(envelope(False, "retrieval", result=result, errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status."}]), 4)
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
+        print(f"CogniRelay retrieval transport failure: {exc.__class__.__name__}", file=sys.stderr)
+        return emit(envelope(False, "retrieval", errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-assets/hooks/cognirelay_retrieval_hook.py
+++ b/agent-assets/hooks/cognirelay_retrieval_hook.py
@@ -12,6 +12,25 @@ import urllib.request
 from typing import Any
 
 
+class InvalidArgsError(Exception):
+    """Raised when argparse should emit the hook JSON failure envelope."""
+
+    def __init__(self, message: str, field: str | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.field = field
+
+
+class HookArgumentParser(argparse.ArgumentParser):
+    """Argument parser that preserves --help and defers errors to JSON output."""
+
+    def error(self, message: str) -> None:
+        field = None
+        if message.startswith("argument --"):
+            field = message.split(":", 1)[0].removeprefix("argument --").replace("-", "_")
+        raise InvalidArgsError(message, field)
+
+
 def envelope(ok: bool, mode: str, result: dict[str, Any] | None = None, errors: list[dict[str, str]] | None = None, warnings: list[Any] | None = None) -> dict[str, Any]:
     return {"ok": ok, "mode": mode, "warnings": warnings or [], "errors": errors or [], "result": result or {}}
 
@@ -41,6 +60,13 @@ def normalize_base_url(value: str) -> str:
     return value[:-1] if value.endswith("/") else value
 
 
+def http_error_result(exc: urllib.error.HTTPError) -> dict[str, Any]:
+    result: dict[str, Any] = {"status": exc.code}
+    if exc.reason:
+        result["reason"] = str(exc.reason)[:120]
+    return result
+
+
 def resolve_timeout(value: float | None) -> tuple[float, dict[str, str] | None]:
     if value is not None:
         return value, None
@@ -52,7 +78,7 @@ def resolve_timeout(value: float | None) -> tuple[float, dict[str, str] | None]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Read CogniRelay startup continuity and optional bounded context.")
+    parser = HookArgumentParser(description="Read CogniRelay startup continuity and optional bounded context.")
     parser.add_argument("--base-url")
     parser.add_argument("--token")
     parser.add_argument("--subject-kind", choices=["thread", "task", "user", "peer"])
@@ -66,7 +92,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except InvalidArgsError as exc:
+        error = {"code": "invalid_args", "message": exc.message}
+        if exc.field:
+            error["field"] = exc.field
+        return emit(envelope(False, "retrieval", errors=[error]), 2)
     base_url = normalize_base_url(args.base_url or os.getenv("COGNIRELAY_BASE_URL") or "")
     token = args.token or os.getenv("COGNIRELAY_TOKEN") or ""
     subject_kind = args.subject_kind or os.getenv("COGNIRELAY_SUBJECT_KIND") or ""
@@ -107,11 +139,7 @@ def main(argv: list[str] | None = None) -> int:
             result["context"] = context
         return emit(envelope(True, "retrieval", result=result), 0)
     except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        result = {"status": exc.code}
-        if body:
-            result["body"] = body
-        return emit(envelope(False, "retrieval", result=result, errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status."}]), 4)
+        return emit(envelope(False, "retrieval", result=http_error_result(exc), errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status. Response body omitted."}]), 4)
     except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
         print(f"CogniRelay retrieval transport failure: {exc.__class__.__name__}", file=sys.stderr)
         return emit(envelope(False, "retrieval", errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)

--- a/agent-assets/hooks/cognirelay_retrieval_hook.py
+++ b/agent-assets/hooks/cognirelay_retrieval_hook.py
@@ -53,7 +53,7 @@ def post_json(base_url: str, token: str, path: str, payload: dict[str, Any], tim
 
 
 def env_bool(value: str | None) -> bool:
-    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+    return value is not None and value.strip() == "1"
 
 
 def normalize_base_url(value: str) -> str:

--- a/agent-assets/hooks/cognirelay_retrieval_hook.py
+++ b/agent-assets/hooks/cognirelay_retrieval_hook.py
@@ -61,10 +61,7 @@ def normalize_base_url(value: str) -> str:
 
 
 def http_error_result(exc: urllib.error.HTTPError) -> dict[str, Any]:
-    result: dict[str, Any] = {"status": exc.code}
-    if exc.reason:
-        result["reason"] = str(exc.reason)[:120]
-    return result
+    return {"status": exc.code}
 
 
 def resolve_timeout(value: float | None) -> tuple[float, dict[str, str] | None]:
@@ -139,7 +136,7 @@ def main(argv: list[str] | None = None) -> int:
             result["context"] = context
         return emit(envelope(True, "retrieval", result=result), 0)
     except urllib.error.HTTPError as exc:
-        return emit(envelope(False, "retrieval", result=http_error_result(exc), errors=[{"code": "http_error", "message": "CogniRelay returned an unsuccessful status. Response body omitted."}]), 4)
+        return emit(envelope(False, "retrieval", result=http_error_result(exc), errors=[{"code": "http_error", "message": "HTTP request failed."}]), 4)
     except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
         print(f"CogniRelay retrieval transport failure: {exc.__class__.__name__}", file=sys.stderr)
         return emit(envelope(False, "retrieval", errors=[{"code": "transport_failure", "message": "No usable HTTP response was received."}]), 3)

--- a/agent-assets/hooks/cognirelay_retrieval_hook.py
+++ b/agent-assets/hooks/cognirelay_retrieval_hook.py
@@ -37,6 +37,20 @@ def env_bool(value: str | None) -> bool:
     return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def normalize_base_url(value: str) -> str:
+    return value[:-1] if value.endswith("/") else value
+
+
+def resolve_timeout(value: float | None) -> tuple[float, dict[str, str] | None]:
+    if value is not None:
+        return value, None
+    raw = os.getenv("COGNIRELAY_TIMEOUT_SECONDS", "10")
+    try:
+        return float(raw), None
+    except ValueError:
+        return 0.0, {"code": "invalid_config", "message": "Timeout must be numeric seconds.", "field": "timeout"}
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Read CogniRelay startup continuity and optional bounded context.")
     parser.add_argument("--base-url")
@@ -53,14 +67,16 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    base_url = (args.base_url or os.getenv("COGNIRELAY_BASE_URL") or "").rstrip("/")
+    base_url = normalize_base_url(args.base_url or os.getenv("COGNIRELAY_BASE_URL") or "")
     token = args.token or os.getenv("COGNIRELAY_TOKEN") or ""
     subject_kind = args.subject_kind or os.getenv("COGNIRELAY_SUBJECT_KIND") or ""
     subject_id = args.subject_id or os.getenv("COGNIRELAY_SUBJECT_ID") or ""
     task = args.task if args.task is not None else os.getenv("COGNIRELAY_RETRIEVAL_TASK", "")
-    timeout = args.timeout if args.timeout is not None else float(os.getenv("COGNIRELAY_TIMEOUT_SECONDS", "10"))
+    timeout, timeout_error = resolve_timeout(args.timeout)
     context_enabled = (args.context_retrieve or env_bool(os.getenv("COGNIRELAY_CONTEXT_RETRIEVE"))) and not args.no_context_retrieve
 
+    if timeout_error is not None:
+        return emit(envelope(False, "retrieval", errors=[timeout_error]), 2)
     if not base_url:
         return emit(envelope(False, "retrieval", errors=[{"code": "missing_config", "message": "Missing CogniRelay base URL.", "field": "base_url"}]), 2)
     if not token:
@@ -79,7 +95,15 @@ def main(argv: list[str] | None = None) -> int:
             context_payload = {"task": task, "subject_kind": subject_kind, "subject_id": subject_id}
             context_status, context = post_json(base_url, token, "/v1/context/retrieve", context_payload, timeout)
             if context_status < 200 or context_status >= 300:
-                return emit(envelope(False, "retrieval", result={"startup": startup, "status": context_status}, errors=[{"code": "http_error", "message": "Context retrieve returned an unsuccessful status."}]), 4)
+                return emit(
+                    envelope(
+                        False,
+                        "retrieval",
+                        result={"startup": startup, "status": context_status},
+                        errors=[{"code": "http_error", "message": "Context retrieve returned an unsuccessful status."}],
+                    ),
+                    4,
+                )
             result["context"] = context
         return emit(envelope(True, "retrieval", result=result), 0)
     except urllib.error.HTTPError as exc:

--- a/agent-assets/skills/cognirelay-continuity-authoring/SKILL.md
+++ b/agent-assets/skills/cognirelay-continuity-authoring/SKILL.md
@@ -1,0 +1,46 @@
+# CogniRelay Continuity Authoring
+
+Use this skill when an agent runtime needs to maintain CogniRelay continuity responsibly.
+
+## Responsibility Split
+
+CogniRelay is the substrate for continuity storage, startup reads, bounded retrieval, graph orientation, schedule orientation, trust signals, and validation limits. CogniRelay is not the semantic author of a capsule.
+
+The running agent authors semantic fields through explicit judgment before any continuity save. Semantic fields include stance, priorities, open loops, constraints, negative decisions, rationale, durable preferences, retrieval hints, and next-step meaning.
+
+Hooks and adapters must not infer semantic continuity from prompts, transcripts, tool output, stale plans, git history, logs, or schedule items. They may gather mechanical facts, provide templates, validate payloads, show diffs, submit an agent-authored payload, and read back stored state.
+
+## Startup And Retrieval
+
+At startup or pre-prompt time, use `agent-assets/hooks/cognirelay_retrieval_hook.py` for read-only orientation. It reads `POST /v1/continuity/read` with `view="startup"` and may call `POST /v1/context/retrieve` only when explicitly enabled and a task is supplied.
+
+Do not use retrieval output as a continuity write. Do not persist prompt text, transcript text, tool chatter, shell output, or copied retrieval snippets.
+
+Graph and schedule sections are read-only orientation adjuncts. They can help the agent decide what to do next, but they are not capsule fields to copy mechanically.
+
+## Save Flow
+
+Use `agent-assets/hooks/cognirelay_continuity_save_hook.py` after the agent has enough context to author a durable update.
+
+1. Run `facts` for mechanical subject/config/runtime facts and help links.
+2. Run `template` for a generic full `continuity.upsert` skeleton.
+3. Author semantic fields explicitly in the payload.
+4. Run `dry-run` to reject placeholders and inspect a candidate-only semantic diff.
+5. Run `write` only after the explicit agent-authored payload exists.
+6. Run `readback` or `doctor` to verify warnings, trust signals, and stored state.
+
+## Scheduling
+
+Agents may create one-shot reminders or task nudges through `schedule.create` or `POST /v1/schedule/items` only when the user or an explicit work plan needs future follow-up.
+
+- Use UTC timestamps only.
+- Use `kind="reminder"` for general follow-up.
+- Use `kind="task_nudge"` only when linked to a task, thread, or subject.
+- Scheduling does not execute work; it surfaces future orientation through `schedule_context`, `schedule.list`, and `/ui/schedule`.
+- Do not auto-create reminders from every open loop.
+- Do not infer due dates.
+- Do not acknowledge or retire schedule items unless the work was actually handled or made irrelevant.
+
+## Write Discipline
+
+Before saving, verify that the payload is bounded, durable, and agent-authored. Reject prompt dumping, transcript dumping, copied retrieval text, and automatic semantic inference. Treat warnings and degraded trust signals as operational input for the agent, not as hook-authored meaning.

--- a/app/help/service.py
+++ b/app/help/service.py
@@ -56,6 +56,7 @@ _TOPIC_IDS = [
     "continuity.read.startup_view",
     "continuity.read.trust_signals",
     "continuity.upsert.session_end_snapshot",
+    "last-mile-adapter",
 ]
 
 _ERROR_CODES = [
@@ -431,6 +432,43 @@ _TOPICS = {
         "correction_hints": [
             "Include the base capsule and then provide session_end_snapshot as a bounded helper.",
             "Use only open_loops, top_priorities, active_constraints, stance_summary, negative_decisions, session_trajectory, and rationale_entries in session_end_snapshot.",
+        ],
+    },
+    "last-mile-adapter": {
+        "kind": "topic",
+        "id": "last-mile-adapter",
+        "purpose": (
+            "Explain the shipped last-mile adapter kit for agent-authored continuity: CogniRelay is the substrate, "
+            "the agent authors semantic fields, and adapters do no semantic inference."
+        ),
+        "when_to_use": [
+            "Use when wiring a cold-start agent runtime to CogniRelay without project-specific glue.",
+            "Use when an adapter needs the facts/template/dry-run/write/readback flow for explicit agent-authored continuity.",
+        ],
+        "read_operations": [
+            "agent-assets/hooks/cognirelay_retrieval_hook.py",
+            "POST /v1/continuity/read",
+            "POST /v1/context/retrieve",
+        ],
+        "write_operations": [
+            "agent-assets/hooks/cognirelay_continuity_save_hook.py",
+            "POST /v1/continuity/upsert",
+        ],
+        "minimal_payload": {
+            "skill_path": "agent-assets/skills/cognirelay-continuity-authoring/SKILL.md",
+            "retrieval_hook_path": "agent-assets/hooks/cognirelay_retrieval_hook.py",
+            "save_hook_path": "agent-assets/hooks/cognirelay_continuity_save_hook.py",
+            "flow": ["facts", "template", "agent-authors-semantic-fields", "dry-run", "write", "readback"],
+        },
+        "common_mistakes": [
+            "Making CogniRelay or an adapter infer stance, priorities, open loops, rationale, or next steps.",
+            "Using the read-only retrieval hook as a write path.",
+            "Turning graph_summary or schedule_context orientation into automatic continuity fields.",
+        ],
+        "correction_hints": [
+            "Treat CogniRelay as substrate and the running agent as the semantic author.",
+            "Use the shipped skill path, retrieval hook path, and continuity save hook path as copyable integration assets.",
+            "Run facts/template/dry-run/write/readback only around an explicit agent-authored continuity.upsert payload.",
         ],
     },
 }
@@ -1584,7 +1622,7 @@ def help_topic_payload(topic_id: str) -> dict[str, Any] | JSONResponse:
         field="id",
         detail="Unsupported topic id.",
         allowed_values=list(_TOPIC_IDS),
-        correction_hint="Use one of: continuity.read.startup_view, continuity.read.trust_signals, continuity.upsert.session_end_snapshot.",
+        correction_hint="Use one of: continuity.read.startup_view, continuity.read.trust_signals, continuity.upsert.session_end_snapshot, last-mile-adapter.",
     )
 
 
@@ -1893,7 +1931,7 @@ def resolve_mcp_help_method(
                 "surface": "topic_help",
                 "httpEquivalent": f"/v1/help/topics/{topic_id}",
                 "id": topic_id,
-                "title": topic_id,
+                "title": topic_id if topic_id != "last-mile-adapter" else "Last-Mile Adapter Kit",
                 "summary": str(payload["purpose"]),
             }
         ), None

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -54,6 +54,22 @@ Map runtime-specific hook names to these four canonical hooks. `startup` and `pr
 - Reminder orientation is also read-only. `schedule.list` supports explicit `thread_id` filtering and subject tuple filtering; `schedule_context` also appears in startup/context orientation for matching thread, task, or subject scopes. Use `schedule.acknowledge` with `status="done"` for completion, or `schedule.retire` when a reminder is no longer relevant.
 - Use deeper references only for exact hook matrix details after this mapping is clear.
 
+## Last-mile Adapter Kit
+
+CogniRelay ships copyable agent assets under [`agent-assets/README.md`](../agent-assets/README.md), including [`agent-assets/skills/cognirelay-continuity-authoring/SKILL.md`](../agent-assets/skills/cognirelay-continuity-authoring/SKILL.md), [`agent-assets/hooks/cognirelay_retrieval_hook.py`](../agent-assets/hooks/cognirelay_retrieval_hook.py), and [`agent-assets/hooks/cognirelay_continuity_save_hook.py`](../agent-assets/hooks/cognirelay_continuity_save_hook.py).
+
+Use this safe sequence for generic runtime glue:
+
+1. Run the retrieval hook at startup/pre-prompt for read-only orientation.
+2. Run save hook `facts` mode for mechanical context.
+3. Run save hook `template` mode for a semantic skeleton.
+4. Have the agent author semantic fields explicitly.
+5. Run save hook `dry-run` for placeholder rejection and deterministic diff.
+6. Run save hook `write` only after an explicit agent-authored payload exists.
+7. Run save hook `readback` or `doctor` for verification.
+
+The hooks do not infer semantic continuity and do not turn graph or schedule orientation into capsule fields.
+
 ## How To Ask CogniRelay For Help
 
 Use built-in help/reference lookup for exact route, tool, topic, hook, and error guidance instead of guessing. Use HTTP help surfaces as the runtime lookup path, MCP help/reference methods as the JSON-RPC lookup path, and `GET /v1/capabilities` only when instance support is uncertain.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,8 @@ the [README](../README.md).
   model, and agent usage guidance.
 - [Agent Onboarding](agent-onboarding.md): practical integration guide for
   cold-start and already-running agents.
+- [Last-mile Adapter Kit](../agent-assets/README.md): copyable skill and hook
+  assets for agent-authored continuity integration.
 - [API Surface](api-surface.md): currently implemented HTTP behavior grouped by
   domain.
 - [MCP Guide](mcp.md): MCP bootstrap flow, request methods, and tool mapping.

--- a/tests/test_agent_assets_289.py
+++ b/tests/test_agent_assets_289.py
@@ -7,8 +7,12 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib import util
 from pathlib import Path
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -30,6 +34,51 @@ REQUIRED_HELP_LINKS = {
 }
 
 
+class RecordingHTTPServer:
+    """Small local JSON server for hook subprocess tests."""
+
+    def __init__(self, responses: list[tuple[int, dict[str, Any] | str]]) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self._responses = list(responses)
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length", "0"))
+                raw_body = self.rfile.read(length).decode("utf-8")
+                owner.requests.append(
+                    {
+                        "path": self.path,
+                        "authorization": self.headers.get("Authorization"),
+                        "body": json.loads(raw_body) if raw_body else {},
+                    }
+                )
+                status, body = owner._responses.pop(0) if owner._responses else (200, {})
+                encoded = body if isinstance(body, str) else json.dumps(body)
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded.encode("utf-8"))))
+                self.end_headers()
+                self.wfile.write(encoded.encode("utf-8"))
+
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread: threading.Thread | None = None
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+
+    def __enter__(self) -> "RecordingHTTPServer":
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+
 def run_hook(path: Path, *args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     merged_env = os.environ.copy()
     for key in list(merged_env):
@@ -46,6 +95,15 @@ def run_hook(path: Path, *args: str, env: dict[str, str] | None = None) -> subpr
         text=True,
         timeout=10,
     )
+
+
+def load_hook(path: Path) -> Any:
+    spec = util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {path}")
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def valid_payload() -> dict[str, object]:
@@ -124,11 +182,112 @@ class TestAgentAssets289(unittest.TestCase):
         self.assertEqual(completed.stderr, "")
         self.assertNotIn("secret-token", completed.stdout)
 
+    def test_invalid_retrieval_cli_flag_emits_json_envelope(self) -> None:
+        completed = run_hook(RETRIEVAL_HOOK, "--bogus")
+        self.assertEqual(completed.returncode, 2)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["mode"], "retrieval")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["warnings"], [])
+        self.assertEqual(payload["result"], {})
+        self.assertEqual(payload["errors"][0]["code"], "invalid_args")
+        self.assertEqual(completed.stderr, "")
+
+    def test_retrieval_http_error_does_not_print_token_from_body(self) -> None:
+        token = "secret-token-289"
+        with RecordingHTTPServer([(500, {"error": f"reflected {token}"})]) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                token,
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+            )
+        self.assertEqual(completed.returncode, 4)
+        self.assertNotIn(token, completed.stdout)
+        self.assertNotIn(token, completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["errors"][0]["code"], "http_error")
+        self.assertNotIn("body", payload["result"])
+
+    def test_cli_overrides_env_for_retrieval_request_construction(self) -> None:
+        with RecordingHTTPServer([(200, {"capsule": {"subject_id": "cli-subject"}})]) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                "cli-token",
+                "--subject-kind",
+                "task",
+                "--subject-id",
+                "cli-subject",
+                env={
+                    "COGNIRELAY_BASE_URL": "http://127.0.0.1:9",
+                    "COGNIRELAY_TOKEN": "env-token",
+                    "COGNIRELAY_SUBJECT_KIND": "thread",
+                    "COGNIRELAY_SUBJECT_ID": "env-subject",
+                },
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(len(server.requests), 1)
+        self.assertEqual(server.requests[0]["authorization"], "Bearer cli-token")
+        self.assertEqual(server.requests[0]["body"]["subject_kind"], "task")
+        self.assertEqual(server.requests[0]["body"]["subject_id"], "cli-subject")
+
+    def test_base_url_strips_exactly_one_trailing_slash(self) -> None:
+        hook = load_hook(RETRIEVAL_HOOK)
+        self.assertEqual(hook.normalize_base_url("http://example.test/"), "http://example.test")
+        self.assertEqual(hook.normalize_base_url("http://example.test//"), "http://example.test/")
+
+    def test_no_context_retrieve_suppresses_env_enabled_context(self) -> None:
+        with RecordingHTTPServer([(200, {"capsule": {"subject_id": "issue-289"}})]) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+                "--task",
+                "retrieve context",
+                "--no-context-retrieve",
+                env={"COGNIRELAY_CONTEXT_RETRIEVE": "true"},
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual([request["path"] for request in server.requests], ["/v1/continuity/read"])
+        self.assertNotIn("context", json.loads(completed.stdout)["result"])
+
+    def test_missing_subject_attempts_no_http_request(self) -> None:
+        with RecordingHTTPServer([(200, {"unexpected": True})]) as server:
+            completed = run_hook(RETRIEVAL_HOOK, "--base-url", server.url, "--token", "secret-token")
+        self.assertEqual(completed.returncode, 2)
+        self.assertEqual(server.requests, [])
+
     def test_save_hook_help_exposes_required_modes(self) -> None:
         completed = run_hook(SAVE_HOOK, "--help")
         self.assertEqual(completed.returncode, 0)
         for token in ("facts", "template", "dry-run", "write", "readback", "doctor"):
             self.assertIn(token, completed.stdout)
+
+    def test_invalid_save_mode_emits_json_envelope(self) -> None:
+        completed = run_hook(SAVE_HOOK, "not-a-mode")
+        self.assertEqual(completed.returncode, 2)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["mode"], "unknown")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["warnings"], [])
+        self.assertEqual(payload["result"], {})
+        self.assertEqual(payload["errors"][0]["code"], "invalid_args")
+        self.assertEqual(payload["errors"][0]["field"], "mode")
+        self.assertEqual(completed.stderr, "")
 
     def test_facts_output_contains_exact_required_help_links(self) -> None:
         completed = run_hook(SAVE_HOOK, "facts", "--subject-kind", "thread", "--subject-id", "issue-289")
@@ -136,6 +295,53 @@ class TestAgentAssets289(unittest.TestCase):
         payload = json.loads(completed.stdout)
         self.assertTrue(payload["ok"])
         self.assertEqual(payload["result"]["help_links"], REQUIRED_HELP_LINKS)
+
+    def test_facts_mode_reads_current_state_when_config_and_subject_available(self) -> None:
+        with RecordingHTTPServer([(200, {"capsule": {"continuity": {"stance_summary": "Current."}}, "trust_signals": {"source": "test"}})]) as server:
+            completed = run_hook(
+                SAVE_HOOK,
+                "facts",
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+            )
+        self.assertEqual(completed.returncode, 0)
+        payload = json.loads(completed.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["warnings"], [])
+        self.assertEqual(server.requests[0]["path"], "/v1/continuity/read")
+        self.assertEqual(
+            server.requests[0]["body"],
+            {"subject_kind": "thread", "subject_id": "issue-289", "view": "startup", "allow_fallback": True},
+        )
+        self.assertEqual(payload["result"]["current_state"]["capsule"]["continuity"]["stance_summary"], "Current.")
+
+    def test_facts_mode_degrades_with_warning_when_current_state_read_fails(self) -> None:
+        token = "secret-token-289"
+        with RecordingHTTPServer([(500, {"error": f"reflected {token}"})]) as server:
+            completed = run_hook(
+                SAVE_HOOK,
+                "facts",
+                "--base-url",
+                server.url,
+                "--token",
+                token,
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertNotIn(token, completed.stdout)
+        payload = json.loads(completed.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["warnings"][0]["code"], "current_state_unavailable")
+        self.assertNotIn("current_state", payload["result"])
 
     def test_template_emits_schema_aligned_skeleton(self) -> None:
         completed = run_hook(SAVE_HOOK, "template", "--subject-kind", "thread", "--subject-id", "issue-289")

--- a/tests/test_agent_assets_289.py
+++ b/tests/test_agent_assets_289.py
@@ -267,7 +267,55 @@ class TestAgentAssets289(unittest.TestCase):
         self.assertEqual(hook.normalize_base_url("http://example.test/"), "http://example.test")
         self.assertEqual(hook.normalize_base_url("http://example.test//"), "http://example.test/")
 
-    def test_no_context_retrieve_suppresses_env_enabled_context(self) -> None:
+    def test_context_retrieve_env_true_with_task_reads_only_startup(self) -> None:
+        with RecordingHTTPServer([(200, {"capsule": {"subject_id": "issue-289"}})]) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+                "--task",
+                "retrieve context",
+                env={"COGNIRELAY_CONTEXT_RETRIEVE": "true"},
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual([request["path"] for request in server.requests], ["/v1/continuity/read"])
+        self.assertNotIn("context", json.loads(completed.stdout)["result"])
+
+    def test_context_retrieve_env_one_with_task_reads_startup_then_context(self) -> None:
+        with RecordingHTTPServer(
+            [
+                (200, {"capsule": {"subject_id": "issue-289"}}),
+                (200, {"items": [{"text": "context"}]}),
+            ]
+        ) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+                "--task",
+                "retrieve context",
+                env={"COGNIRELAY_CONTEXT_RETRIEVE": "1"},
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual([request["path"] for request in server.requests], ["/v1/continuity/read", "/v1/context/retrieve"])
+        self.assertEqual(
+            server.requests[1]["body"],
+            {"task": "retrieve context", "subject_kind": "thread", "subject_id": "issue-289"},
+        )
+
+    def test_no_context_retrieve_suppresses_env_one_context(self) -> None:
         with RecordingHTTPServer([(200, {"capsule": {"subject_id": "issue-289"}})]) as server:
             completed = run_hook(
                 RETRIEVAL_HOOK,
@@ -282,7 +330,7 @@ class TestAgentAssets289(unittest.TestCase):
                 "--task",
                 "retrieve context",
                 "--no-context-retrieve",
-                env={"COGNIRELAY_CONTEXT_RETRIEVE": "true"},
+                env={"COGNIRELAY_CONTEXT_RETRIEVE": "1"},
             )
         self.assertEqual(completed.returncode, 0)
         self.assertEqual([request["path"] for request in server.requests], ["/v1/continuity/read"])

--- a/tests/test_agent_assets_289.py
+++ b/tests/test_agent_assets_289.py
@@ -1,0 +1,277 @@
+"""Last-mile adapter kit coverage for issue #289."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.mcp.service import reset_bootstrap_state
+
+ROOT = Path(__file__).resolve().parents[1]
+RETRIEVAL_HOOK = ROOT / "agent-assets" / "hooks" / "cognirelay_retrieval_hook.py"
+SAVE_HOOK = ROOT / "agent-assets" / "hooks" / "cognirelay_continuity_save_hook.py"
+SKILL = ROOT / "agent-assets" / "skills" / "cognirelay-continuity-authoring" / "SKILL.md"
+
+REQUIRED_HELP_LINKS = {
+    "onboarding": "/v1/help/onboarding",
+    "last_mile_topic": "/v1/help/topics/last-mile-adapter",
+    "continuity_read_tool": "/v1/help/tools/continuity.read",
+    "continuity_upsert_tool": "/v1/help/tools/continuity.upsert",
+    "context_retrieve_tool": "/v1/help/tools/context.retrieve",
+    "limits_index": "/v1/help/limits",
+}
+
+
+def run_hook(path: Path, *args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    merged_env = os.environ.copy()
+    for key in list(merged_env):
+        if key.startswith("COGNIRELAY_"):
+            merged_env.pop(key)
+    if env:
+        merged_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(path), *args],
+        cwd=ROOT,
+        env=merged_env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def valid_payload() -> dict[str, object]:
+    return {
+        "subject_kind": "thread",
+        "subject_id": "issue-289",
+        "merge_mode": "preserve",
+        "capsule": {
+            "schema_version": "1.1",
+            "subject_kind": "thread",
+            "subject_id": "issue-289",
+            "updated_at": "2026-04-26T12:00:00Z",
+            "verified_at": "2026-04-26T12:00:00Z",
+            "continuity": {
+                "top_priorities": ["Ship the last-mile adapter kit."],
+                "active_concerns": [],
+                "active_constraints": ["Keep hooks generic and stdlib-only."],
+                "open_loops": [],
+                "drift_signals": [],
+                "stance_summary": "Implement the generic adapter assets without semantic inference.",
+                "negative_decisions": [],
+                "rationale_entries": [],
+                "retrieval_hints": {"must_include": ["agent-assets/README.md"], "load_next": [], "avoid": []},
+            },
+            "source": {"producer": "agent-authored-test", "update_reason": "manual", "inputs": []},
+            "confidence": {"continuity": 0.8, "relationship_model": 0.5},
+        },
+    }
+
+
+class TestAgentAssets289(unittest.TestCase):
+    """Verify shipped assets and offline hook behavior."""
+
+    def test_agent_asset_files_exist(self) -> None:
+        for path in (
+            ROOT / "agent-assets" / "README.md",
+            SKILL,
+            ROOT / "agent-assets" / "hooks" / "README.md",
+            RETRIEVAL_HOOK,
+            SAVE_HOOK,
+        ):
+            with self.subTest(path=path):
+                self.assertTrue(path.exists())
+
+    def test_skill_preserves_responsibility_split_and_bans_semantic_inference(self) -> None:
+        text = SKILL.read_text(encoding="utf-8")
+        for token in (
+            "CogniRelay is the substrate",
+            "not the semantic author",
+            "The running agent authors semantic fields",
+            "must not infer semantic continuity",
+            "Graph and schedule sections are read-only orientation adjuncts",
+        ):
+            self.assertIn(token, text)
+
+    def test_retrieval_hook_help_and_no_write_modes(self) -> None:
+        completed = run_hook(RETRIEVAL_HOOK, "--help")
+        self.assertEqual(completed.returncode, 0)
+        self.assertIn("--context-retrieve", completed.stdout)
+        self.assertNotIn("write", completed.stdout)
+        self.assertNotIn("dry-run", completed.stdout)
+
+    def test_retrieval_hook_missing_subject_exits_2_without_http(self) -> None:
+        completed = run_hook(
+            RETRIEVAL_HOOK,
+            "--base-url",
+            "http://127.0.0.1:9",
+            "--token",
+            "secret-token",
+        )
+        self.assertEqual(completed.returncode, 2)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["mode"], "retrieval")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["errors"][0]["code"], "missing_subject")
+        self.assertEqual(completed.stderr, "")
+        self.assertNotIn("secret-token", completed.stdout)
+
+    def test_save_hook_help_exposes_required_modes(self) -> None:
+        completed = run_hook(SAVE_HOOK, "--help")
+        self.assertEqual(completed.returncode, 0)
+        for token in ("facts", "template", "dry-run", "write", "readback", "doctor"):
+            self.assertIn(token, completed.stdout)
+
+    def test_facts_output_contains_exact_required_help_links(self) -> None:
+        completed = run_hook(SAVE_HOOK, "facts", "--subject-kind", "thread", "--subject-id", "issue-289")
+        self.assertEqual(completed.returncode, 0)
+        payload = json.loads(completed.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["result"]["help_links"], REQUIRED_HELP_LINKS)
+
+    def test_template_emits_schema_aligned_skeleton(self) -> None:
+        completed = run_hook(SAVE_HOOK, "template", "--subject-kind", "thread", "--subject-id", "issue-289")
+        self.assertEqual(completed.returncode, 0)
+        payload = json.loads(completed.stdout)["result"]["payload"]
+        self.assertEqual(payload["capsule"]["schema_version"], "1.1")
+        self.assertIn("updated_at", payload["capsule"])
+        self.assertIn("verified_at", payload["capsule"])
+        self.assertIn("retrieval_hints", payload["capsule"]["continuity"])
+
+    def test_dry_run_rejects_placeholders_before_write(self) -> None:
+        completed = run_hook(SAVE_HOOK, "template")
+        template_payload = json.loads(completed.stdout)["result"]["payload"]
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json") as handle:
+            json.dump(template_payload, handle)
+            handle.flush()
+            dry_run = run_hook(SAVE_HOOK, "dry-run", "--input", handle.name)
+        self.assertEqual(dry_run.returncode, 2)
+        payload = json.loads(dry_run.stdout)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["result"]["valid"], False)
+        self.assertTrue(payload["result"]["placeholder_errors"])
+
+    def test_dry_run_valid_payload_returns_deterministic_diff_without_server(self) -> None:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json") as handle:
+            json.dump(valid_payload(), handle)
+            handle.flush()
+            completed = run_hook(SAVE_HOOK, "dry-run", "--input", handle.name)
+        self.assertEqual(completed.returncode, 0)
+        payload = json.loads(completed.stdout)
+        diff = payload["result"]["diff"]
+        self.assertEqual(set(diff), {"current_available", "added", "removed", "changed"})
+        self.assertFalse(diff["current_available"])
+        self.assertEqual(diff["removed"], [])
+        self.assertEqual(diff["changed"], [])
+        self.assertEqual([item["path"] for item in diff["added"]], sorted(item["path"] for item in diff["added"]))
+        self.assertIn("/capsule/continuity/stance_summary", {item["path"] for item in diff["added"]})
+        self.assertNotIn("/subject_kind", {item["path"] for item in diff["added"]})
+
+    def test_server_compare_not_implemented_without_contacting_server(self) -> None:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json") as handle:
+            json.dump(valid_payload(), handle)
+            handle.flush()
+            completed = run_hook(
+                SAVE_HOOK,
+                "dry-run",
+                "--input",
+                handle.name,
+                "--server-compare",
+                "--base-url",
+                "http://127.0.0.1:9",
+                "--token",
+                "secret-token",
+            )
+        self.assertEqual(completed.returncode, 2)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["errors"][0]["code"], "server_compare_not_implemented")
+        self.assertEqual(completed.stderr, "")
+
+    def test_docs_link_to_shipped_paths(self) -> None:
+        onboarding = (ROOT / "docs" / "agent-onboarding.md").read_text(encoding="utf-8")
+        index = (ROOT / "docs" / "index.md").read_text(encoding="utf-8")
+        for token in (
+            "agent-assets/README.md",
+            "agent-assets/skills/cognirelay-continuity-authoring/SKILL.md",
+            "agent-assets/hooks/cognirelay_retrieval_hook.py",
+            "agent-assets/hooks/cognirelay_continuity_save_hook.py",
+        ):
+            self.assertIn(token, onboarding)
+        self.assertIn("../agent-assets/README.md", index)
+
+
+class TestLastMileRuntimeHelp289(unittest.TestCase):
+    """Verify HTTP and MCP discovery for the last-mile adapter topic."""
+
+    _HEADERS = {"authorization": "Bearer last-mile-topic"}
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._client_context = TestClient(app)
+        cls.client = cls._client_context.__enter__()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls._client_context.__exit__(None, None, None)
+
+    def setUp(self) -> None:
+        reset_bootstrap_state()
+
+    def _bootstrap(self) -> None:
+        response = self.client.post(
+            "/v1/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-11-25"}},
+            headers=self._HEADERS,
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_help_topic_returns_required_guidance(self) -> None:
+        response = self.client.get("/v1/help/topics/last-mile-adapter")
+        self.assertEqual(response.status_code, 200)
+        text = json.dumps(response.json(), sort_keys=True)
+        for token in (
+            "CogniRelay is the substrate",
+            "agent authors semantic fields",
+            "agent-assets/skills/cognirelay-continuity-authoring/SKILL.md",
+            "agent-assets/hooks/cognirelay_retrieval_hook.py",
+            "agent-assets/hooks/cognirelay_continuity_save_hook.py",
+            "facts",
+            "template",
+            "dry-run",
+            "write",
+            "readback",
+            "semantic inference",
+        ):
+            self.assertIn(token, text)
+
+    def test_root_and_unsupported_topic_hints_include_last_mile_adapter(self) -> None:
+        root = self.client.get("/v1/help").json()
+        self.assertIn("last-mile-adapter", root["non_tool_topics"])
+        response = self.client.get("/v1/help/topics/not-a-topic")
+        self.assertEqual(response.status_code, 400)
+        hint = response.json()["error"]["validation_hints"][0]
+        self.assertIn("last-mile-adapter", hint["allowed_values"])
+        self.assertIn("last-mile-adapter", hint["correction_hint"])
+
+    def test_system_topic_help_preserves_compact_shape(self) -> None:
+        self._bootstrap()
+        response = self.client.post(
+            "/v1/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "system.topic_help", "params": {"id": "last-mile-adapter"}},
+            headers=self._HEADERS,
+        )
+        self.assertEqual(response.status_code, 200)
+        structured = response.json()["result"]["structuredContent"]
+        self.assertEqual(set(structured), {"surface", "httpEquivalent", "id", "title", "summary"})
+        self.assertEqual(structured["httpEquivalent"], "/v1/help/topics/last-mile-adapter")
+        summary = structured["summary"]
+        for token in ("CogniRelay is the substrate", "agent authors semantic fields", "semantic inference"):
+            self.assertIn(token, summary)

--- a/tests/test_agent_assets_289.py
+++ b/tests/test_agent_assets_289.py
@@ -37,7 +37,7 @@ REQUIRED_HELP_LINKS = {
 class RecordingHTTPServer:
     """Small local JSON server for hook subprocess tests."""
 
-    def __init__(self, responses: list[tuple[int, dict[str, Any] | str]]) -> None:
+    def __init__(self, responses: list[tuple[int, dict[str, Any] | str] | tuple[int, dict[str, Any] | str, str]]) -> None:
         self.requests: list[dict[str, Any]] = []
         self._responses = list(responses)
         owner = self
@@ -53,9 +53,11 @@ class RecordingHTTPServer:
                         "body": json.loads(raw_body) if raw_body else {},
                     }
                 )
-                status, body = owner._responses.pop(0) if owner._responses else (200, {})
+                response = owner._responses.pop(0) if owner._responses else (200, {})
+                status, body = response[:2]
+                reason = response[2] if len(response) == 3 else None
                 encoded = body if isinstance(body, str) else json.dumps(body)
-                self.send_response(status)
+                self.send_response(status, reason)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(encoded.encode("utf-8"))))
                 self.end_headers()
@@ -214,6 +216,27 @@ class TestAgentAssets289(unittest.TestCase):
         self.assertEqual(payload["errors"][0]["code"], "http_error")
         self.assertNotIn("body", payload["result"])
 
+    def test_retrieval_http_error_reason_phrase_does_not_print_token(self) -> None:
+        token = "secret-token-289"
+        with RecordingHTTPServer([(500, {"error": "omitted"}, f"reflected {token}")]) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                token,
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+            )
+        self.assertEqual(completed.returncode, 4)
+        self.assertNotIn(token, completed.stdout)
+        self.assertNotIn(token, completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["errors"], [{"code": "http_error", "message": "HTTP request failed."}])
+        self.assertEqual(payload["result"], {"status": 500})
+
     def test_cli_overrides_env_for_retrieval_request_construction(self) -> None:
         with RecordingHTTPServer([(200, {"capsule": {"subject_id": "cli-subject"}})]) as server:
             completed = run_hook(
@@ -270,6 +293,52 @@ class TestAgentAssets289(unittest.TestCase):
             completed = run_hook(RETRIEVAL_HOOK, "--base-url", server.url, "--token", "secret-token")
         self.assertEqual(completed.returncode, 2)
         self.assertEqual(server.requests, [])
+
+    def test_context_retrieve_with_task_reads_startup_then_context(self) -> None:
+        with RecordingHTTPServer(
+            [
+                (200, {"capsule": {"subject_id": "issue-289"}}),
+                (200, {"items": [{"text": "context"}]}),
+            ]
+        ) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+                "--context-retrieve",
+                "--task",
+                "retrieve context",
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual([request["path"] for request in server.requests], ["/v1/continuity/read", "/v1/context/retrieve"])
+        self.assertEqual(
+            server.requests[1]["body"],
+            {"task": "retrieve context", "subject_kind": "thread", "subject_id": "issue-289"},
+        )
+
+    def test_context_retrieve_without_task_reads_only_startup(self) -> None:
+        with RecordingHTTPServer([(200, {"capsule": {"subject_id": "issue-289"}})]) as server:
+            completed = run_hook(
+                RETRIEVAL_HOOK,
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+                "--context-retrieve",
+            )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual([request["path"] for request in server.requests], ["/v1/continuity/read"])
+        self.assertNotIn("context", json.loads(completed.stdout)["result"])
 
     def test_save_hook_help_exposes_required_modes(self) -> None:
         completed = run_hook(SAVE_HOOK, "--help")
@@ -343,6 +412,68 @@ class TestAgentAssets289(unittest.TestCase):
         self.assertEqual(payload["warnings"][0]["code"], "current_state_unavailable")
         self.assertNotIn("current_state", payload["result"])
 
+    def test_save_http_error_reason_phrase_does_not_print_token(self) -> None:
+        token = "secret-token-289"
+        with RecordingHTTPServer([(500, {"error": "omitted"}, f"reflected {token}")]) as server:
+            completed = run_hook(
+                SAVE_HOOK,
+                "readback",
+                "--base-url",
+                server.url,
+                "--token",
+                token,
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+            )
+        self.assertEqual(completed.returncode, 4)
+        self.assertNotIn(token, completed.stdout)
+        self.assertNotIn(token, completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["errors"], [{"code": "http_error", "message": "HTTP request failed."}])
+        self.assertEqual(payload["result"], {"status": 500})
+
+    def test_readback_reports_expected_subject_match_when_returned_subject_matches(self) -> None:
+        with RecordingHTTPServer([(200, {"subject_kind": "thread", "subject_id": "issue-289"})]) as server:
+            completed = run_hook(
+                SAVE_HOOK,
+                "readback",
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+            )
+        self.assertEqual(completed.returncode, 0)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["mode"], "readback")
+        self.assertEqual(payload["warnings"], [])
+        self.assertIs(payload["result"]["expected_subject_matched"], True)
+
+    def test_doctor_preserves_mode_and_reports_expected_subject_match(self) -> None:
+        with RecordingHTTPServer([(200, {"subject": {"kind": "thread", "id": "issue-289"}})]) as server:
+            completed = run_hook(
+                SAVE_HOOK,
+                "doctor",
+                "--base-url",
+                server.url,
+                "--token",
+                "secret-token",
+                "--subject-kind",
+                "thread",
+                "--subject-id",
+                "issue-289",
+            )
+        self.assertEqual(completed.returncode, 0)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["mode"], "doctor")
+        self.assertEqual(payload["warnings"], [])
+        self.assertIs(payload["result"]["expected_subject_matched"], True)
+
     def test_template_emits_schema_aligned_skeleton(self) -> None:
         completed = run_hook(SAVE_HOOK, "template", "--subject-kind", "thread", "--subject-id", "issue-289")
         self.assertEqual(completed.returncode, 0)
@@ -380,6 +511,26 @@ class TestAgentAssets289(unittest.TestCase):
         self.assertEqual([item["path"] for item in diff["added"]], sorted(item["path"] for item in diff["added"]))
         self.assertIn("/capsule/continuity/stance_summary", {item["path"] for item in diff["added"]})
         self.assertNotIn("/subject_kind", {item["path"] for item in diff["added"]})
+
+    def test_write_posts_exact_full_input_payload_to_upsert(self) -> None:
+        payload = valid_payload()
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json") as handle:
+            json.dump(payload, handle)
+            handle.flush()
+            with RecordingHTTPServer([(200, {"ok": True})]) as server:
+                completed = run_hook(
+                    SAVE_HOOK,
+                    "write",
+                    "--input",
+                    handle.name,
+                    "--base-url",
+                    server.url,
+                    "--token",
+                    "secret-token",
+                )
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual([request["path"] for request in server.requests], ["/v1/continuity/upsert"])
+        self.assertEqual(server.requests[0]["body"], payload)
 
     def test_server_compare_not_implemented_without_contacting_server(self) -> None:
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".json") as handle:

--- a/tests/test_help_214_slice1.py
+++ b/tests/test_help_214_slice1.py
@@ -48,6 +48,7 @@ EXPECTED_ROOT = {
         "continuity.read.startup_view",
         "continuity.read.trust_signals",
         "continuity.upsert.session_end_snapshot",
+        "last-mile-adapter",
     ],
     "hook_ids": [
         "startup",
@@ -292,6 +293,43 @@ EXPECTED_TOPICS = {
         "correction_hints": [
             "Include the base capsule and then provide session_end_snapshot as a bounded helper.",
             "Use only open_loops, top_priorities, active_constraints, stance_summary, negative_decisions, session_trajectory, and rationale_entries in session_end_snapshot.",
+        ],
+    },
+    "last-mile-adapter": {
+        "kind": "topic",
+        "id": "last-mile-adapter",
+        "purpose": (
+            "Explain the shipped last-mile adapter kit for agent-authored continuity: CogniRelay is the substrate, "
+            "the agent authors semantic fields, and adapters do no semantic inference."
+        ),
+        "when_to_use": [
+            "Use when wiring a cold-start agent runtime to CogniRelay without project-specific glue.",
+            "Use when an adapter needs the facts/template/dry-run/write/readback flow for explicit agent-authored continuity.",
+        ],
+        "read_operations": [
+            "agent-assets/hooks/cognirelay_retrieval_hook.py",
+            "POST /v1/continuity/read",
+            "POST /v1/context/retrieve",
+        ],
+        "write_operations": [
+            "agent-assets/hooks/cognirelay_continuity_save_hook.py",
+            "POST /v1/continuity/upsert",
+        ],
+        "minimal_payload": {
+            "skill_path": "agent-assets/skills/cognirelay-continuity-authoring/SKILL.md",
+            "retrieval_hook_path": "agent-assets/hooks/cognirelay_retrieval_hook.py",
+            "save_hook_path": "agent-assets/hooks/cognirelay_continuity_save_hook.py",
+            "flow": ["facts", "template", "agent-authors-semantic-fields", "dry-run", "write", "readback"],
+        },
+        "common_mistakes": [
+            "Making CogniRelay or an adapter infer stance, priorities, open loops, rationale, or next steps.",
+            "Using the read-only retrieval hook as a write path.",
+            "Turning graph_summary or schedule_context orientation into automatic continuity fields.",
+        ],
+        "correction_hints": [
+            "Treat CogniRelay as substrate and the running agent as the semantic author.",
+            "Use the shipped skill path, retrieval hook path, and continuity save hook path as copyable integration assets.",
+            "Run facts/template/dry-run/write/readback only around an explicit agent-authored continuity.upsert payload.",
         ],
     },
 }
@@ -683,8 +721,9 @@ class TestHelp214Slice1Validation(HelpHttpTestCase):
                                 "continuity.read.startup_view",
                                 "continuity.read.trust_signals",
                                 "continuity.upsert.session_end_snapshot",
+                                "last-mile-adapter",
                             ],
-                            "correction_hint": "Use one of: continuity.read.startup_view, continuity.read.trust_signals, continuity.upsert.session_end_snapshot.",
+                            "correction_hint": "Use one of: continuity.read.startup_view, continuity.read.trust_signals, continuity.upsert.session_end_snapshot, last-mile-adapter.",
                         }
                     ],
                 }


### PR DESCRIPTION
Closes #289

## Summary
- Adds shipped `agent-assets` last-mile adapter kit with a continuity-authoring skill.
- Adds real copyable Python retrieval and continuity save hooks.
- Adds docs/onboarding links and runtime help topic for `last-mile-adapter`.
- Adds MCP `system.topic_help` coverage while preserving compact structuredContent shape.
- Adds tests for hook contracts, placeholder rejection, dry-run behavior, docs links, and help/MCP discovery.

## Scope
- No project-specific glue.
- No Codex-only behavior.
- No automatic semantic inference.
- No graph/schedule/task mutation.
- No background workers, SSE, callbacks, or new server-side template endpoint.
- Runtime API behavior unchanged except help/topic additions.

## Verification
- `git diff --check`
- `./.venv/bin/python -m ruff check app tests tools agent-assets`
- `./.venv/bin/python -m unittest tests/test_agent_assets_289.py -v`
- `./.venv/bin/python -m unittest tests/test_help_214_slice1.py tests/test_help_243_runtime_onboarding_limits.py tests/test_mcp_216_slice3_help.py -v`
- `./.venv/bin/python -m unittest discover -s tests -v`
