### PR TITLE
Prepare 1.4.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.9] - 2026-04-27
+
+### Changed
+
+- Added PyPI-ready packaging metadata, a thin `cognirelay` CLI wrapper, and
+  `server.json` metadata for MCP Registry publication while preserving the
+  existing `app.main:app` runtime and source-checkout deployment path.
+- Added release safety gates for publishable tree checks, sanitized PyPI
+  metadata, built wheel/sdist inspection, and `server.json` schema validation.
+- Removed tracked runtime state from the Git source surface so GitHub source
+  archives no longer include local `data_repo/` artifacts.
+
 ## [1.4.8] - 2026-04-26
 
 ### Fixed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.8", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.9", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,8 @@ path.
 
 ## Releases
 
-- [Latest release notes: v1.4.8](releases/v1.4.8.md)
+- [Latest release notes: v1.4.9](releases/v1.4.9.md)
+- [v1.4.8 release notes](releases/v1.4.8.md)
 - [v1.4.7 release notes](releases/v1.4.7.md)
 - [v1.4.6 release notes](releases/v1.4.6.md)
 - [v1.4.5 release notes](releases/v1.4.5.md)

--- a/docs/releases/v1.4.9.md
+++ b/docs/releases/v1.4.9.md
@@ -1,0 +1,66 @@
+# CogniRelay v1.4.9 Release Notes
+
+Release date: 2026-04-27
+
+CogniRelay v1.4.9 adds the packaging and publication surfaces needed for a
+first PyPI and MCP Registry release, while preserving the existing source
+checkout deployment path.
+
+## Added
+
+- Added PyPI project metadata with a sanitized `README-PYPI.md` long
+  description and `cognirelay` console entrypoint.
+- Added a thin `cognirelay` package wrapper with `cognirelay serve` and
+  `python -m cognirelay serve`, delegating to the existing `app.main:app`
+  runtime.
+- Added root `server.json` metadata for MCP Registry publication, including
+  local Streamable HTTP transport, positional `serve` startup metadata, and
+  required `COGNIRELAY_REPO_ROOT` environment metadata.
+- Added `tools/validate_server_json.py` for local validation against the
+  committed MCP Registry schema URL.
+
+## Changed
+
+- Extended `tools/prepare_release.py` to validate package versions,
+  dependencies, `server.json`, the PyPI ownership marker, and publishable tree
+  safety before release.
+- Updated installation documentation for source, PyPI, and production
+  hardening paths, including durable `COGNIRELAY_REPO_ROOT` guidance and the
+  local Streamable HTTP-only MCP Registry posture.
+- Added wheel and sdist artifact checks so packaged releases include only the
+  intended runtime assets and source-only documentation/deploy files.
+
+## Security And Privacy
+
+- Removed tracked `data_repo/` runtime state from the Git source surface while
+  preserving local operator files on disk.
+- Added publishable-tree safety checks that block tracked runtime state,
+  generated databases, logs, token/key files, build residue, and private
+  artifacts before publication.
+- Sanitized PyPI metadata so the published long description does not expose
+  local runtime-state paths, audit/log paths, capsule paths, or token file
+  locations.
+- Added runtime guardrails so installed-package startup refuses unsafe runtime
+  state roots under package or `site-packages` paths before creating state.
+
+## Notes
+
+- No PyPI upload, MCP Registry publication, or GitHub Release publication is
+  performed by the code change itself; those remain explicit manual release
+  steps.
+- Runtime MCP protocol support remains `2025-06-18` and `2025-11-25`. The
+  `2025-12-11` value used by `server.json` is the MCP Registry metadata schema,
+  not a CogniRelay runtime protocol version.
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools agent-assets
+./.venv/bin/python -m unittest discover -s tests -v
+./.venv/bin/python tools/validate_server_json.py
+./.venv/bin/python -m build
+./.venv/bin/python -m twine check dist/*
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognirelay"
-version = "1.4.8"
+version = "1.4.9"
 description = "Self-hosted continuity and collaboration substrate for autonomous agents."
 readme = "README-PYPI.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.stef-k/cognirelay",
   "title": "CogniRelay",
   "description": "Self-hosted continuity and collaboration substrate for autonomous agents.",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cognirelay",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "packageArguments": [
         {
           "type": "positional",

--- a/tests/test_packaging_290.py
+++ b/tests/test_packaging_290.py
@@ -45,8 +45,8 @@ FORBIDDEN_ARTIFACT_SUFFIXES = (
     ".tmp",
 )
 ALLOWED_ENV_TEMPLATE_ARTIFACTS = {
-    "cognirelay-1.4.8/.env.example",
-    "cognirelay-1.4.8/deploy/systemd/cognirelay.env.example",
+    "cognirelay-1.4.9/.env.example",
+    "cognirelay-1.4.9/deploy/systemd/cognirelay.env.example",
 }
 FORBIDDEN_METADATA_TOKENS = (
     "data_repo/",
@@ -195,10 +195,10 @@ class Packaging290Tests(unittest.TestCase):
 
             with tarfile.open(sdist) as archive:
                 sdist_names = set(archive.getnames())
-                pkg_info = archive.extractfile("cognirelay-1.4.8/PKG-INFO")
+                pkg_info = archive.extractfile("cognirelay-1.4.9/PKG-INFO")
                 self.assertIsNotNone(pkg_info)
                 sdist_metadata = pkg_info.read().decode("utf-8")  # type: ignore[union-attr]
-            prefix = "cognirelay-1.4.8/"
+            prefix = "cognirelay-1.4.9/"
             for expected in (
                 "README.md",
                 "README-PYPI.md",


### PR DESCRIPTION
## Summary
- Bump runtime/package/server metadata to 1.4.9
- Add v1.4.9 changelog and release notes for PyPI/MCP Registry packaging
- Update docs index latest release pointer
- Update packaging artifact tests for the 1.4.9 archive name

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app tests tools agent-assets
- ./.venv/bin/python tools/validate_server_json.py
- ./.venv/bin/python tools/prepare_release.py check --version 1.4.9 --date 2026-04-27 --allow-dirty
- ./.venv/bin/python -m unittest discover -s tests -v (2279 tests)
- ./.venv/bin/python -m build
- ./.venv/bin/python -m twine check dist/*
- prepare_release check fails with dist/ present, then passes after generated residue cleanup
- exact publishable-tree gate produced no output