### PR TITLE
Prepare 1.4.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ It follows the [Keep a Changelog](https://keepachangelog.com/) format.
 
 ## [Unreleased]
 
+## [1.4.14] - 2026-05-08
+
+### Changed
+
+- Enforce continuity help before mutation
+
 ## [1.4.13] - 2026-05-02
 
 ### Changed

--- a/app/main.py
+++ b/app/main.py
@@ -283,7 +283,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         set_coordination_index(None)
 
 
-app = FastAPI(title="CogniRelay", version="1.4.13", lifespan=_lifespan)
+app = FastAPI(title="CogniRelay", version="1.4.14", lifespan=_lifespan)
 
 if get_settings().ui_enabled:
     app.include_router(build_ui_router(app_version=app.version))

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,8 @@ path.
 
 ## Releases
 
-- [Latest release notes: v1.4.13](releases/v1.4.13.md)
+- [Latest release notes: v1.4.14](releases/v1.4.14.md)
+- [v1.4.13 release notes](releases/v1.4.13.md)
 - [v1.4.12 release notes](releases/v1.4.12.md)
 - [v1.4.11 release notes](releases/v1.4.11.md)
 - [v1.4.10 release notes](releases/v1.4.10.md)

--- a/docs/releases/v1.4.14.md
+++ b/docs/releases/v1.4.14.md
@@ -1,0 +1,15 @@
+# CogniRelay v1.4.14 Release Notes
+
+Release date: 2026-05-08
+
+Enforce continuity help before mutation
+
+## Verification
+
+Release preparation should pass:
+
+```bash
+git diff --check
+./.venv/bin/python -m ruff check app tests tools agent-assets
+./.venv/bin/python -m unittest discover -s tests -v
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cognirelay"
-version = "1.4.13"
+version = "1.4.14"
 description = "Self-hosted continuity and collaboration substrate for autonomous agents with bounded, recoverable memory and explicit restart orientation"
 readme = "README-PYPI.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -3,12 +3,12 @@
   "name": "io.github.stef-k/cognirelay",
   "title": "CogniRelay",
   "description": "Self-hosted agent continuity server with bounded, recoverable memory and restart orientation.",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "cognirelay",
-      "version": "1.4.13",
+      "version": "1.4.14",
       "packageArguments": [
         {
           "type": "positional",


### PR DESCRIPTION
## Summary
- Bump CogniRelay package and app metadata to 1.4.14.
- Update MCP Registry `server.json`, changelog, docs index, and release notes.

## Verification
- git diff --check
- ./.venv/bin/python tools/prepare_release.py check --version 1.4.14 --date 2026-05-08
- ./.venv/bin/python tools/validate_server_json.py
- ./.venv/bin/python -m ruff check app tests tools agent-assets
- ./.venv/bin/python -m unittest discover -s tests -v
- ./.venv/bin/python -m build
- ./.venv/bin/python -m twine check dist/*

## Artifacts
- dist/cognirelay-1.4.14-py3-none-any.whl sha256: 64d2f77539ded96563072424661d8257391aee9b658de2d6cc21aea668b75246
- dist/cognirelay-1.4.14.tar.gz sha256: 36f1373787644e3e61b6f38241b45468f369485dacfd92fc89e1c81c84a27ea6
