### PR TITLE
Merge issue #302 wheel agent assets

### DIFF
--- a/README-PYPI.md
+++ b/README-PYPI.md
@@ -21,6 +21,23 @@ cognirelay serve --host 127.0.0.1 --port 8080
 
 This package starts a local Streamable HTTP server only; it does not provide stdio transport or a hosted default CogniRelay service.
 
+## Agent assets
+
+PyPI installs include the last-mile agent assets needed to integrate CogniRelay continuity hooks and the continuity-authoring skill. To inspect the installed assets:
+
+```bash
+cognirelay assets path
+cognirelay assets list
+```
+
+To materialize them into a workspace, run:
+
+```bash
+cognirelay assets copy --to /path/to/workspace
+```
+
+The copy command writes `/path/to/workspace/agent-assets`. The full last-mile guide remains in the project documentation on GitHub Pages.
+
 ## Documentation
 
 Documentation and release notes are available at:

--- a/cognirelay/cli.py
+++ b/cognirelay/cli.py
@@ -4,16 +4,39 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
+import stat
 import sys
 import sysconfig
 from pathlib import Path
 from typing import Sequence
 
 LOG_LEVELS = ("debug", "info", "warning", "error", "critical")
+AGENT_ASSET_FILES = (
+    "README.md",
+    "hooks/README.md",
+    "hooks/cognirelay_continuity_save_hook.py",
+    "hooks/cognirelay_retrieval_hook.py",
+    "skills/cognirelay-continuity-authoring/SKILL.md",
+)
+AGENT_ASSET_DIRS = {
+    "hooks",
+    "hooks/__pycache__",
+    "skills",
+    "skills/cognirelay-continuity-authoring",
+}
+AGENT_ASSET_INSTALLER_CACHE_PREFIXES = (
+    "hooks/__pycache__/cognirelay_continuity_save_hook.",
+    "hooks/__pycache__/cognirelay_retrieval_hook.",
+)
 
 
 class RuntimeStateError(Exception):
     """Raised when a package startup would place runtime state in install files."""
+
+
+class AgentAssetsError(Exception):
+    """Raised when installed agent assets are unavailable or cannot be copied."""
 
 
 def _is_relative_to(path: Path, parent: Path) -> bool:
@@ -64,6 +87,51 @@ def validate_runtime_state_root(repo_root_raw: str | None, *, cwd: Path | None =
     return repo_root
 
 
+def _installed_agent_assets_root(package_file: Path | None = None) -> Path:
+    package_path = (package_file or Path(__file__)).resolve()
+    return package_path.parent / "agent_assets"
+
+
+def _readable_regular_file(path: Path) -> bool:
+    try:
+        file_stat = path.stat()
+        if not stat.S_ISREG(file_stat.st_mode):
+            return False
+        with path.open("rb") as handle:
+            handle.read(1)
+    except OSError:
+        return False
+    return True
+
+
+def validate_installed_agent_assets(*, package_file: Path | None = None) -> Path:
+    """Return the installed agent-assets root after strict allowlist validation."""
+    root = _installed_agent_assets_root(package_file)
+    if not root.is_dir():
+        raise AgentAssetsError(f"installed agent assets are unavailable at {root}")
+
+    allowed = set(AGENT_ASSET_FILES)
+    for relative in AGENT_ASSET_FILES:
+        if not _readable_regular_file(root / relative):
+            raise AgentAssetsError(f"installed agent assets are unavailable at {root}")
+
+    try:
+        discovered = sorted(path.relative_to(root).as_posix() for path in root.rglob("*"))
+    except OSError as exc:
+        raise AgentAssetsError(f"installed agent assets are unavailable at {root}") from exc
+
+    for relative in discovered:
+        path = root / relative
+        if relative in allowed:
+            continue
+        if relative.endswith(".pyc") and any(relative.startswith(prefix) for prefix in AGENT_ASSET_INSTALLER_CACHE_PREFIXES):
+            continue
+        if relative in AGENT_ASSET_DIRS and path.is_dir():
+            continue
+        raise AgentAssetsError(f"installed agent assets contain unexpected entries at {root}")
+    return root
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CogniRelay CLI parser."""
     parser = argparse.ArgumentParser(prog="cognirelay")
@@ -73,6 +141,13 @@ def build_parser() -> argparse.ArgumentParser:
     serve.add_argument("--port", type=int, default=8080)
     serve.add_argument("--log-level", choices=LOG_LEVELS, default="info")
     serve.add_argument("--reload", action="store_true")
+    assets = subparsers.add_parser("assets")
+    asset_subparsers = assets.add_subparsers(dest="asset_command", required=True)
+    asset_subparsers.add_parser("path")
+    asset_subparsers.add_parser("list")
+    copy = asset_subparsers.add_parser("copy")
+    copy.add_argument("--to", required=True)
+    copy.add_argument("--force", action="store_true")
     return parser
 
 
@@ -90,6 +165,56 @@ def _serve(args: argparse.Namespace) -> int:
     return 0
 
 
+def _assets_path(_args: argparse.Namespace) -> int:
+    root = validate_installed_agent_assets()
+    print(root)
+    return 0
+
+
+def _assets_list(_args: argparse.Namespace) -> int:
+    validate_installed_agent_assets()
+    for relative in sorted(AGENT_ASSET_FILES):
+        print(relative)
+    return 0
+
+
+def _copy_agent_assets(source: Path, destination: Path, *, force: bool) -> None:
+    if destination.is_symlink():
+        raise AgentAssetsError(f"target path is not a real directory: {destination}")
+    if destination.exists():
+        if not destination.is_dir():
+            raise AgentAssetsError(f"target path is not a directory: {destination}")
+        try:
+            has_entries = any(destination.iterdir())
+        except OSError as exc:
+            raise AgentAssetsError(f"could not inspect target directory: {destination}") from exc
+        if has_entries:
+            if not force:
+                raise AgentAssetsError(f"target directory is not empty: {destination}")
+            try:
+                shutil.rmtree(destination)
+            except OSError as exc:
+                raise AgentAssetsError(f"could not replace target directory: {destination}") from exc
+
+    try:
+        shutil.copytree(source, destination, dirs_exist_ok=True)
+    except OSError as exc:
+        raise AgentAssetsError(f"could not copy agent assets to {destination}") from exc
+
+
+def _assets_copy(args: argparse.Namespace) -> int:
+    root = validate_installed_agent_assets()
+    requested_parent = Path(args.to).expanduser()
+    try:
+        requested_parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise AgentAssetsError(f"could not create destination directory: {requested_parent}") from exc
+    destination = requested_parent / "agent-assets"
+    _copy_agent_assets(root, destination, force=args.force)
+    print(destination.resolve())
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CogniRelay CLI."""
     parser = build_parser()
@@ -97,8 +222,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         if args.command == "serve":
             return _serve(args)
+        if args.command == "assets":
+            if args.asset_command == "path":
+                return _assets_path(args)
+            if args.asset_command == "list":
+                return _assets_list(args)
+            if args.asset_command == "copy":
+                return _assets_copy(args)
     except RuntimeStateError as exc:
         print(f"cognirelay: {exc}", file=sys.stderr)
+        return 1
+    except AgentAssetsError as exc:
+        print(f"cognirelay assets: {exc}", file=sys.stderr)
         return 1
     parser.error("unknown command")
     return 2

--- a/cognirelay/cli.py
+++ b/cognirelay/cli.py
@@ -21,14 +21,9 @@ AGENT_ASSET_FILES = (
 )
 AGENT_ASSET_DIRS = {
     "hooks",
-    "hooks/__pycache__",
     "skills",
     "skills/cognirelay-continuity-authoring",
 }
-AGENT_ASSET_INSTALLER_CACHE_PREFIXES = (
-    "hooks/__pycache__/cognirelay_continuity_save_hook.",
-    "hooks/__pycache__/cognirelay_retrieval_hook.",
-)
 
 
 class RuntimeStateError(Exception):
@@ -123,8 +118,6 @@ def validate_installed_agent_assets(*, package_file: Path | None = None) -> Path
     for relative in discovered:
         path = root / relative
         if relative in allowed:
-            continue
-        if relative.endswith(".pyc") and any(relative.startswith(prefix) for prefix in AGENT_ASSET_INSTALLER_CACHE_PREFIXES):
             continue
         if relative in AGENT_ASSET_DIRS and path.is_dir():
             continue

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,12 @@ PyPI installs use `pip install cognirelay` and `cognirelay serve --host
 runtime-state directory outside `site-packages`; the default `./data_repo` is
 only for local/manual development.
 
+PyPI installs also include the last-mile agent assets under the installed
+`cognirelay/agent_assets` package-data directory. Use `cognirelay assets path`
+to print that installed path, `cognirelay assets list` to inspect the bundled
+allowlist, or `cognirelay assets copy --to <dir>` to write `<dir>/agent-assets`
+for local agent configuration.
+
 Wheel installs do not bundle the full source documentation in this slice. The
 `/ui/docs` page may show degraded or unavailable doc entries unless
 `COGNIRELAY_DOCS_SOURCE_ROOT` points at a source checkout.

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+from pathlib import Path
 from pathlib import PurePosixPath
 
 from setuptools import setup
@@ -30,6 +31,7 @@ class build_py(_build_py):
         super().run()
         source_root = PurePosixPath("agent-assets")
         target_root = PurePosixPath("cognirelay") / "agent_assets"
+        shutil.rmtree(Path(self.build_lib) / target_root, ignore_errors=True)
         for relative in AGENT_ASSET_FILES:
             source = source_root / relative
             target = PurePosixPath(self.build_lib) / target_root / relative

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,39 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import PurePosixPath
 
 from setuptools import setup
+from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.sdist import sdist as _sdist
+
+AGENT_ASSET_FILES = (
+    "README.md",
+    "hooks/README.md",
+    "hooks/cognirelay_retrieval_hook.py",
+    "hooks/cognirelay_continuity_save_hook.py",
+    "skills/cognirelay-continuity-authoring/SKILL.md",
+)
 
 
 def _is_egg_info_path(path: str) -> bool:
     """Return whether a source distribution path points inside egg-info metadata."""
     return any(part.endswith(".egg-info") for part in PurePosixPath(path.replace("\\", "/")).parts)
+
+
+class build_py(_build_py):
+    """Copy the allowlisted agent assets into wheel build output only."""
+
+    def run(self) -> None:
+        super().run()
+        source_root = PurePosixPath("agent-assets")
+        target_root = PurePosixPath("cognirelay") / "agent_assets"
+        for relative in AGENT_ASSET_FILES:
+            source = source_root / relative
+            target = PurePosixPath(self.build_lib) / target_root / relative
+            self.mkpath(str(target.parent))
+            shutil.copy2(str(source), str(target))
 
 
 class sdist(_sdist):
@@ -20,4 +44,4 @@ class sdist(_sdist):
         super().make_release_tree(base_dir, [path for path in files if not _is_egg_info_path(path)])
 
 
-setup(cmdclass={"sdist": sdist})
+setup(cmdclass={"build_py": build_py, "sdist": sdist})

--- a/tests/test_cognirelay_cli.py
+++ b/tests/test_cognirelay_cli.py
@@ -7,10 +7,35 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
 from unittest import mock
 
 from cognirelay import cli
+
+AGENT_ASSET_FILES = (
+    "README.md",
+    "hooks/README.md",
+    "hooks/cognirelay_continuity_save_hook.py",
+    "hooks/cognirelay_retrieval_hook.py",
+    "skills/cognirelay-continuity-authoring/SKILL.md",
+)
+
+
+def _write_installed_assets(root: Path) -> None:
+    for relative in AGENT_ASSET_FILES:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{relative}\n", encoding="utf-8")
+
+
+def _run_cli(argv: list[str]) -> tuple[int, str, str]:
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        result = cli.main(argv)
+    return result, stdout.getvalue(), stderr.getvalue()
 
 
 class CogniRelayCliTests(unittest.TestCase):
@@ -82,6 +107,129 @@ class CogniRelayCliTests(unittest.TestCase):
                     cli.validate_runtime_state_root(str(unsafe_root), cwd=Path(td), package_file=package_file)
 
             self.assertFalse(unsafe_root.exists())
+
+    def test_assets_path_and_list_validate_installed_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            assets_root = Path(td) / "site-packages" / "cognirelay" / "agent_assets"
+            _write_installed_assets(assets_root)
+
+            with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
+                path_result, path_stdout, path_stderr = _run_cli(["assets", "path"])
+                list_result, list_stdout, list_stderr = _run_cli(["assets", "list"])
+
+            self.assertEqual(path_result, 0)
+            self.assertEqual(path_stdout, f"{assets_root}\n")
+            self.assertEqual(path_stderr, "")
+            self.assertEqual(list_result, 0)
+            self.assertEqual(list_stdout.splitlines(), sorted(AGENT_ASSET_FILES))
+            self.assertEqual(list_stderr, "")
+
+    def test_assets_copy_target_behaviors(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            assets_root = root / "site-packages" / "cognirelay" / "agent_assets"
+            _write_installed_assets(assets_root)
+
+            cases_root = root / "cases"
+            with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
+                absent_result, absent_stdout, absent_stderr = _run_cli(["assets", "copy", "--to", str(cases_root / "absent")])
+                empty_target = cases_root / "empty" / "agent-assets"
+                empty_target.mkdir(parents=True)
+                empty_result, empty_stdout, empty_stderr = _run_cli(["assets", "copy", "--to", str(cases_root / "empty")])
+                non_empty_target = cases_root / "non-empty" / "agent-assets"
+                non_empty_target.mkdir(parents=True)
+                (non_empty_target / "old.txt").write_text("old\n", encoding="utf-8")
+                non_empty_result, non_empty_stdout, non_empty_stderr = _run_cli(["assets", "copy", "--to", str(cases_root / "non-empty")])
+                force_result, force_stdout, force_stderr = _run_cli(["assets", "copy", "--to", str(cases_root / "non-empty"), "--force"])
+                file_parent = cases_root / "file"
+                file_parent.mkdir()
+                (file_parent / "agent-assets").write_text("not a directory\n", encoding="utf-8")
+                file_result, file_stdout, file_stderr = _run_cli(["assets", "copy", "--to", str(file_parent), "--force"])
+                symlink_parent = cases_root / "symlink"
+                symlink_parent.mkdir()
+                real_target = cases_root / "real-target"
+                real_target.mkdir()
+                (symlink_parent / "agent-assets").symlink_to(real_target, target_is_directory=True)
+                symlink_result, symlink_stdout, symlink_stderr = _run_cli(["assets", "copy", "--to", str(symlink_parent), "--force"])
+
+            self.assertEqual(absent_result, 0, absent_stderr)
+            self.assertEqual(absent_stdout, f"{(cases_root / 'absent' / 'agent-assets').resolve()}\n")
+            self.assertEqual(absent_stderr, "")
+            self.assertEqual(empty_result, 0, empty_stderr)
+            self.assertEqual(empty_stdout, f"{empty_target.resolve()}\n")
+            self.assertEqual(empty_stderr, "")
+            self.assertEqual(non_empty_result, 1)
+            self.assertEqual(non_empty_stdout, "")
+            self.assertIn("target directory is not empty", non_empty_stderr)
+            self.assertEqual(force_result, 0, force_stderr)
+            self.assertEqual(force_stdout, f"{non_empty_target.resolve()}\n")
+            self.assertEqual(force_stderr, "")
+            self.assertFalse((non_empty_target / "old.txt").exists())
+            self.assertEqual(file_result, 1)
+            self.assertEqual(file_stdout, "")
+            self.assertIn("target path is not a directory", file_stderr)
+            self.assertEqual(symlink_result, 1)
+            self.assertEqual(symlink_stdout, "")
+            self.assertIn("target path is not a real directory", symlink_stderr)
+
+            copied = cases_root / "absent" / "agent-assets"
+            for relative in AGENT_ASSET_FILES:
+                self.assertTrue((copied / relative).is_file())
+
+    def test_assets_copy_allows_symlinked_parent_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            assets_root = root / "site-packages" / "cognirelay" / "agent_assets"
+            _write_installed_assets(assets_root)
+            real_parent = root / "real-parent"
+            real_parent.mkdir()
+            linked_parent = root / "linked-parent"
+            linked_parent.symlink_to(real_parent, target_is_directory=True)
+
+            with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
+                result, stdout, stderr = _run_cli(["assets", "copy", "--to", str(linked_parent)])
+
+            self.assertEqual(result, 0, stderr)
+            self.assertEqual(stdout, f"{(real_parent / 'agent-assets').resolve()}\n")
+            self.assertEqual(stderr, "")
+
+    def test_assets_commands_fail_when_installed_assets_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            assets_root = Path(td) / "site-packages" / "cognirelay" / "agent_assets"
+            _write_installed_assets(assets_root)
+            (assets_root / "hooks" / "cognirelay_retrieval_hook.py").unlink()
+
+            with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
+                cases = (
+                    ["assets", "path"],
+                    ["assets", "list"],
+                    ["assets", "copy", "--to", str(Path(td) / "out")],
+                )
+                for argv in cases:
+                    with self.subTest(argv=argv):
+                        result, stdout, stderr = _run_cli(argv)
+                        self.assertEqual(result, 1)
+                        self.assertEqual(stdout, "")
+                        self.assertIn("installed agent assets are unavailable", stderr)
+
+    def test_assets_validation_rejects_extra_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            assets_root = Path(td) / "site-packages" / "cognirelay" / "agent_assets"
+            _write_installed_assets(assets_root)
+            (assets_root / "hooks" / "__pycache__").mkdir()
+            (assets_root / "hooks" / "__pycache__" / "extra.pyc").write_bytes(b"cache")
+
+            with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
+                result, stdout, stderr = _run_cli(["assets", "list"])
+
+            self.assertEqual(result, 1)
+            self.assertEqual(stdout, "")
+            self.assertIn("unexpected entries", stderr)
+
+    def test_assets_copy_from_source_tree_does_not_create_package_mirror(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        package_asset_root = repo_root / "cognirelay" / "agent_assets"
+        self.assertFalse(package_asset_root.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_cognirelay_cli.py
+++ b/tests/test_cognirelay_cli.py
@@ -212,19 +212,36 @@ class CogniRelayCliTests(unittest.TestCase):
                         self.assertEqual(stdout, "")
                         self.assertIn("installed agent assets are unavailable", stderr)
 
-    def test_assets_validation_rejects_extra_files(self) -> None:
+    def test_assets_commands_reject_extra_installed_bytecode_and_cache_entries(self) -> None:
         with tempfile.TemporaryDirectory() as td:
-            assets_root = Path(td) / "site-packages" / "cognirelay" / "agent_assets"
-            _write_installed_assets(assets_root)
-            (assets_root / "hooks" / "__pycache__").mkdir()
-            (assets_root / "hooks" / "__pycache__" / "extra.pyc").write_bytes(b"cache")
+            root = Path(td)
+            cases = {
+                "hook-name-pyc": ("hooks/cognirelay_retrieval_hook.pyc", b"cache"),
+                "pycache-directory": ("hooks/__pycache__", None),
+            }
+            commands = (
+                ["assets", "path"],
+                ["assets", "list"],
+                ["assets", "copy", "--to", str(root / "out")],
+            )
+            for case, (extra_relative, payload) in cases.items():
+                for argv in commands:
+                    with self.subTest(case=case, argv=argv):
+                        assets_root = root / case / "-".join(argv[:2]) / "site-packages" / "cognirelay" / "agent_assets"
+                        _write_installed_assets(assets_root)
+                        extra = assets_root / extra_relative
+                        if payload is None:
+                            extra.mkdir(parents=True)
+                        else:
+                            extra.parent.mkdir(parents=True, exist_ok=True)
+                            extra.write_bytes(payload)
 
-            with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
-                result, stdout, stderr = _run_cli(["assets", "list"])
+                        with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
+                            result, stdout, stderr = _run_cli(argv)
 
-            self.assertEqual(result, 1)
-            self.assertEqual(stdout, "")
-            self.assertIn("unexpected entries", stderr)
+                        self.assertEqual(result, 1)
+                        self.assertEqual(stdout, "")
+                        self.assertIn("unexpected entries", stderr)
 
     def test_assets_copy_from_source_tree_does_not_create_package_mirror(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]

--- a/tests/test_packaging_290.py
+++ b/tests/test_packaging_290.py
@@ -244,6 +244,25 @@ class Packaging290Tests(unittest.TestCase):
                 self.assertNotIn(token, sdist_metadata)
             self.assertFalse((ROOT / "cognirelay" / "agent_assets").exists())
 
+    def test_built_wheel_prunes_stale_agent_asset_build_residue(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            copied = root / "copy"
+            shutil.copytree(ROOT, copied, ignore=shutil.ignore_patterns(".git", ".venv", "dist", "*.egg-info", ".pytest_cache", ".ruff_cache", ".mypy_cache"))
+            stale = copied / "build" / "lib" / "cognirelay" / "agent_assets" / "leak.token"
+            stale.parent.mkdir(parents=True, exist_ok=True)
+            stale.write_text("private-token\n", encoding="utf-8")
+            dist = root / "dist"
+
+            subprocess.run([sys.executable, "-m", "build", "--wheel", "--outdir", str(dist)], cwd=copied, check=True, capture_output=True, text=True, timeout=120)
+
+            wheel = next(dist.glob("*.whl"))
+            with zipfile.ZipFile(wheel) as archive:
+                wheel_names = set(archive.namelist())
+            self.assertEqual({name for name in wheel_names if name.startswith("cognirelay/agent_assets/")}, WHEEL_AGENT_ASSET_FILES)
+            self.assertNotIn("cognirelay/agent_assets/leak.token", wheel_names)
+            self.assertFalse((ROOT / "cognirelay" / "agent_assets").exists())
+
     def test_built_wheel_installed_cli_can_manage_agent_assets(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -253,7 +272,7 @@ class Packaging290Tests(unittest.TestCase):
             venv_dir = root / "venv"
             venv.EnvBuilder(with_pip=True).create(venv_dir)
             venv_python = venv_dir / "bin" / "python"
-            subprocess.run([str(venv_python), "-m", "pip", "install", "--no-deps", str(wheel)], check=True, capture_output=True, text=True, timeout=120)
+            subprocess.run([str(venv_python), "-m", "pip", "install", "--no-deps", "--no-compile", str(wheel)], check=True, capture_output=True, text=True, timeout=120)
             console_script = venv_dir / "bin" / "cognirelay"
 
             path_proc = subprocess.run([str(console_script), "assets", "path"], cwd=root, check=False, capture_output=True, text=True, timeout=30)

--- a/tests/test_packaging_290.py
+++ b/tests/test_packaging_290.py
@@ -10,6 +10,7 @@ import tarfile
 import tempfile
 import tomllib
 import unittest
+import venv
 import zipfile
 from pathlib import Path
 from unittest import mock
@@ -77,6 +78,14 @@ FORBIDDEN_METADATA_TOKENS = (
     "/home/",
     "/Users/",
 )
+WHEEL_AGENT_ASSET_FILES = {
+    "cognirelay/agent_assets/README.md",
+    "cognirelay/agent_assets/hooks/README.md",
+    "cognirelay/agent_assets/hooks/cognirelay_continuity_save_hook.py",
+    "cognirelay/agent_assets/hooks/cognirelay_retrieval_hook.py",
+    "cognirelay/agent_assets/skills/cognirelay-continuity-authoring/SKILL.md",
+}
+CLI_AGENT_ASSET_FILES = sorted(name.removeprefix("cognirelay/agent_assets/") for name in WHEEL_AGENT_ASSET_FILES)
 
 
 def _forbidden_artifact_name(name: str) -> bool:
@@ -207,7 +216,8 @@ class Packaging290Tests(unittest.TestCase):
             for source in (ROOT / "app" / "ui" / "static").rglob("*"):
                 if source.is_file():
                     self.assertIn(source.relative_to(ROOT).as_posix(), wheel_names)
-            self.assertFalse(any(name.startswith(("docs/", "agent-assets/", "deploy/", "data_repo/")) for name in wheel_names))
+            self.assertEqual({name for name in wheel_names if name.startswith("cognirelay/agent_assets/")}, WHEEL_AGENT_ASSET_FILES)
+            self.assertFalse(any(name.startswith(("docs/", "agent-assets/", "deploy/", "tests/", "data_repo/", "dist/", "build/")) for name in wheel_names))
             self.assertFalse(any(_forbidden_artifact_name(name) for name in wheel_names))
             self.assertIn("<!-- mcp-name: io.github.stef-k/cognirelay -->", wheel_metadata)
             for token in FORBIDDEN_METADATA_TOKENS:
@@ -232,6 +242,47 @@ class Packaging290Tests(unittest.TestCase):
             self.assertIn("<!-- mcp-name: io.github.stef-k/cognirelay -->", sdist_metadata)
             for token in FORBIDDEN_METADATA_TOKENS:
                 self.assertNotIn(token, sdist_metadata)
+            self.assertFalse((ROOT / "cognirelay" / "agent_assets").exists())
+
+    def test_built_wheel_installed_cli_can_manage_agent_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            dist = root / "dist"
+            subprocess.run([sys.executable, "-m", "build", "--wheel", "--outdir", str(dist)], cwd=ROOT, check=True, capture_output=True, text=True, timeout=120)
+            wheel = next(dist.glob("*.whl"))
+            venv_dir = root / "venv"
+            venv.EnvBuilder(with_pip=True).create(venv_dir)
+            venv_python = venv_dir / "bin" / "python"
+            subprocess.run([str(venv_python), "-m", "pip", "install", "--no-deps", str(wheel)], check=True, capture_output=True, text=True, timeout=120)
+            console_script = venv_dir / "bin" / "cognirelay"
+
+            path_proc = subprocess.run([str(console_script), "assets", "path"], cwd=root, check=False, capture_output=True, text=True, timeout=30)
+            list_proc = subprocess.run([str(console_script), "assets", "list"], cwd=root, check=False, capture_output=True, text=True, timeout=30)
+            copy_parent = root / "copied"
+            copy_proc = subprocess.run([str(console_script), "assets", "copy", "--to", str(copy_parent)], cwd=root, check=False, capture_output=True, text=True, timeout=30)
+            module_proc = subprocess.run([str(venv_python), "-m", "cognirelay", "assets", "path"], cwd=root, check=False, capture_output=True, text=True, timeout=30)
+
+            self.assertEqual(path_proc.returncode, 0, path_proc.stderr)
+            self.assertEqual(path_proc.stderr, "")
+            installed_assets = Path(path_proc.stdout.strip())
+            self.assertTrue(installed_assets.is_dir())
+            self.assertTrue(installed_assets.is_absolute())
+            self.assertEqual(list_proc.returncode, 0, list_proc.stderr)
+            self.assertEqual(list_proc.stdout.splitlines(), CLI_AGENT_ASSET_FILES)
+            self.assertEqual(list_proc.stderr, "")
+            self.assertEqual(copy_proc.returncode, 0, copy_proc.stderr)
+            self.assertEqual(copy_proc.stderr, "")
+            copied_assets = copy_parent / "agent-assets"
+            self.assertEqual(Path(copy_proc.stdout.strip()), copied_assets.resolve())
+            for relative in CLI_AGENT_ASSET_FILES:
+                self.assertTrue((copied_assets / relative).is_file())
+            self.assertTrue((copied_assets / "hooks" / "cognirelay_retrieval_hook.py").is_file())
+            self.assertTrue((copied_assets / "hooks" / "cognirelay_continuity_save_hook.py").is_file())
+            self.assertTrue((copied_assets / "skills" / "cognirelay-continuity-authoring" / "SKILL.md").is_file())
+            self.assertEqual(module_proc.returncode, 0, module_proc.stderr)
+            self.assertEqual(module_proc.stdout, path_proc.stdout)
+            self.assertEqual(module_proc.stderr, "")
+            self.assertFalse((ROOT / "cognirelay" / "agent_assets").exists())
 
     def test_sdist_prunes_temp_only_runtime_fixture_paths(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
Closes #302

## Summary
- Wheel now includes exactly the five last-mile agent assets under cognirelay/agent_assets.
- Adds the new cognirelay assets path/list/copy CLI.
- Full docs/deploy/tests/runtime state remain excluded from the wheel.
- sdist behavior remains unchanged.

## Verification
- git status --short --branch: clean on feature/302-wheel-agent-assets.
- git log -1 --oneline: 733d01c Fix issue 302 review findings.
- git diff --check: passed.
- ./.venv/bin/python -m ruff check app cognirelay tests tools agent-assets: passed.
- ./.venv/bin/python -m unittest tests/test_packaging_290.py tests/test_cognirelay_cli.py tests/test_agent_assets_289.py -v: passed, 56 tests.
- ./.venv/bin/python -m unittest discover -s tests -v: passed, 2287 tests.
- ./.venv/bin/python tools/validate_server_json.py: passed.
- ./.venv/bin/python tools/prepare_release.py check --version 1.4.10 --date 2026-04-27 --allow-dirty: passed after removing generated build residue from packaging tests.
- ./.venv/bin/python -m build: passed, built cognirelay-1.4.10.tar.gz and cognirelay-1.4.10-py3-none-any.whl.
- ./.venv/bin/python -m twine check dist/*: passed for wheel and sdist.
- rm -rf dist build cognirelay.egg-info: completed.
- ./.venv/bin/python tools/prepare_release.py check --version 1.4.10 --date 2026-04-27 --allow-dirty: passed after cleanup.
- test ! -e cognirelay/agent_assets: passed.
- git status --short --branch: clean on feature/302-wheel-agent-assets.