### PR TITLE
Prepare v1.4.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.7] - 2026-04-26
+
+### Added
+
+- Added a shipped last-mile adapter kit under `agent-assets/` for
+  agent-authored continuity integration, including a copyable
+  continuity-authoring skill and real stdlib-only Python retrieval/save hooks.
+- Added runtime help topic coverage for `last-mile-adapter`, with MCP
+  `system.topic_help` parity while preserving the compact structuredContent
+  shape.
+- Added documentation links from onboarding and the GitHub Pages documentation
+  index so cold-start agents can discover the adapter kit without loading the
+  full repository.
+
+### Changed
+
+- Documented and tested the responsibility split between CogniRelay, local
+  adapters, and the running agent: hooks gather facts, template, validate, diff,
+  write, and read back, while semantic continuity fields remain agent-authored.
+
 ## [1.4.6] - 2026-04-26
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.6", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.7", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,8 @@ the [README](../README.md).
 
 ## Releases
 
-- [Latest release notes: v1.4.6](releases/v1.4.6.md)
+- [Latest release notes: v1.4.7](releases/v1.4.7.md)
+- [v1.4.6 release notes](releases/v1.4.6.md)
 - [v1.4.5 release notes](releases/v1.4.5.md)
 - [v1.4.4 release notes](releases/v1.4.4.md)
 - [v1.4.3 release notes](releases/v1.4.3.md)

--- a/docs/releases/v1.4.7.md
+++ b/docs/releases/v1.4.7.md
@@ -1,0 +1,49 @@
+# CogniRelay v1.4.7 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.7 ships the last-mile adapter kit for agent-authored
+continuity integration. It is a distribution and integration-quality release:
+the runtime API remains stable except for the added help topic, while operators
+now get copyable assets for safe agent startup/retrieval and continuity saves.
+
+## Highlights
+
+- Added `agent-assets/` with a copyable `cognirelay-continuity-authoring`
+  skill and real stdlib-only Python hooks for retrieval and continuity save
+  flows.
+- The retrieval hook performs read-only startup orientation and optional
+  bounded context retrieval, surfacing graph and schedule orientation without
+  mutating continuity, tasks, or schedule items.
+- The continuity save hook supports `facts`, `template`, `dry-run`, `write`,
+  `readback`, and `doctor` modes with deterministic JSON output, placeholder
+  rejection, local-only dry-run diffs, and readback verification.
+- Added the runtime help topic `last-mile-adapter`, available over HTTP and MCP
+  through `system.topic_help`.
+- Updated agent onboarding and the documentation index so cold-start agents can
+  discover the shipped adapter kit and the responsibility split.
+
+## Compatibility Notes
+
+- Runtime version is now `1.4.7`.
+- Existing HTTP, MCP, graph, schedule, continuity, and UI behavior is unchanged
+  except for the added help topic and documentation/assets.
+- The adapter hooks are shipped as copyable assets. They do not become server
+  runtime behavior and do not infer semantic continuity content.
+- Scheduling guidance remains bounded: agents may create one-shot reminders
+  explicitly when needed, but the adapter hooks do not create, acknowledge,
+  retire, execute, or mutate schedule items.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools agent-assets
+./.venv/bin/python -m unittest tests/test_agent_assets_289.py -v
+./.venv/bin/python -m unittest tests/test_help_214_slice1.py tests/test_help_243_runtime_onboarding_limits.py tests/test_mcp_216_slice3_help.py -v
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary
- Bumps runtime version to 1.4.7.
- Adds v1.4.7 release notes for the shipped last-mile adapter kit.
- Updates CHANGELOG and docs release index.

## Verification
- `git diff --check`
- `./.venv/bin/python -m ruff check app tests tools agent-assets`
- `./.venv/bin/python -m unittest tests/test_agent_assets_289.py -v`
- `./.venv/bin/python -m unittest tests/test_help_214_slice1.py tests/test_help_243_runtime_onboarding_limits.py tests/test_mcp_216_slice3_help.py -v`
- `./.venv/bin/python -m unittest discover -s tests -v` ran 2227 tests OK
