### PR TITLE
Prepare 1.4.10 metadata release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.10] - 2026-04-27
+
+### Changed
+
+- Improve public package discovery metadata
+
 ## [1.4.9] - 2026-04-27
 
 ### Changed

--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: io.github.stef-k/cognirelay -->
 
-CogniRelay is a self-hosted continuity and collaboration substrate for autonomous agents. It provides a local FastAPI and MCP-facing service for bounded agent orientation, retrieval, coordination, and recovery across context resets.
+CogniRelay is a self-hosted continuity and collaboration substrate for autonomous agents with bounded, recoverable memory and explicit restart orientation. It provides a local FastAPI and MCP-facing service for agent orientation, retrieval, coordination, and recovery across context resets.
 
 ## Install
 

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.9", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.10", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,8 @@ path.
 
 ## Releases
 
-- [Latest release notes: v1.4.9](releases/v1.4.9.md)
+- [Latest release notes: v1.4.10](releases/v1.4.10.md)
+- [v1.4.9 release notes](releases/v1.4.9.md)
 - [v1.4.8 release notes](releases/v1.4.8.md)
 - [v1.4.7 release notes](releases/v1.4.7.md)
 - [v1.4.6 release notes](releases/v1.4.6.md)

--- a/docs/releases/v1.4.10.md
+++ b/docs/releases/v1.4.10.md
@@ -1,0 +1,24 @@
+# CogniRelay v1.4.10 Release Notes
+
+Release date: 2026-04-27
+
+This metadata-only release aligns the PyPI and MCP Registry discovery text with
+the GitHub project description and topics:
+
+> Self-hosted continuity and collaboration substrate for autonomous agents with
+> bounded, recoverable memory and explicit restart orientation
+
+It also adds the GitHub project topics as PyPI package keywords so the package is
+easier to discover by agents and operators searching for MCP, agent memory,
+continuity, context recovery, session recovery, and self-hosted agent
+infrastructure.
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools agent-assets
+./.venv/bin/python -m unittest discover -s tests -v
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,27 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognirelay"
-version = "1.4.9"
-description = "Self-hosted continuity and collaboration substrate for autonomous agents."
+version = "1.4.10"
+description = "Self-hosted continuity and collaboration substrate for autonomous agents with bounded, recoverable memory and explicit restart orientation"
 readme = "README-PYPI.md"
 requires-python = ">=3.12"
+keywords = [
+    "mcp",
+    "ai-collaboration",
+    "agent-infrastructure",
+    "continuity",
+    "agent-memory",
+    "autonomous-agents",
+    "context-recovery",
+    "fastapi",
+    "long-horizon-agents",
+    "multi-agent-systems",
+    "self-hosted",
+    "session-recovery",
+    "agent-continuity",
+    "continuity-infrastructure",
+    "recoverable-memory",
+]
 dependencies = [
     "fastapi>=0.115,<1",
     "uvicorn>=0.30,<1",

--- a/server.json
+++ b/server.json
@@ -2,13 +2,13 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.stef-k/cognirelay",
   "title": "CogniRelay",
-  "description": "Self-hosted continuity and collaboration substrate for autonomous agents.",
-  "version": "1.4.9",
+  "description": "Self-hosted agent continuity server with bounded, recoverable memory and restart orientation.",
+  "version": "1.4.10",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cognirelay",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "packageArguments": [
         {
           "type": "positional",

--- a/tests/test_packaging_290.py
+++ b/tests/test_packaging_290.py
@@ -21,6 +21,25 @@ from tools import prepare_release
 
 
 ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_VERSION = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+SDIST_PREFIX = f"cognirelay-{PACKAGE_VERSION}/"
+GITHUB_REPOSITORY_TOPICS = [
+    "mcp",
+    "ai-collaboration",
+    "agent-infrastructure",
+    "continuity",
+    "agent-memory",
+    "autonomous-agents",
+    "context-recovery",
+    "fastapi",
+    "long-horizon-agents",
+    "multi-agent-systems",
+    "self-hosted",
+    "session-recovery",
+    "agent-continuity",
+    "continuity-infrastructure",
+    "recoverable-memory",
+]
 FORBIDDEN_ARTIFACT_SUFFIXES = (
     ".pyc",
     ".pyo",
@@ -45,8 +64,8 @@ FORBIDDEN_ARTIFACT_SUFFIXES = (
     ".tmp",
 )
 ALLOWED_ENV_TEMPLATE_ARTIFACTS = {
-    "cognirelay-1.4.9/.env.example",
-    "cognirelay-1.4.9/deploy/systemd/cognirelay.env.example",
+    f"{SDIST_PREFIX}.env.example",
+    f"{SDIST_PREFIX}deploy/systemd/cognirelay.env.example",
 }
 FORBIDDEN_METADATA_TOKENS = (
     "data_repo/",
@@ -78,6 +97,7 @@ class Packaging290Tests(unittest.TestCase):
         expected = prepare_release.runtime_requirements(ROOT)
 
         self.assertEqual(pyproject["project"]["readme"], "README-PYPI.md")
+        self.assertEqual(pyproject["project"]["keywords"], GITHUB_REPOSITORY_TOPICS)
         self.assertEqual(pyproject["project"]["dependencies"], expected)
         self.assertNotIn("build", "\n".join(pyproject["project"]["dependencies"]))
         self.assertNotIn("twine", "\n".join(pyproject["project"]["dependencies"]))
@@ -195,10 +215,9 @@ class Packaging290Tests(unittest.TestCase):
 
             with tarfile.open(sdist) as archive:
                 sdist_names = set(archive.getnames())
-                pkg_info = archive.extractfile("cognirelay-1.4.9/PKG-INFO")
+                pkg_info = archive.extractfile(f"{SDIST_PREFIX}PKG-INFO")
                 self.assertIsNotNone(pkg_info)
                 sdist_metadata = pkg_info.read().decode("utf-8")  # type: ignore[union-attr]
-            prefix = "cognirelay-1.4.9/"
             for expected in (
                 "README.md",
                 "README-PYPI.md",
@@ -208,7 +227,7 @@ class Packaging290Tests(unittest.TestCase):
                 "agent-assets/README.md",
                 "deploy/systemd/cognirelay.env.example",
             ):
-                self.assertIn(prefix + expected, sdist_names)
+                self.assertIn(SDIST_PREFIX + expected, sdist_names)
             self.assertFalse(any(_forbidden_artifact_name(name) for name in sdist_names))
             self.assertIn("<!-- mcp-name: io.github.stef-k/cognirelay -->", sdist_metadata)
             for token in FORBIDDEN_METADATA_TOKENS:

--- a/tests/test_prepare_release_293.py
+++ b/tests/test_prepare_release_293.py
@@ -76,7 +76,7 @@ def _write_fixture(root: Path, *, version: str = "1.4.8", latest: str = "1.4.8")
                 "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
                 "name": "io.github.stef-k/cognirelay",
                 "title": "CogniRelay",
-                "description": "Self-hosted continuity and collaboration substrate for autonomous agents.",
+                "description": "Self-hosted agent continuity server with bounded, recoverable memory and restart orientation.",
                 "version": version,
                 "packages": [
                     {

--- a/tools/prepare_release.py
+++ b/tools/prepare_release.py
@@ -39,7 +39,7 @@ APP_VERSION_RE = re.compile(r"(FastAPI\([^)]*\bversion=)([\"'])([^\"']+)(\2)", r
 PROJECT_VERSION_RE = re.compile(r"(^\[project\]\s*?.*?^version\s*=\s*)([\"'])([^\"']+)(\2)", re.MULTILINE | re.DOTALL)
 LATEST_RE = re.compile(r"^- \[Latest release notes: v([0-9]+\.[0-9]+\.[0-9]+)\]\(releases/v\1\.md\)$")
 NORMAL_RELEASE_RE = re.compile(r"^- \[v([0-9]+\.[0-9]+\.[0-9]+) release notes\]\(releases/v\1\.md\)$")
-SERVER_JSON_DESCRIPTION = "Self-hosted continuity and collaboration substrate for autonomous agents."
+SERVER_JSON_DESCRIPTION = "Self-hosted agent continuity server with bounded, recoverable memory and restart orientation."
 SERVER_JSON_PACKAGE_IDENTIFIER = "cognirelay"
 SERVER_JSON_PACKAGE_ARGUMENTS = [{"type": "positional", "value": "serve"}]
 SERVER_JSON_TRANSPORT = {"type": "streamable-http", "url": "http://127.0.0.1:8080/v1/mcp"}


### PR DESCRIPTION
## Summary
- Bump CogniRelay to v1.4.10 for a metadata-only discovery release.
- Align PyPI metadata with the GitHub project description and topics.
- Keep server.json schema-valid with the closest bounded registry description and matching release-helper check.
- Add regression coverage for PyPI keywords and dynamic sdist version expectations.

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app tests tools agent-assets
- ./.venv/bin/python tools/validate_server_json.py
- ./.venv/bin/python tools/prepare_release.py check --version 1.4.10 --date 2026-04-27 --allow-dirty
- ./.venv/bin/python -m unittest tests/test_packaging_290.py tests/test_prepare_release_293.py -v
- ./.venv/bin/python -m unittest discover -s tests -v
- ./.venv/bin/python -m build
- ./.venv/bin/python -m twine check dist/*
- Built wheel/sdist metadata inspected: version 1.4.10, full GitHub description, exact GitHub topic keywords
- Release helper rejects dist/ residue and passes after cleanup
