### PR TITLE
Prepare 1.4.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.13] - 2026-05-02
+
+### Changed
+
+- Fix MCP structured tool schemas
+
 ## [1.4.12] - 2026-04-28
 
 ### Changed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.12", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.13", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,8 @@ path.
 
 ## Releases
 
-- [Latest release notes: v1.4.12](releases/v1.4.12.md)
+- [Latest release notes: v1.4.13](releases/v1.4.13.md)
+- [v1.4.12 release notes](releases/v1.4.12.md)
 - [v1.4.11 release notes](releases/v1.4.11.md)
 - [v1.4.10 release notes](releases/v1.4.10.md)
 - [v1.4.9 release notes](releases/v1.4.9.md)

--- a/docs/releases/v1.4.13.md
+++ b/docs/releases/v1.4.13.md
@@ -1,0 +1,31 @@
+# CogniRelay v1.4.13 Release Notes
+
+Release date: 2026-05-02
+
+CogniRelay v1.4.13 is a focused patch release for MCP `tools/list` metadata
+consumed by PyPI and MCP Registry users.
+
+## Fixed
+
+- Fixed MCP `tools/list` metadata for structured payload fields.
+- `continuity.upsert` now advertises `capsule` as an object and
+  `session_end_snapshot` as object/null instead of ambiguous string fields.
+- Generalized top-level structured field inlining across MCP tool schemas.
+- Preserved HTTP/runtime validation behavior; JSON-stringified capsules remain
+  rejected.
+- Stabilized schedule tests with deterministic future dates.
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app cognirelay tests tools agent-assets
+./.venv/bin/python tools/validate_server_json.py
+./.venv/bin/python tools/prepare_release.py check --version 1.4.13 --date 2026-05-02 --allow-dirty
+./.venv/bin/python -m unittest tests/test_mcp_216_slice2_runtime.py tests/test_mcp_rpc.py tests/test_discovery.py tests/test_schedule_255.py tests/test_continuity_217_slice3_limits.py -v
+./.venv/bin/python -m unittest discover -s tests -v
+./.venv/bin/python -m build
+./.venv/bin/python -m twine check dist/*
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognirelay"
-version = "1.4.12"
+version = "1.4.13"
 description = "Self-hosted continuity and collaboration substrate for autonomous agents with bounded, recoverable memory and explicit restart orientation"
 readme = "README-PYPI.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.stef-k/cognirelay",
   "title": "CogniRelay",
   "description": "Self-hosted agent continuity server with bounded, recoverable memory and restart orientation.",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cognirelay",
-      "version": "1.4.12",
+      "version": "1.4.13",
       "packageArguments": [
         {
           "type": "positional",


### PR DESCRIPTION
## Summary
- Prepare CogniRelay v1.4.13 release metadata and notes.
- Document the MCP structured tool schema patch for PyPI and MCP Registry users.

## Verification
- git diff --check
- ./.venv/bin/python -m ruff check app cognirelay tests tools agent-assets
- ./.venv/bin/python tools/validate_server_json.py
- ./.venv/bin/python tools/prepare_release.py check --version 1.4.13 --date 2026-05-02 --allow-dirty
- ./.venv/bin/python -m unittest tests/test_mcp_216_slice2_runtime.py tests/test_mcp_rpc.py tests/test_discovery.py tests/test_schedule_255.py tests/test_continuity_217_slice3_limits.py -v
- ./.venv/bin/python -m unittest discover -s tests -v
- ./.venv/bin/python -m build
- ./.venv/bin/python -m twine check dist/*
- Residue gate verified: failed with dist/build residue, passed after cleanup.
