### PR TITLE
Add local release version sync helper

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Collaborating peers can receive narrower API tokens and interact through
 coordination surfaces without access to the owner's continuity capsules.
 
 For the full product introduction, installation notes, and feature summary, see
-the [README](../README.md).
+the [README](https://github.com/stef-k/CogniRelay/blob/main/README.md).
 
 ## Documentation
 

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -455,6 +455,7 @@ class PrepareReleaseCliTests(unittest.TestCase):
         self.assertEqual(payload["checked"], [])
         self.assertEqual(payload["updated"], [])
         self.assertEqual(len(payload["errors"]), 1)
+        self.assertFalse(payload["dry_run"])
 
     def test_invalid_version_date_and_title_exit_2(self) -> None:
         cases = [
@@ -467,6 +468,20 @@ class PrepareReleaseCliTests(unittest.TestCase):
                 proc = self._run_cli(*args)
                 self.assertEqual(proc.returncode, 2)
                 self.assertFalse(json.loads(proc.stdout)["ok"])
+
+    def test_update_dry_run_validation_failures_preserve_dry_run_flag(self) -> None:
+        cases = [
+            ("update", "--version", "bad", "--title", "T", "--dry-run"),
+            ("update", "--version", "1.4.9", "--title", "T", "--date", "bad-date", "--dry-run"),
+        ]
+        for args in cases:
+            with self.subTest(args=args):
+                proc = self._run_cli(*args)
+                payload = json.loads(proc.stdout)
+
+                self.assertEqual(proc.returncode, 2)
+                self.assertFalse(payload["ok"])
+                self.assertTrue(payload["dry_run"])
 
     def test_dirty_worktree_exits_2_unless_allowed(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -143,6 +143,41 @@ class PrepareReleaseTests(unittest.TestCase):
             self.assertEqual(result["errors"][0]["code"], "changelog_date_mismatch")
             self.assertEqual(changelog.read_text(encoding="utf-8").count("## [1.4.9]"), 1)
 
+    def test_update_rejects_out_of_order_existing_changelog_release_without_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            changelog = root / "CHANGELOG.md"
+            changelog.write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n\n"
+                "## [1.4.9] - 2026-04-27\n\n"
+                "### Changed\n\n"
+                "- Current release in the wrong position.\n",
+                encoding="utf-8",
+            )
+            tracked_paths = [
+                root / "app" / "main.py",
+                root / "CHANGELOG.md",
+                root / "docs" / "index.md",
+                root / "docs" / "releases" / "v1.4.8.md",
+            ]
+            before = {path: path.read_bytes() for path in tracked_paths}
+            new_notes = root / "docs" / "releases" / "v1.4.9.md"
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 1)
+            self.assertIn("changelog_release_out_of_order", {error["code"] for error in result["errors"]})
+            self.assertEqual({path: path.read_bytes() for path in tracked_paths}, before)
+            self.assertFalse(new_notes.exists())
+            text = changelog.read_text(encoding="utf-8")
+            self.assertEqual(text.count("## [1.4.9]"), 1)
+
     def test_update_conflict_writes_no_release_surfaces(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -33,7 +33,10 @@ def _write_fixture(root: Path, *, version: str = "1.4.8", latest: str = "1.4.8")
         "## [Unreleased]\n\n"
         f"## [{latest}] - 2026-04-26\n\n"
         "### Fixed\n\n"
-        "- Previous release.\n",
+        "- Previous release.\n\n"
+        "## [1.4.7] - 2026-04-25\n\n"
+        "### Fixed\n\n"
+        "- Older release.\n",
         encoding="utf-8",
     )
     (root / "docs" / "index.md").write_text(
@@ -138,6 +141,104 @@ class PrepareReleaseTests(unittest.TestCase):
             self.assertEqual(prepare_release.exit_code_for(result), 1)
             self.assertEqual(result["errors"][0]["code"], "changelog_date_mismatch")
             self.assertEqual(changelog.read_text(encoding="utf-8").count("## [1.4.9]"), 1)
+
+    def test_update_conflict_writes_no_release_surfaces(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            notes = root / "docs" / "releases" / "v1.4.9.md"
+            notes.write_text(
+                "# CogniRelay v1.4.9 Release Notes\n\n"
+                "Release date: 2026-04-26\n\n"
+                "Conflicting existing notes.\n",
+                encoding="utf-8",
+            )
+            tracked_paths = [
+                root / "app" / "main.py",
+                root / "CHANGELOG.md",
+                root / "docs" / "index.md",
+                notes,
+            ]
+            before = {path: path.read_text(encoding="utf-8") for path in tracked_paths}
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 1)
+            self.assertIn("release_notes_conflict", {error["code"] for error in result["errors"]})
+            self.assertEqual({path: path.read_text(encoding="utf-8") for path in tracked_paths}, before)
+
+    def test_changelog_check_requires_exact_heading_line(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root, version="1.4.9", latest="1.4.8")
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "### Notes\n\n"
+                "- Mention `## [1.4.9] - 2026-04-27` in prose, not as a heading.\n\n"
+                "```text\n"
+                "## [1.4.9] - 2026-04-27\n"
+                "```\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n\n"
+                "## [1.4.7] - 2026-04-25\n\n"
+                "### Fixed\n\n"
+                "- Older release.\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "releases" / "v1.4.9.md").write_text(
+                "# CogniRelay v1.4.9 Release Notes\n\nRelease date: 2026-04-27\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "index.md").write_text(
+                "# CogniRelay Documentation\n\n"
+                "## Releases\n\n"
+                "- [Latest release notes: v1.4.9](releases/v1.4.9.md)\n"
+                "- [v1.4.8 release notes](releases/v1.4.8.md)\n",
+                encoding="utf-8",
+            )
+
+            result = prepare_release.check_release(root, "1.4.9", "2026-04-27")
+
+            self.assertFalse(result["ok"])
+            self.assertIn("changelog_release_missing", {error["code"] for error in result["errors"]})
+
+    def test_docs_index_check_requires_exact_previous_latest_from_changelog(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root, version="1.4.9", latest="1.4.9")
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [1.4.9] - 2026-04-27\n\n"
+                "### Changed\n\n"
+                "- Current release.\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n\n"
+                "## [1.4.7] - 2026-04-25\n\n"
+                "### Fixed\n\n"
+                "- Older release.\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "releases" / "v1.4.9.md").write_text(
+                "# CogniRelay v1.4.9 Release Notes\n\nRelease date: 2026-04-27\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "index.md").write_text(
+                "# CogniRelay Documentation\n\n"
+                "## Releases\n\n"
+                "- [Latest release notes: v1.4.9](releases/v1.4.9.md)\n"
+                "- [v1.4.7 release notes](releases/v1.4.7.md)\n",
+                encoding="utf-8",
+            )
+
+            result = prepare_release.check_release(root, "1.4.9", "2026-04-27")
+
+            self.assertFalse(result["ok"])
+            self.assertIn("docs_previous_latest_missing", {error["code"] for error in result["errors"]})
 
     def test_existing_matching_release_notes_are_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -1,0 +1,249 @@
+"""Tests for the local release preparation helper from issue #293."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_helper_path = Path(__file__).resolve().parents[1] / "tools" / "prepare_release.py"
+_spec = importlib.util.spec_from_file_location("prepare_release", _helper_path)
+prepare_release = importlib.util.module_from_spec(_spec)
+sys.modules["prepare_release"] = prepare_release
+_spec.loader.exec_module(prepare_release)
+
+
+def _write_fixture(root: Path, *, version: str = "1.4.8", latest: str = "1.4.8") -> None:
+    """Create the release surfaces used by the helper tests."""
+    (root / "app").mkdir(parents=True)
+    (root / "docs" / "releases").mkdir(parents=True)
+    (root / "tools").mkdir(parents=True)
+    (root / "app" / "main.py").write_text(
+        f'from fastapi import FastAPI\n\napp = FastAPI(title="CogniRelay", version="{version}")\n',
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        f"## [{latest}] - 2026-04-26\n\n"
+        "### Fixed\n\n"
+        "- Previous release.\n",
+        encoding="utf-8",
+    )
+    (root / "docs" / "index.md").write_text(
+        "# CogniRelay Documentation\n\n"
+        "## Releases\n\n"
+        f"- [Latest release notes: v{latest}](releases/v{latest}.md)\n"
+        "- [v1.4.7 release notes](releases/v1.4.7.md)\n"
+        "- [Changelog](https://github.com/stef-k/CogniRelay/blob/main/CHANGELOG.md)\n\n"
+        "## Other Links\n\n"
+        f"- [Latest release notes: v{latest}](releases/v{latest}.md)\n",
+        encoding="utf-8",
+    )
+    (root / "docs" / "releases" / f"v{latest}.md").write_text(
+        f"# CogniRelay v{latest} Release Notes\n\nRelease date: 2026-04-26\n",
+        encoding="utf-8",
+    )
+
+
+class PrepareReleaseTests(unittest.TestCase):
+    def test_check_mode_passes_on_matching_fixture(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+
+            result = prepare_release.check_release(root, "1.4.8", "2026-04-26")
+
+            self.assertTrue(result["ok"])
+            self.assertEqual([entry["surface"] for entry in result["checked"]], ["app_version", "changelog", "release_notes", "docs_index"])
+            self.assertEqual(result["updated"], [])
+
+    def test_check_mode_reports_content_mismatch_as_exit_1_class(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root, version="1.4.7")
+
+            result = prepare_release.check_release(root, "1.4.8", "2026-04-26")
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 1)
+            self.assertEqual(result["errors"][0]["code"], "version_mismatch")
+            self.assertEqual(result["errors"][0]["surface"], "app_version")
+
+    def test_update_mode_edits_only_allowed_surfaces(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            untouched = root / "docs" / "outside.md"
+            untouched.write_text("outside\n", encoding="utf-8")
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertTrue(result["ok"], result["errors"])
+            self.assertEqual(untouched.read_text(encoding="utf-8"), "outside\n")
+            self.assertIn('version="1.4.9"', (root / "app" / "main.py").read_text(encoding="utf-8"))
+            self.assertTrue((root / "docs" / "releases" / "v1.4.9.md").exists())
+            paths = {entry["path"] for entry in result["updated"]}
+            self.assertEqual(paths, {"app/main.py", "CHANGELOG.md", "docs/releases/v1.4.9.md", "docs/index.md"})
+
+    def test_update_preserves_non_empty_unreleased_content(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            changelog = root / "CHANGELOG.md"
+            changelog.write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "### Changed\n\n"
+                "- Keep this.\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n",
+                encoding="utf-8",
+            )
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertTrue(result["ok"], result["errors"])
+            text = changelog.read_text(encoding="utf-8")
+            self.assertLess(text.index("- Keep this."), text.index("## [1.4.9] - 2026-04-27"))
+            self.assertLess(text.index("## [1.4.9] - 2026-04-27"), text.index("## [1.4.8] - 2026-04-26"))
+
+    def test_update_does_not_duplicate_changelog_version_with_wrong_date(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            changelog = root / "CHANGELOG.md"
+            changelog.write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [1.4.9] - 2026-04-26\n\n"
+                "### Changed\n\n"
+                "- Existing.\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n",
+                encoding="utf-8",
+            )
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 1)
+            self.assertEqual(result["errors"][0]["code"], "changelog_date_mismatch")
+            self.assertEqual(changelog.read_text(encoding="utf-8").count("## [1.4.9]"), 1)
+
+    def test_existing_matching_release_notes_are_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            notes = root / "docs" / "releases" / "v1.4.9.md"
+            notes.write_text(
+                "# CogniRelay v1.4.9 Release Notes\n\n"
+                "Release date: 2026-04-27\n\n"
+                "Custom prose.\n",
+                encoding="utf-8",
+            )
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertTrue(result["ok"], result["errors"])
+            self.assertIn("Custom prose.", notes.read_text(encoding="utf-8"))
+            release_entry = next(entry for entry in result["updated"] if entry["surface"] == "release_notes")
+            self.assertEqual(release_entry["action"], "unchanged")
+
+    def test_docs_index_update_is_bounded_to_release_list(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertTrue(result["ok"], result["errors"])
+            text = (root / "docs" / "index.md").read_text(encoding="utf-8")
+            releases_block = text.split("## Releases", 1)[1].split("## Other Links", 1)[0]
+            self.assertIn("- [Latest release notes: v1.4.9](releases/v1.4.9.md)", releases_block)
+            self.assertIn("- [v1.4.8 release notes](releases/v1.4.8.md)", releases_block)
+            self.assertIn("- [Latest release notes: v1.4.8](releases/v1.4.8.md)", text.split("## Other Links", 1)[1])
+
+    def test_dry_run_writes_no_files_and_reports_would_write(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            before = (root / "app" / "main.py").read_text(encoding="utf-8")
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=True)
+
+            self.assertTrue(result["ok"], result["errors"])
+            self.assertTrue(result["dry_run"])
+            self.assertEqual((root / "app" / "main.py").read_text(encoding="utf-8"), before)
+            self.assertTrue(all("would_write" in entry for entry in result["updated"]))
+            self.assertFalse((root / "docs" / "releases" / "v1.4.9.md").exists())
+
+
+class PrepareReleaseCliTests(unittest.TestCase):
+    def _run_cli(self, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(_helper_path), *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_parser_validation_failures_emit_single_json_object(self) -> None:
+        proc = self._run_cli()
+
+        self.assertEqual(proc.returncode, 2)
+        payload = json.loads(proc.stdout)
+        self.assertFalse(payload["ok"])
+        self.assertIsNone(payload["mode"])
+        self.assertIsNone(payload["version"])
+        self.assertEqual(payload["checked"], [])
+        self.assertEqual(payload["updated"], [])
+        self.assertEqual(len(payload["errors"]), 1)
+
+    def test_invalid_version_date_and_title_exit_2(self) -> None:
+        cases = [
+            ("check", "--version", "1.2"),
+            ("check", "--version", "1.2.3", "--date", "2026-02-30"),
+            ("update", "--version", "1.2.3", "--title", "bad\ntitle"),
+        ]
+        for args in cases:
+            with self.subTest(args=args):
+                proc = self._run_cli(*args)
+                self.assertEqual(proc.returncode, 2)
+                self.assertFalse(json.loads(proc.stdout)["ok"])
+
+    def test_dirty_worktree_exits_2_unless_allowed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True, text=True)
+            subprocess.run(["git", "add", "."], cwd=root, check=True, capture_output=True, text=True)
+            git_env = {
+                **os.environ,
+                "GIT_AUTHOR_NAME": "Test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "Test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+            subprocess.run(["git", "commit", "-m", "fixture"], cwd=root, check=True, capture_output=True, text=True, env=git_env)
+            (root / "untracked.txt").write_text("dirty\n", encoding="utf-8")
+
+            dirty = self._run_cli("check", "--version", "1.4.8", "--date", "2026-04-26", cwd=root)
+            allowed = self._run_cli("check", "--version", "1.4.8", "--date", "2026-04-26", "--allow-dirty", cwd=root)
+
+            self.assertEqual(dirty.returncode, 2)
+            self.assertEqual(json.loads(dirty.stdout)["errors"][0]["code"], "dirty_worktree")
+            self.assertEqual(allowed.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 
@@ -205,6 +206,38 @@ class PrepareReleaseTests(unittest.TestCase):
             self.assertFalse(result["ok"])
             self.assertIn("changelog_release_missing", {error["code"] for error in result["errors"]})
 
+    def test_changelog_check_requires_requested_release_before_older_releases(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root, version="1.4.9", latest="1.4.9")
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n\n"
+                "## [1.4.9] - 2026-04-27\n\n"
+                "### Changed\n\n"
+                "- Current release in the wrong position.\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "releases" / "v1.4.9.md").write_text(
+                "# CogniRelay v1.4.9 Release Notes\n\nRelease date: 2026-04-27\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "index.md").write_text(
+                "# CogniRelay Documentation\n\n"
+                "## Releases\n\n"
+                "- [Latest release notes: v1.4.9](releases/v1.4.9.md)\n"
+                "- [v1.4.8 release notes](releases/v1.4.8.md)\n",
+                encoding="utf-8",
+            )
+
+            result = prepare_release.check_release(root, "1.4.9", "2026-04-27")
+
+            self.assertFalse(result["ok"])
+            self.assertIn("changelog_release_missing", {error["code"] for error in result["errors"]})
+
     def test_docs_index_check_requires_exact_previous_latest_from_changelog(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -337,6 +370,33 @@ class PrepareReleaseTests(unittest.TestCase):
             self.assertEqual((root / "app" / "main.py").read_text(encoding="utf-8"), before)
             self.assertTrue(all("would_write" in entry for entry in result["updated"]))
             self.assertFalse((root / "docs" / "releases" / "v1.4.9.md").exists())
+
+    def test_update_rolls_back_earlier_writes_when_later_write_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            tracked_paths = [
+                root / "app" / "main.py",
+                root / "CHANGELOG.md",
+                root / "docs" / "index.md",
+            ]
+            before = {path: path.read_bytes() for path in tracked_paths}
+            notes = root / "docs" / "releases" / "v1.4.9.md"
+            original_write_text = prepare_release.write_text
+
+            def fail_docs_index(path: Path, root: Path, surface: str, content: str) -> None:
+                if surface == "docs_index":
+                    raise prepare_release.SurfaceError("write_failed", "cannot write docs/index.md", surface, "docs/index.md")
+                original_write_text(path, root, surface, content)
+
+            with mock.patch.object(prepare_release, "write_text", side_effect=fail_docs_index):
+                result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 3)
+            self.assertEqual(result["errors"][0]["code"], "write_failed")
+            self.assertEqual({path: path.read_bytes() for path in tracked_paths}, before)
+            self.assertFalse(notes.exists())
 
 
 class PrepareReleaseCliTests(unittest.TestCase):

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -240,6 +240,57 @@ class PrepareReleaseTests(unittest.TestCase):
             self.assertFalse(result["ok"])
             self.assertIn("docs_previous_latest_missing", {error["code"] for error in result["errors"]})
 
+    def test_docs_index_update_repairs_current_latest_with_wrong_previous_link(self) -> None:
+        cases = {
+            "missing": "",
+            "wrong": "- [v1.4.7 release notes](releases/v1.4.7.md)\n",
+        }
+        for name, existing_previous in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                _write_fixture(root, version="1.4.9", latest="1.4.9")
+                (root / "CHANGELOG.md").write_text(
+                    "# Changelog\n\n"
+                    "## [Unreleased]\n\n"
+                    "## [1.4.9] - 2026-04-27\n\n"
+                    "### Changed\n\n"
+                    "- Current release.\n\n"
+                    "## [1.4.8] - 2026-04-26\n\n"
+                    "### Fixed\n\n"
+                    "- Previous release.\n\n"
+                    "## [1.4.7] - 2026-04-25\n\n"
+                    "### Fixed\n\n"
+                    "- Older release.\n",
+                    encoding="utf-8",
+                )
+                (root / "docs" / "releases" / "v1.4.9.md").write_text(
+                    "# CogniRelay v1.4.9 Release Notes\n\nRelease date: 2026-04-27\n",
+                    encoding="utf-8",
+                )
+                (root / "docs" / "index.md").write_text(
+                    "# CogniRelay Documentation\n\n"
+                    "## Releases\n\n"
+                    "- [Latest release notes: v1.4.9](releases/v1.4.9.md)\n"
+                    f"{existing_previous}"
+                    "- [v1.4.9 release notes](releases/v1.4.9.md)\n"
+                    "- [Changelog](https://github.com/stef-k/CogniRelay/blob/main/CHANGELOG.md)\n\n"
+                    "## Other Links\n\n"
+                    "- [Latest release notes: v1.4.9](releases/v1.4.9.md)\n",
+                    encoding="utf-8",
+                )
+
+                result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+                self.assertTrue(result["ok"], result["errors"])
+                text = (root / "docs" / "index.md").read_text(encoding="utf-8")
+                releases_block = text.split("## Releases", 1)[1].split("## Other Links", 1)[0]
+                release_lines = releases_block.strip().splitlines()
+                self.assertEqual(release_lines[0], "- [Latest release notes: v1.4.9](releases/v1.4.9.md)")
+                self.assertEqual(release_lines[1], "- [v1.4.8 release notes](releases/v1.4.8.md)")
+                self.assertNotIn("- [v1.4.9 release notes](releases/v1.4.9.md)", releases_block)
+                check = prepare_release.check_release(root, "1.4.9", "2026-04-27")
+                self.assertTrue(check["ok"], check["errors"])
+
     def test_existing_matching_release_notes_are_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -178,6 +178,81 @@ class PrepareReleaseTests(unittest.TestCase):
             text = changelog.read_text(encoding="utf-8")
             self.assertEqual(text.count("## [1.4.9]"), 1)
 
+    def test_check_rejects_duplicate_target_changelog_release(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root, version="1.4.9", latest="1.4.9")
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [1.4.9] - 2026-04-27\n\n"
+                "### Changed\n\n"
+                "- Current release.\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n\n"
+                "## [1.4.9] - 2026-04-27\n\n"
+                "### Changed\n\n"
+                "- Duplicate release.\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "releases" / "v1.4.9.md").write_text(
+                "# CogniRelay v1.4.9 Release Notes\n\nRelease date: 2026-04-27\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "index.md").write_text(
+                "# CogniRelay Documentation\n\n"
+                "## Releases\n\n"
+                "- [Latest release notes: v1.4.9](releases/v1.4.9.md)\n"
+                "- [v1.4.8 release notes](releases/v1.4.8.md)\n",
+                encoding="utf-8",
+            )
+
+            result = prepare_release.check_release(root, "1.4.9", "2026-04-27")
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 1)
+            self.assertIn("changelog_release_duplicate", {error["code"] for error in result["errors"]})
+
+    def test_update_rejects_duplicate_target_changelog_release_without_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root, version="1.4.9", latest="1.4.9")
+            changelog = root / "CHANGELOG.md"
+            changelog.write_text(
+                "# Changelog\n\n"
+                "## [Unreleased]\n\n"
+                "## [1.4.9] - 2026-04-27\n\n"
+                "### Changed\n\n"
+                "- Current release.\n\n"
+                "## [1.4.8] - 2026-04-26\n\n"
+                "### Fixed\n\n"
+                "- Previous release.\n\n"
+                "## [1.4.9] - 2026-04-27\n\n"
+                "### Changed\n\n"
+                "- Duplicate release.\n",
+                encoding="utf-8",
+            )
+            (root / "docs" / "releases" / "v1.4.9.md").write_text(
+                "# CogniRelay v1.4.9 Release Notes\n\nRelease date: 2026-04-27\n",
+                encoding="utf-8",
+            )
+            tracked_paths = [
+                root / "app" / "main.py",
+                root / "CHANGELOG.md",
+                root / "docs" / "index.md",
+                root / "docs" / "releases" / "v1.4.9.md",
+            ]
+            before = {path: path.read_bytes() for path in tracked_paths}
+
+            result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 1)
+            self.assertIn("changelog_release_duplicate", {error["code"] for error in result["errors"]})
+            self.assertEqual({path: path.read_bytes() for path in tracked_paths}, before)
+            self.assertEqual(changelog.read_text(encoding="utf-8").count("## [1.4.9]"), 2)
+
     def test_update_conflict_writes_no_release_surfaces(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -432,6 +507,36 @@ class PrepareReleaseTests(unittest.TestCase):
             self.assertEqual(result["errors"][0]["code"], "write_failed")
             self.assertEqual({path: path.read_bytes() for path in tracked_paths}, before)
             self.assertFalse(notes.exists())
+
+    def test_update_rolls_back_new_release_notes_parent_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write_fixture(root)
+            releases_dir = root / "docs" / "releases"
+            for child in releases_dir.iterdir():
+                child.unlink()
+            releases_dir.rmdir()
+            tracked_paths = [
+                root / "app" / "main.py",
+                root / "CHANGELOG.md",
+                root / "docs" / "index.md",
+            ]
+            before = {path: path.read_bytes() for path in tracked_paths}
+            original_write_text = prepare_release.write_text
+
+            def fail_docs_index(path: Path, root: Path, surface: str, content: str) -> None:
+                if surface == "docs_index":
+                    raise prepare_release.SurfaceError("write_failed", "cannot write docs/index.md", surface, "docs/index.md")
+                original_write_text(path, root, surface, content)
+
+            with mock.patch.object(prepare_release, "write_text", side_effect=fail_docs_index):
+                result = prepare_release.update_release(root, "1.4.9", "2026-04-27", "Release helper", dry_run=False)
+
+            self.assertFalse(result["ok"])
+            self.assertEqual(prepare_release.exit_code_for(result), 3)
+            self.assertEqual({path: path.read_bytes() for path in tracked_paths}, before)
+            self.assertFalse((root / "docs" / "releases" / "v1.4.9.md").exists())
+            self.assertFalse(releases_dir.exists())
 
 
 class PrepareReleaseCliTests(unittest.TestCase):

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Validate and update local CogniRelay release/version surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _datetime
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SURFACES = ("app_version", "changelog", "release_notes", "docs_index")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+CHANGELOG_HEADING_RE = re.compile(r"^## \[([0-9]+\.[0-9]+\.[0-9]+)\] - ([0-9]{4}-[0-9]{2}-[0-9]{2})$", re.MULTILINE)
+APP_VERSION_RE = re.compile(r"(FastAPI\([^)]*\bversion=)([\"'])([^\"']+)(\2)", re.DOTALL)
+LATEST_RE = re.compile(r"^- \[Latest release notes: v([0-9]+\.[0-9]+\.[0-9]+)\]\(releases/v\1\.md\)$")
+NORMAL_RELEASE_RE = re.compile(r"^- \[v([0-9]+\.[0-9]+\.[0-9]+) release notes\]\(releases/v\1\.md\)$")
+
+
+CONTENT_ERROR_CODES = {
+    "version_mismatch",
+    "changelog_release_missing",
+    "changelog_date_mismatch",
+    "release_notes_missing",
+    "release_notes_conflict",
+    "docs_latest_mismatch",
+    "docs_previous_latest_missing",
+    "docs_duplicate_release_link",
+    "docs_release_link_order",
+}
+VALIDATION_ERROR_CODES = {
+    "invalid_args",
+    "invalid_version",
+    "invalid_date",
+    "invalid_title",
+    "dirty_worktree",
+    "not_git_worktree",
+}
+
+
+@dataclass(frozen=True)
+class SurfaceError(Exception):
+    """Structured release helper error for one local surface."""
+
+    code: str
+    message: str
+    surface: str | None = None
+    path: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, "surface": self.surface, "path": self.path}
+
+
+class JsonArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser variant that raises instead of exiting."""
+
+    def error(self, message: str) -> None:
+        raise SurfaceError("invalid_args", message)
+
+
+def standard_result(
+    *,
+    ok: bool,
+    mode: str | None,
+    version: str | None,
+    date: str | None,
+    dry_run: bool = False,
+    checked: list[dict[str, Any]] | None = None,
+    updated: list[dict[str, Any]] | None = None,
+    warnings: list[dict[str, Any]] | None = None,
+    errors: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return the standard JSON-compatible result object."""
+    tag = f"v{version}" if version else None
+    return {
+        "ok": ok,
+        "mode": mode,
+        "version": version,
+        "tag": tag,
+        "date": date,
+        "dry_run": dry_run,
+        "checked": checked or [],
+        "updated": updated or [],
+        "warnings": warnings or [],
+        "errors": errors or [],
+    }
+
+
+def error_result(error: SurfaceError, *, mode: str | None = None, version: str | None = None, date: str | None = None, dry_run: bool = False) -> dict[str, Any]:
+    """Return a standard failure result containing a single error."""
+    return standard_result(ok=False, mode=mode, version=version, date=date, dry_run=dry_run, errors=[error.as_dict()])
+
+
+def update_entry(surface: str, path: str, action: str, *, dry_run: bool, would_write: bool) -> dict[str, Any]:
+    """Return an ordered update entry, including dry-run write intent when needed."""
+    entry: dict[str, Any] = {"surface": surface, "path": path, "action": action}
+    if dry_run:
+        entry["would_write"] = would_write
+    return entry
+
+
+def exit_code_for(result: dict[str, Any]) -> int:
+    """Classify the process exit code for a standard result."""
+    if result["ok"]:
+        return 0
+    codes = {error["code"] for error in result["errors"]}
+    if codes and codes <= VALIDATION_ERROR_CODES:
+        return 2
+    if codes and all(code in CONTENT_ERROR_CODES for code in codes):
+        return 1
+    return 3
+
+
+def validate_version(value: str) -> str:
+    """Return a normalized version or raise a validation error."""
+    if not VERSION_RE.fullmatch(value):
+        raise SurfaceError("invalid_version", "--version must match X.Y.Z")
+    return value
+
+
+def validate_date(value: str) -> str:
+    """Return an ISO release date after calendar validation."""
+    try:
+        return _datetime.date.fromisoformat(value).isoformat()
+    except ValueError as exc:
+        raise SurfaceError("invalid_date", "--date must be a valid YYYY-MM-DD date") from exc
+
+
+def validate_title(value: str | None) -> str:
+    """Return a stripped single-line title or raise a validation error."""
+    title = (value or "").strip()
+    if not title or "\n" in title or "\r" in title or CONTROL_RE.search(title):
+        raise SurfaceError("invalid_title", "--title must be non-empty, single-line, and contain no control characters")
+    return title
+
+
+def today_utc() -> str:
+    """Return the current UTC calendar date."""
+    return _datetime.datetime.now(_datetime.timezone.utc).date().isoformat()
+
+
+def rel_path(path: Path, root: Path) -> str:
+    """Return a POSIX path relative to the repository root."""
+    return path.relative_to(root).as_posix()
+
+
+def read_text(path: Path, root: Path, surface: str) -> str:
+    """Read a required UTF-8 file or raise a structured IO error."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SurfaceError("read_failed", f"cannot read {rel_path(path, root)}: {exc}", surface, rel_path(path, root)) from exc
+
+
+def write_text(path: Path, root: Path, surface: str, content: str) -> None:
+    """Write a UTF-8 file or raise a structured IO error."""
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise SurfaceError("write_failed", f"cannot write {rel_path(path, root)}: {exc}", surface, rel_path(path, root)) from exc
+
+
+def ensure_parent(path: Path, root: Path, surface: str) -> None:
+    """Create a file parent directory when the contract allows it."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise SurfaceError("write_failed", f"cannot create {rel_path(path.parent, root)}: {exc}", surface, rel_path(path.parent, root)) from exc
+
+
+def check_app_version(root: Path, version: str) -> dict[str, Any] | SurfaceError:
+    """Validate the FastAPI app version assignment."""
+    path = root / "app" / "main.py"
+    text = read_text(path, root, "app_version")
+    match = APP_VERSION_RE.search(text)
+    if not match:
+        raise SurfaceError("app_version_parse_failed", "FastAPI app version assignment was not found", "app_version", rel_path(path, root))
+    if match.group(3) != version:
+        return SurfaceError("version_mismatch", f"FastAPI app version is {match.group(3)}, expected {version}", "app_version", rel_path(path, root))
+    return {"surface": "app_version", "path": rel_path(path, root), "ok": True}
+
+
+def update_app_version(root: Path, version: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError]:
+    """Update the FastAPI app version assignment if needed."""
+    path = root / "app" / "main.py"
+    text = read_text(path, root, "app_version")
+    match = APP_VERSION_RE.search(text)
+    if not match:
+        raise SurfaceError("app_version_parse_failed", "FastAPI app version assignment was not found", "app_version", rel_path(path, root))
+    checked = {"surface": "app_version", "path": rel_path(path, root), "ok": match.group(3) == version}
+    if match.group(3) == version:
+        return checked, update_entry("app_version", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+    updated_text = text[: match.start(3)] + version + text[match.end(3) :]
+    if not dry_run:
+        write_text(path, root, "app_version", updated_text)
+    return checked, update_entry("app_version", rel_path(path, root), "updated", dry_run=dry_run, would_write=True)
+
+
+def changelog_sections(text: str, root: Path, path: Path) -> tuple[re.Match[str], re.Match[str]]:
+    """Return the Unreleased heading and first older release heading."""
+    unreleased = re.search(r"^## \[Unreleased\]$", text, re.MULTILINE)
+    if not unreleased:
+        raise SurfaceError("changelog_parse_failed", "missing ## [Unreleased] heading", "changelog", rel_path(path, root))
+    older = CHANGELOG_HEADING_RE.search(text, unreleased.end())
+    if not older:
+        raise SurfaceError("changelog_parse_failed", "missing older release heading after ## [Unreleased]", "changelog", rel_path(path, root))
+    return unreleased, older
+
+
+def check_changelog(root: Path, version: str, date: str) -> dict[str, Any] | SurfaceError:
+    """Validate the requested changelog release heading."""
+    path = root / "CHANGELOG.md"
+    text = read_text(path, root, "changelog")
+    unreleased, older = changelog_sections(text, root, path)
+    heading = f"## [{version}] - {date}"
+    search_end = CHANGELOG_HEADING_RE.search(text, older.end())
+    boundary = search_end.start() if search_end else len(text)
+    if heading not in text[unreleased.end() : boundary]:
+        version_heading = re.search(rf"^## \[{re.escape(version)}\] - ([0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}})$", text[unreleased.end() : boundary], re.MULTILINE)
+        if version_heading:
+            return SurfaceError("changelog_date_mismatch", f"changelog release {version} has date {version_heading.group(1)}, expected {date}", "changelog", rel_path(path, root))
+        return SurfaceError("changelog_release_missing", f"changelog release heading {heading} is missing", "changelog", rel_path(path, root))
+    return {"surface": "changelog", "path": rel_path(path, root), "ok": True}
+
+
+def update_changelog(root: Path, version: str, date: str, title: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Insert the generated changelog section if it is absent."""
+    path = root / "CHANGELOG.md"
+    text = read_text(path, root, "changelog")
+    unreleased, older = changelog_sections(text, root, path)
+    existing = check_changelog(root, version, date)
+    if isinstance(existing, dict):
+        return existing, update_entry("changelog", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+    if existing.code == "changelog_date_mismatch":
+        return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, existing
+
+    section = f"## [{version}] - {date}\n\n### Changed\n\n- {title}\n\n"
+    unreleased_body = text[unreleased.end() : older.start()]
+    insert_at = older.start()
+    if not unreleased_body.strip():
+        insert_at = unreleased.end()
+        if text[insert_at:].startswith("\n\n"):
+            insert_at += 2
+        elif text[insert_at:].startswith("\n"):
+            insert_at += 1
+    new_text = text[:insert_at] + section + text[insert_at:]
+    if not dry_run:
+        write_text(path, root, "changelog", new_text)
+    return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, update_entry(
+        "changelog",
+        rel_path(path, root),
+        "updated",
+        dry_run=dry_run,
+        would_write=True,
+    )
+
+
+def release_notes_path(root: Path, version: str) -> Path:
+    """Return the release notes path for a version."""
+    return root / "docs" / "releases" / f"v{version}.md"
+
+
+def check_release_notes(root: Path, version: str, date: str) -> dict[str, Any] | SurfaceError:
+    """Validate release notes heading and date line."""
+    path = release_notes_path(root, version)
+    if not path.exists():
+        return SurfaceError("release_notes_missing", f"{rel_path(path, root)} is missing", "release_notes", rel_path(path, root))
+    text = read_text(path, root, "release_notes")
+    lines = text.splitlines()
+    expected_heading = f"# CogniRelay v{version} Release Notes"
+    expected_date = f"Release date: {date}"
+    if not lines or lines[0] != expected_heading:
+        return SurfaceError("release_notes_conflict", f"release notes heading must be {expected_heading}", "release_notes", rel_path(path, root))
+    if len(lines) < 3 or lines[2] != expected_date:
+        return SurfaceError("release_notes_conflict", f"release notes date line must be {expected_date}", "release_notes", rel_path(path, root))
+    return {"surface": "release_notes", "path": rel_path(path, root), "ok": True}
+
+
+def release_notes_template(version: str, date: str, title: str) -> str:
+    """Return the deterministic release notes template."""
+    return (
+        f"# CogniRelay v{version} Release Notes\n\n"
+        f"Release date: {date}\n\n"
+        f"{title}\n\n"
+        "## Verification\n\n"
+        "Release preparation should pass:\n\n"
+        "```bash\n"
+        "git diff --check\n"
+        "./.venv/bin/python -m ruff check app tests tools agent-assets\n"
+        "./.venv/bin/python -m unittest discover -s tests -v\n"
+        "```\n"
+    )
+
+
+def update_release_notes(root: Path, version: str, date: str, title: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError]:
+    """Create release notes or preserve matching existing notes."""
+    path = release_notes_path(root, version)
+    existing = check_release_notes(root, version, date)
+    if isinstance(existing, dict):
+        return existing, update_entry("release_notes", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+    if existing.code != "release_notes_missing":
+        return {"surface": "release_notes", "path": rel_path(path, root), "ok": False}, existing
+    if not dry_run:
+        ensure_parent(path, root, "release_notes")
+        write_text(path, root, "release_notes", release_notes_template(version, date, title))
+    return {"surface": "release_notes", "path": rel_path(path, root), "ok": False}, update_entry(
+        "release_notes",
+        rel_path(path, root),
+        "created",
+        dry_run=dry_run,
+        would_write=True,
+    )
+
+
+def release_list_bounds(text: str, root: Path, path: Path) -> tuple[int, int]:
+    """Return start/end offsets for the bounded release bullet list."""
+    heading = re.search(r"^## Releases$", text, re.MULTILINE)
+    if not heading:
+        raise SurfaceError("docs_index_parse_failed", "missing ## Releases heading", "docs_index", rel_path(path, root))
+    pos = heading.end()
+    if text[pos:].startswith("\n"):
+        pos += 1
+    if text[pos:].startswith("\n"):
+        pos += 1
+    line_start = pos
+    end = pos
+    saw_list = False
+    for line in text[pos:].splitlines(keepends=True):
+        if line.startswith("## "):
+            break
+        if line.startswith("- "):
+            saw_list = True
+            end = line_start + len(line)
+        elif saw_list and line.strip():
+            break
+        elif not saw_list and line.strip():
+            raise SurfaceError("docs_index_parse_failed", "release list must begin with Markdown bullets", "docs_index", rel_path(path, root))
+        line_start += len(line)
+    if not saw_list:
+        raise SurfaceError("docs_index_parse_failed", "release list is missing after ## Releases", "docs_index", rel_path(path, root))
+    return pos, end
+
+
+def release_list_lines(root: Path) -> tuple[Path, str, int, int, list[str]]:
+    """Return docs index text and bounded release list lines."""
+    path = root / "docs" / "index.md"
+    text = read_text(path, root, "docs_index")
+    start, end = release_list_bounds(text, root, path)
+    return path, text, start, end, text[start:end].splitlines()
+
+
+def check_docs_index(root: Path, version: str) -> dict[str, Any] | SurfaceError:
+    """Validate the latest release pointer and previous latest list entry."""
+    path, _text, _start, _end, lines = release_list_lines(root)
+    expected_latest = f"- [Latest release notes: v{version}](releases/v{version}.md)"
+    if not lines or lines[0] != expected_latest:
+        return SurfaceError("docs_latest_mismatch", f"latest release pointer must be {expected_latest}", "docs_index", rel_path(path, root))
+    if len(lines) < 2 or not NORMAL_RELEASE_RE.fullmatch(lines[1]):
+        return SurfaceError("docs_previous_latest_missing", "previous latest release link must be immediately below latest pointer", "docs_index", rel_path(path, root))
+    seen: set[str] = set()
+    for line in lines[1:]:
+        match = NORMAL_RELEASE_RE.fullmatch(line)
+        if not match:
+            continue
+        release_version = match.group(1)
+        if release_version in seen or release_version == version:
+            return SurfaceError("docs_duplicate_release_link", f"duplicate or current normal release link for v{release_version}", "docs_index", rel_path(path, root))
+        seen.add(release_version)
+    return {"surface": "docs_index", "path": rel_path(path, root), "ok": True}
+
+
+def update_docs_index(root: Path, version: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError]:
+    """Update only the bounded release list in docs/index.md."""
+    path, text, start, end, lines = release_list_lines(root)
+    if not lines:
+        raise SurfaceError("docs_index_parse_failed", "release list is missing after ## Releases", "docs_index", rel_path(path, root))
+    latest_match = LATEST_RE.fullmatch(lines[0])
+    if not latest_match:
+        raise SurfaceError("docs_index_parse_failed", "first release list item must be the latest release pointer", "docs_index", rel_path(path, root))
+    previous_latest = latest_match.group(1)
+    checked = check_docs_index(root, version)
+    if isinstance(checked, dict):
+        return checked, update_entry("docs_index", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+
+    new_latest = f"- [Latest release notes: v{version}](releases/v{version}.md)"
+    previous_normal = f"- [v{previous_latest} release notes](releases/v{previous_latest}.md)"
+    remaining: list[str] = []
+    for line in lines[1:]:
+        normal = NORMAL_RELEASE_RE.fullmatch(line)
+        if normal and normal.group(1) in {version, previous_latest}:
+            continue
+        remaining.append(line)
+    new_lines = [new_latest, previous_normal, *remaining]
+    new_block = "\n".join(new_lines) + "\n"
+    new_text = text[:start] + new_block + text[end:]
+    if not dry_run:
+        write_text(path, root, "docs_index", new_text)
+    return {"surface": "docs_index", "path": rel_path(path, root), "ok": False}, update_entry(
+        "docs_index",
+        rel_path(path, root),
+        "updated",
+        dry_run=dry_run,
+        would_write=True,
+    )
+
+
+def check_release(root: Path, version: str, date: str) -> dict[str, Any]:
+    """Check local release surfaces for a requested version."""
+    checked: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    checks = (
+        lambda: check_app_version(root, version),
+        lambda: check_changelog(root, version, date),
+        lambda: check_release_notes(root, version, date),
+        lambda: check_docs_index(root, version),
+    )
+    for func in checks:
+        try:
+            result = func()
+        except SurfaceError as exc:
+            errors.append(exc.as_dict())
+            continue
+        if isinstance(result, SurfaceError):
+            errors.append(result.as_dict())
+        else:
+            checked.append(result)
+    return standard_result(ok=not errors, mode="check", version=version, date=date, checked=checked, errors=errors)
+
+
+def update_release(root: Path, version: str, date: str, title: str, *, dry_run: bool) -> dict[str, Any]:
+    """Update local release surfaces for a requested version."""
+    checked: list[dict[str, Any]] = []
+    updated: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    for func in (update_app_version, update_changelog, update_release_notes, update_docs_index):
+        try:
+            if func is update_app_version or func is update_docs_index:
+                check_entry, update_entry = func(root, version, dry_run=dry_run)
+            else:
+                check_entry, update_entry = func(root, version, date, title, dry_run=dry_run)
+        except SurfaceError as exc:
+            errors.append(exc.as_dict())
+            continue
+        checked.append(check_entry)
+        if isinstance(update_entry, SurfaceError):
+            errors.append(update_entry.as_dict())
+        else:
+            updated.append(update_entry)
+    return standard_result(ok=not errors, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments or raise a structured validation error."""
+    parser = JsonArgumentParser(prog="prepare_release.py", add_help=True)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for mode in ("check", "update"):
+        sub = subparsers.add_parser(mode)
+        sub.add_argument("--version", required=True)
+        sub.add_argument("--date", default=today_utc())
+        sub.add_argument("--allow-dirty", action="store_true")
+        if mode == "update":
+            sub.add_argument("--title", required=True)
+            sub.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def resolve_repo_root() -> Path:
+    """Resolve the git repository root from the current working directory."""
+    try:
+        proc = subprocess.run(["git", "rev-parse", "--show-toplevel"], check=False, capture_output=True, text=True)
+    except OSError as exc:
+        raise SurfaceError("not_git_worktree", f"cannot run git rev-parse: {exc}") from exc
+    if proc.returncode != 0:
+        raise SurfaceError("not_git_worktree", "current directory is not inside a git worktree")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def ensure_clean_worktree(root: Path) -> None:
+    """Fail when tracked or untracked non-ignored files are present."""
+    try:
+        proc = subprocess.run(["git", "status", "--porcelain=v1"], cwd=root, check=False, capture_output=True, text=True)
+    except OSError as exc:
+        raise SurfaceError("dirty_worktree", f"cannot inspect git status: {exc}") from exc
+    if proc.returncode != 0:
+        raise SurfaceError("dirty_worktree", "cannot inspect git status")
+    if proc.stdout:
+        raise SurfaceError("dirty_worktree", "worktree has tracked or untracked non-ignored changes")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    mode = version = date = None
+    dry_run = False
+    try:
+        args = parse_args(argv)
+        mode = args.mode
+        version = validate_version(args.version)
+        date = validate_date(args.date)
+        dry_run = bool(getattr(args, "dry_run", False))
+        title = validate_title(getattr(args, "title", None)) if mode == "update" else None
+        root = resolve_repo_root()
+        if not args.allow_dirty:
+            ensure_clean_worktree(root)
+        result = check_release(root, version, date) if mode == "check" else update_release(root, version, date, title or "", dry_run=dry_run)
+    except SurfaceError as exc:
+        result = error_result(exc, mode=mode, version=version, date=date, dry_run=dry_run)
+    print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    return exit_code_for(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -438,7 +438,7 @@ def update_docs_index(root: Path, version: str, *, dry_run: bool) -> tuple[dict[
     latest_match = LATEST_RE.fullmatch(lines[0])
     if not latest_match:
         raise SurfaceError("docs_index_parse_failed", "first release list item must be the latest release pointer", "docs_index", rel_path(path, root))
-    previous_latest = latest_match.group(1)
+    existing_latest = latest_match.group(1)
     checked = {"surface": "docs_index", "path": rel_path(path, root), "ok": lines[0] == f"- [Latest release notes: v{version}](releases/v{version}.md)"}
     if checked["ok"]:
         checked_result = check_docs_index(root, version)
@@ -447,12 +447,24 @@ def update_docs_index(root: Path, version: str, *, dry_run: bool) -> tuple[dict[
         checked = {"surface": "docs_index", "path": rel_path(path, root), "ok": False}
 
     new_latest = f"- [Latest release notes: v{version}](releases/v{version}.md)"
+    previous_latest = previous_release_from_changelog(root, version) if existing_latest == version else existing_latest
+    if previous_latest is None or previous_latest == version:
+        return checked, SurfaceError(
+            "docs_previous_latest_missing",
+            "previous latest release link must be available from CHANGELOG.md before updating docs/index.md",
+            "docs_index",
+            rel_path(path, root),
+        ), None
     previous_normal = f"- [v{previous_latest} release notes](releases/v{previous_latest}.md)"
     remaining: list[str] = []
+    seen_normal_versions = {previous_latest}
     for line in lines[1:]:
         normal = NORMAL_RELEASE_RE.fullmatch(line)
-        if normal and normal.group(1) in {version, previous_latest}:
-            continue
+        if normal:
+            release_version = normal.group(1)
+            if release_version == version or release_version in seen_normal_versions:
+                continue
+            seen_normal_versions.add(release_version)
         remaining.append(line)
     new_lines = [new_latest, previous_normal, *remaining]
     new_block = "\n".join(new_lines) + "\n"

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -57,6 +57,25 @@ class SurfaceError(Exception):
         return {"code": self.code, "message": self.message, "surface": self.surface, "path": self.path}
 
 
+@dataclass(frozen=True)
+class PlannedWrite:
+    """A validated file update to apply after all surfaces have been checked."""
+
+    path: Path
+    surface: str
+    content: str
+
+
+@dataclass(frozen=True)
+class ChangelogReleaseHeading:
+    """A changelog release heading outside fenced code blocks."""
+
+    version: str
+    date: str
+    start: int
+    end: int
+
+
 class JsonArgumentParser(argparse.ArgumentParser):
     """ArgumentParser variant that raises instead of exiting."""
 
@@ -186,8 +205,8 @@ def check_app_version(root: Path, version: str) -> dict[str, Any] | SurfaceError
     return {"surface": "app_version", "path": rel_path(path, root), "ok": True}
 
 
-def update_app_version(root: Path, version: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError]:
-    """Update the FastAPI app version assignment if needed."""
+def update_app_version(root: Path, version: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError, PlannedWrite | None]:
+    """Plan a FastAPI app version assignment update if needed."""
     path = root / "app" / "main.py"
     text = read_text(path, root, "app_version")
     match = APP_VERSION_RE.search(text)
@@ -195,54 +214,72 @@ def update_app_version(root: Path, version: str, *, dry_run: bool) -> tuple[dict
         raise SurfaceError("app_version_parse_failed", "FastAPI app version assignment was not found", "app_version", rel_path(path, root))
     checked = {"surface": "app_version", "path": rel_path(path, root), "ok": match.group(3) == version}
     if match.group(3) == version:
-        return checked, update_entry("app_version", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+        return checked, update_entry("app_version", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False), None
     updated_text = text[: match.start(3)] + version + text[match.end(3) :]
-    if not dry_run:
-        write_text(path, root, "app_version", updated_text)
-    return checked, update_entry("app_version", rel_path(path, root), "updated", dry_run=dry_run, would_write=True)
+    return checked, update_entry("app_version", rel_path(path, root), "updated", dry_run=dry_run, would_write=True), PlannedWrite(path, "app_version", updated_text)
 
 
-def changelog_sections(text: str, root: Path, path: Path) -> tuple[re.Match[str], re.Match[str]]:
+def changelog_release_headings(text: str, start: int = 0) -> list[ChangelogReleaseHeading]:
+    """Return changelog release headings outside fenced code blocks."""
+    headings: list[ChangelogReleaseHeading] = []
+    in_fence = False
+    line_start = 0
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+        elif not in_fence and line_start >= start:
+            match = CHANGELOG_HEADING_RE.fullmatch(line.rstrip("\r\n"))
+            if match:
+                headings.append(ChangelogReleaseHeading(match.group(1), match.group(2), line_start, line_start + len(line)))
+        line_start += len(line)
+    return headings
+
+
+def changelog_sections(text: str, root: Path, path: Path) -> tuple[re.Match[str], ChangelogReleaseHeading]:
     """Return the Unreleased heading and first older release heading."""
     unreleased = re.search(r"^## \[Unreleased\]$", text, re.MULTILINE)
     if not unreleased:
         raise SurfaceError("changelog_parse_failed", "missing ## [Unreleased] heading", "changelog", rel_path(path, root))
-    older = CHANGELOG_HEADING_RE.search(text, unreleased.end())
-    if not older:
+    older_headings = changelog_release_headings(text, unreleased.end())
+    if not older_headings:
         raise SurfaceError("changelog_parse_failed", "missing older release heading after ## [Unreleased]", "changelog", rel_path(path, root))
-    return unreleased, older
+    return unreleased, older_headings[0]
 
 
 def check_changelog(root: Path, version: str, date: str) -> dict[str, Any] | SurfaceError:
     """Validate the requested changelog release heading."""
     path = root / "CHANGELOG.md"
     text = read_text(path, root, "changelog")
-    unreleased, older = changelog_sections(text, root, path)
+    unreleased, _older = changelog_sections(text, root, path)
     heading = f"## [{version}] - {date}"
-    search_end = CHANGELOG_HEADING_RE.search(text, older.end())
-    boundary = search_end.start() if search_end else len(text)
-    if heading not in text[unreleased.end() : boundary]:
-        version_heading = re.search(rf"^## \[{re.escape(version)}\] - ([0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}})$", text[unreleased.end() : boundary], re.MULTILINE)
-        if version_heading:
-            return SurfaceError("changelog_date_mismatch", f"changelog release {version} has date {version_heading.group(1)}, expected {date}", "changelog", rel_path(path, root))
-        return SurfaceError("changelog_release_missing", f"changelog release heading {heading} is missing", "changelog", rel_path(path, root))
-    return {"surface": "changelog", "path": rel_path(path, root), "ok": True}
+    headings = changelog_release_headings(text, unreleased.end())
+    boundary = headings[1].start if len(headings) > 1 else len(text)
+    bounded_text = text[unreleased.end() : boundary]
+    bounded_headings = changelog_release_headings(bounded_text)
+    exact_heading = next((item for item in bounded_headings if f"## [{item.version}] - {item.date}" == heading), None)
+    if exact_heading:
+        return {"surface": "changelog", "path": rel_path(path, root), "ok": True}
+    version_heading = next((item for item in bounded_headings if item.version == version), None)
+    if version_heading:
+        return SurfaceError("changelog_date_mismatch", f"changelog release {version} has date {version_heading.date}, expected {date}", "changelog", rel_path(path, root))
+    return SurfaceError("changelog_release_missing", f"changelog release heading {heading} is missing", "changelog", rel_path(path, root))
 
 
-def update_changelog(root: Path, version: str, date: str, title: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Insert the generated changelog section if it is absent."""
+def update_changelog(root: Path, version: str, date: str, title: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError, PlannedWrite | None]:
+    """Plan insertion of the generated changelog section if it is absent."""
     path = root / "CHANGELOG.md"
     text = read_text(path, root, "changelog")
     unreleased, older = changelog_sections(text, root, path)
     existing = check_changelog(root, version, date)
     if isinstance(existing, dict):
-        return existing, update_entry("changelog", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+        return existing, update_entry("changelog", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False), None
     if existing.code == "changelog_date_mismatch":
-        return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, existing
+        return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, existing, None
 
     section = f"## [{version}] - {date}\n\n### Changed\n\n- {title}\n\n"
-    unreleased_body = text[unreleased.end() : older.start()]
-    insert_at = older.start()
+    unreleased_body = text[unreleased.end() : older.start]
+    insert_at = older.start
     if not unreleased_body.strip():
         insert_at = unreleased.end()
         if text[insert_at:].startswith("\n\n"):
@@ -250,15 +287,13 @@ def update_changelog(root: Path, version: str, date: str, title: str, *, dry_run
         elif text[insert_at:].startswith("\n"):
             insert_at += 1
     new_text = text[:insert_at] + section + text[insert_at:]
-    if not dry_run:
-        write_text(path, root, "changelog", new_text)
     return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, update_entry(
         "changelog",
         rel_path(path, root),
         "updated",
         dry_run=dry_run,
         would_write=True,
-    )
+    ), PlannedWrite(path, "changelog", new_text)
 
 
 def release_notes_path(root: Path, version: str) -> Path:
@@ -298,24 +333,21 @@ def release_notes_template(version: str, date: str, title: str) -> str:
     )
 
 
-def update_release_notes(root: Path, version: str, date: str, title: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError]:
-    """Create release notes or preserve matching existing notes."""
+def update_release_notes(root: Path, version: str, date: str, title: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError, PlannedWrite | None]:
+    """Plan release note creation or preserve matching existing notes."""
     path = release_notes_path(root, version)
     existing = check_release_notes(root, version, date)
     if isinstance(existing, dict):
-        return existing, update_entry("release_notes", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+        return existing, update_entry("release_notes", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False), None
     if existing.code != "release_notes_missing":
-        return {"surface": "release_notes", "path": rel_path(path, root), "ok": False}, existing
-    if not dry_run:
-        ensure_parent(path, root, "release_notes")
-        write_text(path, root, "release_notes", release_notes_template(version, date, title))
+        return {"surface": "release_notes", "path": rel_path(path, root), "ok": False}, existing, None
     return {"surface": "release_notes", "path": rel_path(path, root), "ok": False}, update_entry(
         "release_notes",
         rel_path(path, root),
         "created",
         dry_run=dry_run,
         would_write=True,
-    )
+    ), PlannedWrite(path, "release_notes", release_notes_template(version, date, title))
 
 
 def release_list_bounds(text: str, root: Path, path: Path) -> tuple[int, int]:
@@ -355,14 +387,37 @@ def release_list_lines(root: Path) -> tuple[Path, str, int, int, list[str]]:
     return path, text, start, end, text[start:end].splitlines()
 
 
+def changelog_release_order(root: Path) -> list[str]:
+    """Return release versions in changelog order after Unreleased."""
+    path = root / "CHANGELOG.md"
+    text = read_text(path, root, "changelog")
+    unreleased, _older = changelog_sections(text, root, path)
+    return [heading.version for heading in changelog_release_headings(text, unreleased.end())]
+
+
+def previous_release_from_changelog(root: Path, version: str) -> str | None:
+    """Return the release heading immediately after version in CHANGELOG.md."""
+    releases = changelog_release_order(root)
+    try:
+        index = releases.index(version)
+    except ValueError:
+        return None
+    if index + 1 >= len(releases):
+        return None
+    return releases[index + 1]
+
+
 def check_docs_index(root: Path, version: str) -> dict[str, Any] | SurfaceError:
     """Validate the latest release pointer and previous latest list entry."""
     path, _text, _start, _end, lines = release_list_lines(root)
     expected_latest = f"- [Latest release notes: v{version}](releases/v{version}.md)"
     if not lines or lines[0] != expected_latest:
         return SurfaceError("docs_latest_mismatch", f"latest release pointer must be {expected_latest}", "docs_index", rel_path(path, root))
-    if len(lines) < 2 or not NORMAL_RELEASE_RE.fullmatch(lines[1]):
-        return SurfaceError("docs_previous_latest_missing", "previous latest release link must be immediately below latest pointer", "docs_index", rel_path(path, root))
+    previous_latest = previous_release_from_changelog(root, version)
+    expected_previous = f"- [v{previous_latest} release notes](releases/v{previous_latest}.md)" if previous_latest else None
+    if len(lines) < 2 or expected_previous is None or lines[1] != expected_previous:
+        expected = expected_previous or "the previous changelog release link"
+        return SurfaceError("docs_previous_latest_missing", f"previous latest release link must be immediately below latest pointer as {expected}", "docs_index", rel_path(path, root))
     seen: set[str] = set()
     for line in lines[1:]:
         match = NORMAL_RELEASE_RE.fullmatch(line)
@@ -375,8 +430,8 @@ def check_docs_index(root: Path, version: str) -> dict[str, Any] | SurfaceError:
     return {"surface": "docs_index", "path": rel_path(path, root), "ok": True}
 
 
-def update_docs_index(root: Path, version: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError]:
-    """Update only the bounded release list in docs/index.md."""
+def update_docs_index(root: Path, version: str, *, dry_run: bool) -> tuple[dict[str, Any], dict[str, Any] | SurfaceError, PlannedWrite | None]:
+    """Plan an update only to the bounded release list in docs/index.md."""
     path, text, start, end, lines = release_list_lines(root)
     if not lines:
         raise SurfaceError("docs_index_parse_failed", "release list is missing after ## Releases", "docs_index", rel_path(path, root))
@@ -384,9 +439,12 @@ def update_docs_index(root: Path, version: str, *, dry_run: bool) -> tuple[dict[
     if not latest_match:
         raise SurfaceError("docs_index_parse_failed", "first release list item must be the latest release pointer", "docs_index", rel_path(path, root))
     previous_latest = latest_match.group(1)
-    checked = check_docs_index(root, version)
-    if isinstance(checked, dict):
-        return checked, update_entry("docs_index", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False)
+    checked = {"surface": "docs_index", "path": rel_path(path, root), "ok": lines[0] == f"- [Latest release notes: v{version}](releases/v{version}.md)"}
+    if checked["ok"]:
+        checked_result = check_docs_index(root, version)
+        if isinstance(checked_result, dict):
+            return checked_result, update_entry("docs_index", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False), None
+        checked = {"surface": "docs_index", "path": rel_path(path, root), "ok": False}
 
     new_latest = f"- [Latest release notes: v{version}](releases/v{version}.md)"
     previous_normal = f"- [v{previous_latest} release notes](releases/v{previous_latest}.md)"
@@ -399,15 +457,13 @@ def update_docs_index(root: Path, version: str, *, dry_run: bool) -> tuple[dict[
     new_lines = [new_latest, previous_normal, *remaining]
     new_block = "\n".join(new_lines) + "\n"
     new_text = text[:start] + new_block + text[end:]
-    if not dry_run:
-        write_text(path, root, "docs_index", new_text)
     return {"surface": "docs_index", "path": rel_path(path, root), "ok": False}, update_entry(
         "docs_index",
         rel_path(path, root),
         "updated",
         dry_run=dry_run,
         would_write=True,
-    )
+    ), PlannedWrite(path, "docs_index", new_text)
 
 
 def check_release(root: Path, version: str, date: str) -> dict[str, Any]:
@@ -438,20 +494,28 @@ def update_release(root: Path, version: str, date: str, title: str, *, dry_run: 
     checked: list[dict[str, Any]] = []
     updated: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
+    planned_writes: list[PlannedWrite] = []
     for func in (update_app_version, update_changelog, update_release_notes, update_docs_index):
         try:
             if func is update_app_version or func is update_docs_index:
-                check_entry, update_entry = func(root, version, dry_run=dry_run)
+                check_entry, update_result, planned_write = func(root, version, dry_run=dry_run)
             else:
-                check_entry, update_entry = func(root, version, date, title, dry_run=dry_run)
+                check_entry, update_result, planned_write = func(root, version, date, title, dry_run=dry_run)
         except SurfaceError as exc:
             errors.append(exc.as_dict())
             continue
         checked.append(check_entry)
-        if isinstance(update_entry, SurfaceError):
-            errors.append(update_entry.as_dict())
+        if isinstance(update_result, SurfaceError):
+            errors.append(update_result.as_dict())
         else:
-            updated.append(update_entry)
+            updated.append(update_result)
+        if planned_write is not None:
+            planned_writes.append(planned_write)
+    if errors or dry_run:
+        return standard_result(ok=not errors, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
+    for planned_write in planned_writes:
+        ensure_parent(planned_write.path, root, planned_write.surface)
+        write_text(planned_write.path, root, planned_write.surface, planned_write.content)
     return standard_result(ok=not errors, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
 
 

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -632,9 +632,9 @@ def main(argv: list[str] | None = None) -> int:
     try:
         args = parse_args(argv)
         mode = args.mode
+        dry_run = bool(getattr(args, "dry_run", False))
         version = validate_version(args.version)
         date = validate_date(args.date)
-        dry_run = bool(getattr(args, "dry_run", False))
         title = validate_title(getattr(args, "title", None)) if mode == "update" else None
         root = resolve_repo_root()
         if not args.allow_dirty:

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -27,6 +27,7 @@ CONTENT_ERROR_CODES = {
     "version_mismatch",
     "changelog_release_missing",
     "changelog_date_mismatch",
+    "changelog_release_out_of_order",
     "release_notes_missing",
     "release_notes_conflict",
     "docs_latest_mismatch",
@@ -273,11 +274,19 @@ def update_changelog(root: Path, version: str, date: str, title: str, *, dry_run
     path = root / "CHANGELOG.md"
     text = read_text(path, root, "changelog")
     unreleased, older = changelog_sections(text, root, path)
+    release_headings = changelog_release_headings(text, unreleased.end())
     existing = check_changelog(root, version, date)
     if isinstance(existing, dict):
         return existing, update_entry("changelog", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False), None
     if existing.code == "changelog_date_mismatch":
         return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, existing, None
+    if any(heading.version == version for heading in release_headings[1:]):
+        return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, SurfaceError(
+            "changelog_release_out_of_order",
+            f"changelog release {version} exists after an older release heading",
+            "changelog",
+            rel_path(path, root),
+        ), None
 
     section = f"## [{version}] - {date}\n\n### Changed\n\n- {title}\n\n"
     unreleased_body = text[unreleased.end() : older.start]

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -27,6 +27,7 @@ CONTENT_ERROR_CODES = {
     "version_mismatch",
     "changelog_release_missing",
     "changelog_date_mismatch",
+    "changelog_release_duplicate",
     "changelog_release_out_of_order",
     "release_notes_missing",
     "release_notes_conflict",
@@ -194,12 +195,19 @@ def write_text(path: Path, root: Path, surface: str, content: str) -> None:
         raise SurfaceError("write_failed", f"cannot write {rel_path(path, root)}: {exc}", surface, rel_path(path, root)) from exc
 
 
-def ensure_parent(path: Path, root: Path, surface: str) -> None:
+def ensure_parent(path: Path, root: Path, surface: str) -> list[Path]:
     """Create a file parent directory when the contract allows it."""
+    parent = path.parent
+    missing: list[Path] = []
+    current = parent
+    while current != root and not current.exists():
+        missing.append(current)
+        current = current.parent
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
+        parent.mkdir(parents=True, exist_ok=True)
     except OSError as exc:
-        raise SurfaceError("write_failed", f"cannot create {rel_path(path.parent, root)}: {exc}", surface, rel_path(path.parent, root)) from exc
+        raise SurfaceError("write_failed", f"cannot create {rel_path(parent, root)}: {exc}", surface, rel_path(parent, root)) from exc
+    return missing
 
 
 def check_app_version(root: Path, version: str) -> dict[str, Any] | SurfaceError:
@@ -260,9 +268,12 @@ def check_changelog(root: Path, version: str, date: str) -> dict[str, Any] | Sur
     """Validate the requested changelog release heading."""
     path = root / "CHANGELOG.md"
     text = read_text(path, root, "changelog")
-    _unreleased, first_release = changelog_sections(text, root, path)
+    unreleased, first_release = changelog_sections(text, root, path)
+    release_headings = changelog_release_headings(text, unreleased.end())
     heading = f"## [{version}] - {date}"
     if first_release.version == version and first_release.date == date:
+        if any(release.version == version for release in release_headings[1:]):
+            return SurfaceError("changelog_release_duplicate", f"changelog release {version} appears more than once", "changelog", rel_path(path, root))
         return {"surface": "changelog", "path": rel_path(path, root), "ok": True}
     if first_release.version == version:
         return SurfaceError("changelog_date_mismatch", f"changelog release {version} has date {first_release.date}, expected {date}", "changelog", rel_path(path, root))
@@ -278,7 +289,7 @@ def update_changelog(root: Path, version: str, date: str, title: str, *, dry_run
     existing = check_changelog(root, version, date)
     if isinstance(existing, dict):
         return existing, update_entry("changelog", rel_path(path, root), "unchanged", dry_run=dry_run, would_write=False), None
-    if existing.code == "changelog_date_mismatch":
+    if existing.code in {"changelog_date_mismatch", "changelog_release_duplicate"}:
         return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, existing, None
     if any(heading.version == version for heading in release_headings[1:]):
         return {"surface": "changelog", "path": rel_path(path, root), "ok": False}, SurfaceError(
@@ -542,12 +553,14 @@ def update_release(root: Path, version: str, date: str, title: str, *, dry_run: 
         errors.append(exc.as_dict())
         return standard_result(ok=False, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
     written_paths: list[Path] = []
+    created_dirs: list[Path] = []
     for planned_write in planned_writes:
         try:
-            ensure_parent(planned_write.path, root, planned_write.surface)
+            created_dirs.extend(ensure_parent(planned_write.path, root, planned_write.surface))
             write_text(planned_write.path, root, planned_write.surface, planned_write.content)
         except SurfaceError as exc:
             rollback_written_targets([*written_paths, planned_write.path], snapshots)
+            remove_created_dirs(created_dirs)
             errors.append(exc.as_dict())
             return standard_result(ok=False, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
         written_paths.append(planned_write.path)
@@ -582,6 +595,19 @@ def rollback_written_targets(written_paths: list[Path], snapshots: dict[Path, Wr
                 path.write_text(snapshot.content or "", encoding="utf-8")
             elif path.exists():
                 path.unlink()
+        except OSError:
+            continue
+
+
+def remove_created_dirs(created_dirs: list[Path]) -> None:
+    """Remove newly-created empty directories deepest first."""
+    removed: set[Path] = set()
+    for path in sorted(created_dirs, key=lambda item: len(item.parts), reverse=True):
+        if path in removed:
+            continue
+        removed.add(path)
+        try:
+            path.rmdir()
         except OSError:
             continue
 

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -67,6 +67,14 @@ class PlannedWrite:
 
 
 @dataclass(frozen=True)
+class WriteSnapshot:
+    """Prior file state captured before applying planned writes."""
+
+    existed: bool
+    content: str | None
+
+
+@dataclass(frozen=True)
 class ChangelogReleaseHeading:
     """A changelog release heading outside fenced code blocks."""
 
@@ -251,18 +259,12 @@ def check_changelog(root: Path, version: str, date: str) -> dict[str, Any] | Sur
     """Validate the requested changelog release heading."""
     path = root / "CHANGELOG.md"
     text = read_text(path, root, "changelog")
-    unreleased, _older = changelog_sections(text, root, path)
+    _unreleased, first_release = changelog_sections(text, root, path)
     heading = f"## [{version}] - {date}"
-    headings = changelog_release_headings(text, unreleased.end())
-    boundary = headings[1].start if len(headings) > 1 else len(text)
-    bounded_text = text[unreleased.end() : boundary]
-    bounded_headings = changelog_release_headings(bounded_text)
-    exact_heading = next((item for item in bounded_headings if f"## [{item.version}] - {item.date}" == heading), None)
-    if exact_heading:
+    if first_release.version == version and first_release.date == date:
         return {"surface": "changelog", "path": rel_path(path, root), "ok": True}
-    version_heading = next((item for item in bounded_headings if item.version == version), None)
-    if version_heading:
-        return SurfaceError("changelog_date_mismatch", f"changelog release {version} has date {version_heading.date}, expected {date}", "changelog", rel_path(path, root))
+    if first_release.version == version:
+        return SurfaceError("changelog_date_mismatch", f"changelog release {version} has date {first_release.date}, expected {date}", "changelog", rel_path(path, root))
     return SurfaceError("changelog_release_missing", f"changelog release heading {heading} is missing", "changelog", rel_path(path, root))
 
 
@@ -525,10 +527,54 @@ def update_release(root: Path, version: str, date: str, title: str, *, dry_run: 
             planned_writes.append(planned_write)
     if errors or dry_run:
         return standard_result(ok=not errors, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
+    try:
+        snapshots = snapshot_write_targets(planned_writes, root)
+    except SurfaceError as exc:
+        errors.append(exc.as_dict())
+        return standard_result(ok=False, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
+    written_paths: list[Path] = []
     for planned_write in planned_writes:
-        ensure_parent(planned_write.path, root, planned_write.surface)
-        write_text(planned_write.path, root, planned_write.surface, planned_write.content)
+        try:
+            ensure_parent(planned_write.path, root, planned_write.surface)
+            write_text(planned_write.path, root, planned_write.surface, planned_write.content)
+        except SurfaceError as exc:
+            rollback_written_targets([*written_paths, planned_write.path], snapshots)
+            errors.append(exc.as_dict())
+            return standard_result(ok=False, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
+        written_paths.append(planned_write.path)
     return standard_result(ok=not errors, mode="update", version=version, date=date, dry_run=dry_run, checked=checked, updated=updated, errors=errors)
+
+
+def snapshot_write_targets(planned_writes: list[PlannedWrite], root: Path) -> dict[Path, WriteSnapshot]:
+    """Capture existing target file state before the write phase."""
+    snapshots: dict[Path, WriteSnapshot] = {}
+    for planned_write in planned_writes:
+        path = planned_write.path
+        if path in snapshots:
+            continue
+        try:
+            existed = path.exists()
+            snapshots[path] = WriteSnapshot(existed, path.read_text(encoding="utf-8") if existed else None)
+        except OSError as exc:
+            raise SurfaceError("read_failed", f"cannot snapshot {rel_path(path, root)}: {exc}", planned_write.surface, rel_path(path, root)) from exc
+    return snapshots
+
+
+def rollback_written_targets(written_paths: list[Path], snapshots: dict[Path, WriteSnapshot]) -> None:
+    """Restore targets already changed by a failed write phase."""
+    restored: set[Path] = set()
+    for path in reversed(written_paths):
+        if path in restored:
+            continue
+        restored.add(path)
+        snapshot = snapshots[path]
+        try:
+            if snapshot.existed:
+                path.write_text(snapshot.content or "", encoding="utf-8")
+            elif path.exists():
+                path.unlink()
+        except OSError:
+            continue
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:


### PR DESCRIPTION
Closes #293

## Summary
- Adds `tools/prepare_release.py` for local release/version sync checks and updates.
- Covers runtime version, changelog, release notes, and docs latest-release pointer.
- Adds deterministic JSON output, dirty-worktree guard, dry-run mode, idempotent docs/index handling, and rollback on write failure.
- Fixes the docs index README link to use the canonical GitHub README URL.
- Keeps PyPI, MCP Registry, GitHub release creation, package metadata, and `server.json` out of scope.

## Verification
- `git diff --check`
- `./.venv/bin/python -m ruff check app tests tools agent-assets`
- `./.venv/bin/python -m unittest tests/test_prepare_release_293.py -v`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python tools/prepare_release.py check --version 1.4.8 --date 2026-04-26 --allow-dirty`
- `./.venv/bin/python tools/prepare_release.py update --version 9.9.9 --title "Dry run smoke" --date 2026-04-26 --dry-run --allow-dirty`
- `./.venv/bin/python -m unittest tests/test_ui_docs.py -v`