### PR TITLE
Fix shipped continuity skill frontmatter

### DIFF
--- a/agent-assets/skills/cognirelay-continuity-authoring/SKILL.md
+++ b/agent-assets/skills/cognirelay-continuity-authoring/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: cognirelay-continuity-authoring
+description: Use when maintaining CogniRelay continuity responsibly from an agent runtime. The agent authors semantic capsule meaning; hooks and adapters only read, gather facts, template, validate, diff,
+  write, and read back.
+---
+
 # CogniRelay Continuity Authoring
 
 Use this skill when an agent runtime needs to maintain CogniRelay continuity responsibly.

--- a/tests/test_agent_assets_289.py
+++ b/tests/test_agent_assets_289.py
@@ -161,6 +161,23 @@ class TestAgentAssets289(unittest.TestCase):
         ):
             self.assertIn(token, text)
 
+    def test_skill_has_valid_frontmatter(self) -> None:
+        text = SKILL.read_text(encoding="utf-8")
+        lines = text.splitlines()
+
+        self.assertGreaterEqual(len(lines), 4)
+        self.assertEqual(lines[0], "---")
+        self.assertEqual(lines[4], "---")
+
+        frontmatter = "\n".join(lines[1:4])
+        self.assertIn("name: cognirelay-continuity-authoring", frontmatter)
+
+        description_lines = [
+            line for line in lines[1:4] if line.startswith("description:") or line.startswith("  ")
+        ]
+        description = " ".join(line.removeprefix("description:").strip() for line in description_lines).strip()
+        self.assertTrue(description)
+
     def test_retrieval_hook_help_and_no_write_modes(self) -> None:
         completed = run_hook(RETRIEVAL_HOOK, "--help")
         self.assertEqual(completed.returncode, 0)

--- a/tests/test_agent_assets_289.py
+++ b/tests/test_agent_assets_289.py
@@ -165,17 +165,27 @@ class TestAgentAssets289(unittest.TestCase):
         text = SKILL.read_text(encoding="utf-8")
         lines = text.splitlines()
 
-        self.assertGreaterEqual(len(lines), 4)
+        self.assertGreaterEqual(len(lines), 3)
         self.assertEqual(lines[0], "---")
-        self.assertEqual(lines[4], "---")
+        self.assertIn("---", lines[1:])
 
-        frontmatter = "\n".join(lines[1:4])
+        closing_index = lines[1:].index("---") + 1
+        frontmatter_lines = lines[1:closing_index]
+        frontmatter = "\n".join(frontmatter_lines)
+
         self.assertIn("name: cognirelay-continuity-authoring", frontmatter)
 
-        description_lines = [
-            line for line in lines[1:4] if line.startswith("description:") or line.startswith("  ")
-        ]
-        description = " ".join(line.removeprefix("description:").strip() for line in description_lines).strip()
+        description = ""
+        for index, line in enumerate(frontmatter_lines):
+            if not line.startswith("description:"):
+                continue
+            description_parts = [line.removeprefix("description:").strip()]
+            for continuation in frontmatter_lines[index + 1 :]:
+                if not continuation.startswith("  "):
+                    break
+                description_parts.append(continuation.strip())
+            description = " ".join(description_parts).strip()
+            break
         self.assertTrue(description)
 
     def test_retrieval_hook_help_and_no_write_modes(self) -> None:


### PR DESCRIPTION
Closes #294

## Summary
- Adds YAML frontmatter to the shipped `cognirelay-continuity-authoring` skill.
- Adds a flexible regression test that validates the frontmatter block without overfitting line positions.
- Keeps the existing skill body and responsibility split unchanged.

## Verification
- `git diff --check`
- `./.venv/bin/python -m ruff check app tests tools agent-assets`
- `./.venv/bin/python -m unittest tests/test_agent_assets_289.py -v`
- `./.venv/bin/python -m unittest discover -s tests -v`
