### PR TITLE
Point PyPI README at published docs

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -23,6 +23,10 @@ This package starts a local Streamable HTTP server only; it does not provide std
 
 ## Documentation
 
-Project source, full documentation, and release notes are available at:
+Documentation and release notes are available at:
+
+https://stef-k.github.io/CogniRelay/
+
+Project source is available at:
 
 https://github.com/stef-k/CogniRelay


### PR DESCRIPTION
## Summary
- Point README-PYPI.md documentation users to the GitHub Pages docs first
- Keep the GitHub repository link as the project source link

## Verification
- git diff --check
- ./.venv/bin/python -m unittest tests.test_packaging_290.Packaging290Tests.test_pypi_readme_is_sanitized_and_carries_mcp_marker -v