### PR TITLE
Prepare 1.4.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.11] - 2026-04-28
+
+### Changed
+
+- Ship last-mile agent assets in PyPI wheel
+
 ## [1.4.10] - 2026-04-27
 
 ### Changed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.10", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.11", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,8 @@ path.
 
 ## Releases
 
-- [Latest release notes: v1.4.10](releases/v1.4.10.md)
+- [Latest release notes: v1.4.11](releases/v1.4.11.md)
+- [v1.4.10 release notes](releases/v1.4.10.md)
 - [v1.4.9 release notes](releases/v1.4.9.md)
 - [v1.4.8 release notes](releases/v1.4.8.md)
 - [v1.4.7 release notes](releases/v1.4.7.md)

--- a/docs/releases/v1.4.11.md
+++ b/docs/releases/v1.4.11.md
@@ -1,0 +1,30 @@
+# CogniRelay v1.4.11 Release Notes
+
+Release date: 2026-04-28
+
+This release makes the last-mile agent integration kit available from a normal
+PyPI wheel install.
+
+## Changed
+
+- Added the shipped continuity retrieval/save hooks and continuity-authoring
+  skill to the installed wheel under `cognirelay/agent_assets`.
+- Added `cognirelay assets path`, `cognirelay assets list`, and
+  `cognirelay assets copy --to <dir>` so agents can discover or materialize the
+  last-mile assets without cloning the full repository.
+- Kept full source documentation, deploy templates, tests, runtime state, and
+  private/local residue out of the wheel while preserving source/sdist behavior.
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app cognirelay tests tools agent-assets
+./.venv/bin/python tools/validate_server_json.py
+./.venv/bin/python tools/prepare_release.py check --version 1.4.11 --date 2026-04-28 --allow-dirty
+./.venv/bin/python -m unittest discover -s tests -v
+./.venv/bin/python -m build
+./.venv/bin/python -m twine check dist/*
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognirelay"
-version = "1.4.10"
+version = "1.4.11"
 description = "Self-hosted continuity and collaboration substrate for autonomous agents with bounded, recoverable memory and explicit restart orientation"
 readme = "README-PYPI.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.stef-k/cognirelay",
   "title": "CogniRelay",
   "description": "Self-hosted agent continuity server with bounded, recoverable memory and restart orientation.",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cognirelay",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "packageArguments": [
         {
           "type": "positional",


### PR DESCRIPTION
## Summary
- Bump CogniRelay to v1.4.11.
- Add changelog and release notes for the wheel-installed last-mile agent assets from #302.
- Update docs index and server/PyPI/MCP version surfaces.

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app cognirelay tests tools agent-assets
- ./.venv/bin/python tools/validate_server_json.py
- ./.venv/bin/python tools/prepare_release.py check --version 1.4.11 --date 2026-04-28 --allow-dirty
- ./.venv/bin/python -m unittest tests/test_packaging_290.py tests/test_cognirelay_cli.py tests/test_agent_assets_289.py -v
- ./.venv/bin/python -m unittest discover -s tests -v
- ./.venv/bin/python -m build
- ./.venv/bin/python -m twine check dist/*
- Wheel inspection confirmed exactly five cognirelay/agent_assets files
- Sdist inspection confirmed top-level agent-assets remain and generated cognirelay/agent_assets are absent
- Release helper rejects dist/ residue and passes after cleanup
