### PR TITLE
Prepare 1.4.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.12] - 2026-04-28
+
+### Changed
+
+- Fix installed agent asset validation for pip bytecode
+
 ## [1.4.11] - 2026-04-28
 
 ### Changed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.11", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.12", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/cognirelay/cli.py
+++ b/cognirelay/cli.py
@@ -21,8 +21,13 @@ AGENT_ASSET_FILES = (
 )
 AGENT_ASSET_DIRS = {
     "hooks",
+    "hooks/__pycache__",
     "skills",
     "skills/cognirelay-continuity-authoring",
+}
+AGENT_ASSET_GENERATED_CACHE_FILES = {
+    "hooks/__pycache__/cognirelay_continuity_save_hook",
+    "hooks/__pycache__/cognirelay_retrieval_hook",
 }
 
 
@@ -120,6 +125,8 @@ def validate_installed_agent_assets(*, package_file: Path | None = None) -> Path
         if relative in allowed:
             continue
         if relative in AGENT_ASSET_DIRS and path.is_dir():
+            continue
+        if path.is_file() and relative.endswith(".pyc") and any(relative.startswith(f"{prefix}.") for prefix in AGENT_ASSET_GENERATED_CACHE_FILES):
             continue
         raise AgentAssetsError(f"installed agent assets contain unexpected entries at {root}")
     return root

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,8 @@ path.
 
 ## Releases
 
-- [Latest release notes: v1.4.11](releases/v1.4.11.md)
+- [Latest release notes: v1.4.12](releases/v1.4.12.md)
+- [v1.4.11 release notes](releases/v1.4.11.md)
 - [v1.4.10 release notes](releases/v1.4.10.md)
 - [v1.4.9 release notes](releases/v1.4.9.md)
 - [v1.4.8 release notes](releases/v1.4.8.md)

--- a/docs/releases/v1.4.12.md
+++ b/docs/releases/v1.4.12.md
@@ -1,0 +1,30 @@
+# CogniRelay v1.4.12 Release Notes
+
+Release date: 2026-04-28
+
+This corrective release fixes the installed agent-asset CLI after normal PyPI
+installation.
+
+## Fixed
+
+- Allowed the expected pip-generated `hooks/__pycache__/*.pyc` files for the
+  two packaged hook modules when validating installed `cognirelay/agent_assets`.
+- Kept validation strict for any other extra files under
+  `cognirelay/agent_assets`, including unrelated bytecode, temp files, logs,
+  tokens, or runtime residue.
+- Preserved the wheel allowlist: the wheel itself still contains exactly the
+  five shipped last-mile agent asset files.
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app cognirelay tests tools agent-assets
+./.venv/bin/python tools/validate_server_json.py
+./.venv/bin/python tools/prepare_release.py check --version 1.4.12 --date 2026-04-28 --allow-dirty
+./.venv/bin/python -m unittest discover -s tests -v
+./.venv/bin/python -m build
+./.venv/bin/python -m twine check dist/*
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognirelay"
-version = "1.4.11"
+version = "1.4.12"
 description = "Self-hosted continuity and collaboration substrate for autonomous agents with bounded, recoverable memory and explicit restart orientation"
 readme = "README-PYPI.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.stef-k/cognirelay",
   "title": "CogniRelay",
   "description": "Self-hosted agent continuity server with bounded, recoverable memory and restart orientation.",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cognirelay",
-      "version": "1.4.11",
+      "version": "1.4.12",
       "packageArguments": [
         {
           "type": "positional",

--- a/tests/test_cognirelay_cli.py
+++ b/tests/test_cognirelay_cli.py
@@ -212,12 +212,37 @@ class CogniRelayCliTests(unittest.TestCase):
                         self.assertEqual(stdout, "")
                         self.assertIn("installed agent assets are unavailable", stderr)
 
-    def test_assets_commands_reject_extra_installed_bytecode_and_cache_entries(self) -> None:
+    def test_assets_commands_allow_pip_generated_hook_bytecode(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            assets_root = root / "site-packages" / "cognirelay" / "agent_assets"
+            _write_installed_assets(assets_root)
+            pycache = assets_root / "hooks" / "__pycache__"
+            pycache.mkdir()
+            (pycache / "cognirelay_retrieval_hook.cpython-312.pyc").write_bytes(b"cache")
+            (pycache / "cognirelay_continuity_save_hook.cpython-312.pyc").write_bytes(b"cache")
+
+            with mock.patch.object(cli, "_installed_agent_assets_root", return_value=assets_root):
+                path_result, path_stdout, path_stderr = _run_cli(["assets", "path"])
+                list_result, list_stdout, list_stderr = _run_cli(["assets", "list"])
+                copy_result, copy_stdout, copy_stderr = _run_cli(["assets", "copy", "--to", str(root / "out")])
+
+            self.assertEqual(path_result, 0)
+            self.assertEqual(path_stdout, f"{assets_root}\n")
+            self.assertEqual(path_stderr, "")
+            self.assertEqual(list_result, 0)
+            self.assertEqual(list_stdout.splitlines(), sorted(cli.AGENT_ASSET_FILES))
+            self.assertEqual(list_stderr, "")
+            self.assertEqual(copy_result, 0)
+            self.assertEqual(copy_stdout, f"{(root / 'out' / 'agent-assets').resolve()}\n")
+            self.assertEqual(copy_stderr, "")
+
+    def test_assets_commands_reject_extra_installed_asset_entries(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             cases = {
                 "hook-name-pyc": ("hooks/cognirelay_retrieval_hook.pyc", b"cache"),
-                "pycache-directory": ("hooks/__pycache__", None),
+                "unrelated-pycache-file": ("hooks/__pycache__/unexpected.cpython-312.pyc", b"cache"),
             }
             commands = (
                 ["assets", "path"],


### PR DESCRIPTION
## Summary
- allow expected pip-generated hook bytecode under installed `cognirelay/agent_assets/hooks/__pycache__`
- keep installed asset validation strict for all other unexpected files
- prepare v1.4.12 version, changelog, docs index, server metadata, and release notes

## Context
PyPI v1.4.11 installed successfully, but `cognirelay assets list/path/copy` rejected normal pip-generated hook bytecode. Do not publish v1.4.11 to the MCP Registry; v1.4.12 is the corrective release candidate.

## Verification
- `git diff --check`
- `./.venv/bin/python -m ruff check app cognirelay tests tools agent-assets`
- `./.venv/bin/python tools/validate_server_json.py`
- `./.venv/bin/python tools/prepare_release.py check --version 1.4.12 --date 2026-04-28 --allow-dirty`
- `./.venv/bin/python -m unittest tests/test_packaging_290.py tests/test_cognirelay_cli.py tests/test_agent_assets_289.py -v`
- `./.venv/bin/python -m unittest discover -s tests -v`
- `./.venv/bin/python -m build`
- `./.venv/bin/python -m twine check dist/*`
- Fresh wheel install smoke: import version, `cognirelay assets list`, `assets path`, and `assets copy` passed with pip-generated hook bytecode present
- Build residue check: `prepare_release.py check ...` fails on `dist`, then passes after cleanup
