### PR TITLE
Prepare v1.4.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.8] - 2026-04-26
+
+### Fixed
+
+- Added YAML frontmatter to the shipped
+  `cognirelay-continuity-authoring` skill so common skill loaders accept the
+  asset copied from `agent-assets/`.
+- Added flexible regression coverage that validates the skill frontmatter block
+  without depending on hard-coded line positions.
+
 ## [1.4.7] - 2026-04-26
 
 ### Added

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.7", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.8", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,8 @@ the [README](../README.md).
 
 ## Releases
 
-- [Latest release notes: v1.4.7](releases/v1.4.7.md)
+- [Latest release notes: v1.4.8](releases/v1.4.8.md)
+- [v1.4.7 release notes](releases/v1.4.7.md)
 - [v1.4.6 release notes](releases/v1.4.6.md)
 - [v1.4.5 release notes](releases/v1.4.5.md)
 - [v1.4.4 release notes](releases/v1.4.4.md)

--- a/docs/releases/v1.4.8.md
+++ b/docs/releases/v1.4.8.md
@@ -1,0 +1,37 @@
+# CogniRelay v1.4.8 Release Notes
+
+Release date: 2026-04-26
+
+CogniRelay v1.4.8 is a focused packaging compatibility patch for the shipped
+last-mile adapter skill. It fixes the `cognirelay-continuity-authoring` skill
+from v1.4.7 so common skill loaders can accept it directly from
+`agent-assets/`.
+
+## Highlights
+
+- Added YAML frontmatter to the shipped `cognirelay-continuity-authoring`
+  skill.
+- Preserved the existing skill body and responsibility split: CogniRelay is the
+  substrate, the running agent authors semantic continuity fields, and hooks or
+  adapters do not infer semantic meaning.
+- Added a flexible regression test that validates the frontmatter block without
+  overfitting line positions.
+
+## Compatibility Notes
+
+- Runtime version is now `1.4.8`.
+- Existing HTTP, MCP, graph, schedule, continuity, UI, and adapter-hook behavior
+  is unchanged.
+- The `GET /v1/capabilities` `version` field remains the capability schema
+  version (`"1"`).
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools agent-assets
+./.venv/bin/python -m unittest tests/test_agent_assets_289.py -v
+./.venv/bin/python -m unittest discover -s tests -v
+```


### PR DESCRIPTION
## Summary
- Bumps runtime version to `1.4.8`.
- Adds v1.4.8 changelog and release notes for the shipped skill frontmatter compatibility fix.
- Updates the docs release index.

## Verification
- `git diff --check`
- `./.venv/bin/python -m ruff check app tests tools agent-assets`
- `./.venv/bin/python -m unittest tests/test_agent_assets_289.py -v`
- `./.venv/bin/python -m unittest discover -s tests -v`
